### PR TITLE
Set up VS Code development with SweetPad, linting, and CI coverage

### DIFF
--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -1,5 +1,7 @@
 name: Format and lint
+
 on:
+  workflow_call:
   pull_request:
 
 concurrency:
@@ -8,18 +10,26 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: macos-15
 
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6
 
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.3.app
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
       - name: Check formatting
         if: always()
         run: |
-          echo "Skipping until new workflow is in place."
+          xcrun swift-format lint --recursive --strict \
+            app/Taskmato \
+            app/TaskmatoTests \
+            app/TaskmatoUITests
 
       - name: Check lint
         if: always()
-        run: |
-          echo "Skipping until new workflow is in place."
+        run: swiftlint lint --strict

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -1,17 +1,19 @@
 name: Test
+
 on:
+  workflow_call:
   pull_request:
 
 concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: macos-15
-
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout source code
@@ -27,6 +29,38 @@ jobs:
             -scheme Taskmato \
             -destination 'platform=macOS' \
             -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO
+
+      - name: Convert coverage to lcov
+        run: |
+          python3 << 'EOF'
+          import json, subprocess
+
+          result = subprocess.run(
+              ['xcrun', 'xccov', 'view', '--report', '--json', 'TestResults.xcresult'],
+              capture_output=True, text=True, check=True
+          )
+          data = json.loads(result.stdout)
+
+          with open('coverage.lcov', 'w') as f:
+              for target in data.get('targets', []):
+                  for file in target.get('files', []):
+                      path = file.get('path', '')
+                      lines = file.get('lines', [])
+                      if not lines:
+                          continue
+                      f.write(f'SF:{path}\n')
+                      for line in lines:
+                          f.write(f'DA:{line["line"]},{line["executionCount"]}\n')
+                      f.write('end_of_record\n')
+          EOF
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.lcov

--- a/.github/workflows/report-coverage.yaml
+++ b/.github/workflows/report-coverage.yaml
@@ -1,0 +1,58 @@
+name: Report Coverage
+
+on:
+  workflow_run:
+    workflows: ['Test']
+    types:
+      - completed
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v6
+
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: coverage
+          path: coverage
+
+      - name: Generate coverage report
+        uses: danielpalme/ReportGenerator-GitHub-Action@5
+        with:
+          reports: coverage/coverage.lcov
+          targetdir: coverage-report
+          reporttypes: MarkdownSummaryGithub
+          verbosity: Warning
+
+      - name: Get PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+              state: 'open'
+            });
+            return prs[0]?.number ?? '';
+
+      - name: Post coverage comment
+        if: steps.pr.outputs.result != ''
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.result }}
+          path: coverage-report/SummaryGithub.md
+          header: coverage

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,38 @@
+included:
+  - app/Taskmato
+  - app/TaskmatoTests
+  - app/TaskmatoUITests
+
+excluded:
+  - .build
+  - .worktrees
+
+disabled_rules:
+  - todo
+
+opt_in_rules:
+  - array_init
+  - closure_spacing
+  - collection_alignment
+  - empty_count
+  - empty_string
+  - first_where
+  - toggle_bool
+
+line_length:
+  warning: 120
+  error: 150
+  ignores_comments: true
+  ignores_urls: true
+
+type_body_length:
+  warning: 300
+  error: 400
+
+file_length:
+  warning: 500
+  error: 1000
+
+function_body_length:
+  warning: 60
+  error: 100

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": ["swiftlang.swift-vscode", "streetsidesoftware.code-spell-checker"],
+  "recommendations": ["swiftlang.swift-vscode", "sweetpad.sweetpad", "vadimcn.vscode-lldb", "vknabel.vscode-swiftlint", "streetsidesoftware.code-spell-checker", "ms-vscode.makefile-tools"],
   "unwantedRecommendations": []
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "sweetpad-lldb",
+      "request": "attach",
+      "name": "Launch Taskmato",
+      "preLaunchTask": "Build and Launch"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,11 @@
   "editor.wordWrapColumn": 120,
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
-  "[markdown]": { "editor.wordWrap": "wordWrapColumn" },
+  "[markdown]": { 
+    "editor.wordWrap": "wordWrapColumn" 
+  },
+  "[swift]": {
+    "editor.defaultFormatter": "sweetpad.sweetpad",
+  },
   "cSpell.words": ["taskmato", "pomodoro"]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+        {
+      "type": "sweetpad",
+      "action": "launch",
+      "problemMatcher": [
+        "$sweetpad-watch", // ! Required for debugging
+        "$sweetpad-xcodebuild-default",
+        "$sweetpad-xcbeautify-errors",
+        "$sweetpad-xcbeautify-warnings"
+      ],
+      "label": "Build and Launch",
+      "detail": "Build and Launch the app",
+      "isBackground": true // ! Required for debugging
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.DEFAULT_GOAL := help
+
+SCHEME      = Taskmato
+PROJECT     = app/Taskmato.xcodeproj
+DESTINATION = platform=macOS
+SIGN_FLAGS  = CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+SOURCE_DIRS = app/Taskmato app/TaskmatoTests app/TaskmatoUITests
+
+.PHONY: help build test lint format clean
+
+help: ## List the available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the app in Debug configuration
+	xcodebuild build \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-configuration Debug \
+		-destination '$(DESTINATION)' \
+		$(SIGN_FLAGS)
+
+test: ## Run the unit test suite
+	xcodebuild test \
+		-project $(PROJECT) \
+		-scheme $(SCHEME) \
+		-destination '$(DESTINATION)' \
+		-enableCodeCoverage YES \
+		$(SIGN_FLAGS)
+
+lint: ## Check for SwiftLint violations
+	swiftlint lint --strict
+
+format: ## Format source files in-place with swift-format
+	xcrun swift-format format --recursive -i $(SOURCE_DIRS)
+
+format-check: ## Verify formatting without modifying files (used in CI)
+	xcrun swift-format lint --recursive --strict $(SOURCE_DIRS)
+
+clean: ## Remove build artifacts
+	xcodebuild clean \
+		-project $(PROJECT) \
+		-scheme $(SCHEME)

--- a/app/Taskmato/Notifications/NotificationService.swift
+++ b/app/Taskmato/Notifications/NotificationService.swift
@@ -11,48 +11,48 @@ import UserNotifications
 /// appear even while the app is active (menu bar apps are always active).
 final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
-    private let center = UNUserNotificationCenter.current()
+  private let center = UNUserNotificationCenter.current()
 
-    override init() {
-        super.init()
-        center.delegate = self
+  override init() {
+    super.init()
+    center.delegate = self
+  }
+
+  /// Requests authorization if needed, then delivers a notification for the completed phase.
+  ///
+  /// Silently does nothing if the user has denied notification permission.
+  func send(phase: SessionPhase) {
+    center.requestAuthorization(options: [.alert]) { [weak self] granted, _ in
+      guard granted, let self else { return }
+      let content = UNMutableNotificationContent()
+      switch phase {
+      case .focus:
+        content.title = "Focus session complete"
+        content.body = "Time for a break."
+      case .shortBreak:
+        content.title = "Break's over"
+        content.body = "Ready to focus again?"
+      case .longBreak:
+        content.title = "Long break done"
+        content.body = "Time to get back to it."
+      }
+      let request = UNNotificationRequest(
+        identifier: UUID().uuidString,
+        content: content,
+        trigger: nil
+      )
+      self.center.add(request)
     }
+  }
 
-    /// Requests authorization if needed, then delivers a notification for the completed phase.
-    ///
-    /// Silently does nothing if the user has denied notification permission.
-    func send(phase: SessionPhase) {
-        center.requestAuthorization(options: [.alert]) { [weak self] granted, _ in
-            guard granted, let self else { return }
-            let content = UNMutableNotificationContent()
-            switch phase {
-            case .focus:
-                content.title = "Focus session complete"
-                content.body = "Time for a break."
-            case .shortBreak:
-                content.title = "Break's over"
-                content.body = "Ready to focus again?"
-            case .longBreak:
-                content.title = "Long break done"
-                content.body = "Time to get back to it."
-            }
-            let request = UNNotificationRequest(
-                identifier: UUID().uuidString,
-                content: content,
-                trigger: nil
-            )
-            self.center.add(request)
-        }
-    }
+  // MARK: - UNUserNotificationCenterDelegate
 
-    // MARK: - UNUserNotificationCenterDelegate
-
-    /// Allows banners and sound to appear while the app is active.
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
-        completionHandler([.banner])
-    }
+  /// Allows banners and sound to appear while the app is active.
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    completionHandler([.banner])
+  }
 }

--- a/app/Taskmato/Notifications/SoundService.swift
+++ b/app/Taskmato/Notifications/SoundService.swift
@@ -3,8 +3,8 @@
 //  Taskmato
 //
 
-import AppKit
 import AVFoundation
+import AppKit
 
 /// Plays a short alert sound when a Pomodoro phase completes.
 ///
@@ -13,31 +13,34 @@ import AVFoundation
 /// Falls back to "Glass", then `NSSound.beep()` if a sound cannot be found.
 final class SoundService {
 
-    private var audioPlayer: AVAudioPlayer?
-    private var activeSound: NSSound?
+  private var audioPlayer: AVAudioPlayer?
+  private var activeSound: NSSound?
 
-    /// Plays the named sound. Defaults to `"Radial"`, falling back to `"Glass"` if unavailable.
-    func play(named name: String = "Radial") {
-        if name == "Radial" {
-            let url = URL(filePath: "/System/Library/PrivateFrameworks/ToneLibrary.framework/Versions/A/Resources/Ringtones/Radial-EncoreInfinitum.m4r")
-            if let player = try? AVAudioPlayer(contentsOf: url) {
-                audioPlayer = player
-                player.play()
-                return
-            }
-            playSystemSound(named: "Glass")
-        } else {
-            playSystemSound(named: name)
-        }
+  /// Plays the named sound. Defaults to `"Radial"`, falling back to `"Glass"` if unavailable.
+  func play(named name: String = "Radial") {
+    if name == "Radial" {
+      let radialPath =
+        "/System/Library/PrivateFrameworks/ToneLibrary.framework"
+        + "/Versions/A/Resources/Ringtones/Radial-EncoreInfinitum.m4r"
+      let url = URL(filePath: radialPath)
+      if let player = try? AVAudioPlayer(contentsOf: url) {
+        audioPlayer = player
+        player.play()
+        return
+      }
+      playSystemSound(named: "Glass")
+    } else {
+      playSystemSound(named: name)
     }
+  }
 
-    private func playSystemSound(named name: String) {
-        let url = URL(filePath: "/System/Library/Sounds/\(name).aiff")
-        if let sound = NSSound(contentsOf: url, byReference: true) {
-            activeSound = sound
-            sound.play()
-        } else {
-            NSSound.beep()
-        }
+  private func playSystemSound(named name: String) {
+    let url = URL(filePath: "/System/Library/Sounds/\(name).aiff")
+    if let sound = NSSound(contentsOf: url, byReference: true) {
+      activeSound = sound
+      sound.play()
+    } else {
+      NSSound.beep()
     }
+  }
 }

--- a/app/Taskmato/Session/Session.swift
+++ b/app/Taskmato/Session/Session.swift
@@ -8,25 +8,25 @@ import Foundation
 /// An immutable record of a single completed Pomodoro phase.
 struct Session: Codable, Identifiable {
 
-    /// Stable unique identifier for this session record.
-    let id: UUID
+  /// Stable unique identifier for this session record.
+  let id: UUID
 
-    /// The phase that was completed.
-    let phase: SessionPhase
+  /// The phase that was completed.
+  let phase: SessionPhase
 
-    /// Wall-clock time when this phase began.
-    let startedAt: Date
+  /// Wall-clock time when this phase began.
+  let startedAt: Date
 
-    /// Wall-clock time when this phase ended naturally (not stopped manually).
-    let endedAt: Date
+  /// Wall-clock time when this phase ended naturally (not stopped manually).
+  let endedAt: Date
 
-    /// `true` if the phase ran to completion naturally; `false` if the user stopped it early.
-    let wasCompleted: Bool
+  /// `true` if the phase ran to completion naturally; `false` if the user stopped it early.
+  let wasCompleted: Bool
 
-    /// The EventKit reminder identifier associated with this session, if any.
-    /// Populated once Reminders integration is added.
-    var reminderID: String?
+  /// The EventKit reminder identifier associated with this session, if any.
+  /// Populated once Reminders integration is added.
+  var reminderID: String?
 
-    /// Actual elapsed duration of this phase in seconds.
-    var duration: TimeInterval { endedAt.timeIntervalSince(startedAt) }
+  /// Actual elapsed duration of this phase in seconds.
+  var duration: TimeInterval { endedAt.timeIntervalSince(startedAt) }
 }

--- a/app/Taskmato/Session/SessionEngine.swift
+++ b/app/Taskmato/Session/SessionEngine.swift
@@ -177,7 +177,7 @@ final class SessionEngine {
       state = .running(phase: next, startedAt: now(), duration: dur)
       startTicking()
     } else {
-      state = .paused(phase: next, remaining: d)
+      state = .paused(phase: next, remaining: dur)
     }
   }
 

--- a/app/Taskmato/Session/SessionEngine.swift
+++ b/app/Taskmato/Session/SessionEngine.swift
@@ -3,34 +3,34 @@
 //  Taskmato
 //
 
-import Observation
 import Foundation
+import Observation
 
 /// The phase of an active or paused Pomodoro session.
 enum SessionPhase: Equatable, Codable {
-    /// A focus interval — the core work period.
-    case focus
-    /// A short recovery break, typically taken after each focus interval.
-    case shortBreak
-    /// A longer recovery break, typically taken after every fourth focus interval.
-    case longBreak
+  /// A focus interval — the core work period.
+  case focus
+  /// A short recovery break, typically taken after each focus interval.
+  case shortBreak
+  /// A longer recovery break, typically taken after every fourth focus interval.
+  case longBreak
 }
 
 /// The current state of the session engine's state machine.
 enum SessionState: Equatable {
-    /// No session is active. The engine is ready to start a new focus interval.
-    case idle
-    /// A session is actively counting down.
-    /// - Parameters:
-    ///   - phase: The current phase (focus or break).
-    ///   - startedAt: The wall-clock time when this phase began (or was virtually backdated on resume).
-    ///   - duration: The total length of this phase in seconds.
-    case running(phase: SessionPhase, startedAt: Date, duration: TimeInterval)
-    /// A session is suspended mid-phase.
-    /// - Parameters:
-    ///   - phase: The phase that was active when the session was paused.
-    ///   - remaining: The number of seconds left when the session was paused.
-    case paused(phase: SessionPhase, remaining: TimeInterval)
+  /// No session is active. The engine is ready to start a new focus interval.
+  case idle
+  /// A session is actively counting down.
+  /// - Parameters:
+  ///   - phase: The current phase (focus or break).
+  ///   - startedAt: The wall-clock time when this phase began (or was virtually backdated on resume).
+  ///   - duration: The total length of this phase in seconds.
+  case running(phase: SessionPhase, startedAt: Date, duration: TimeInterval)
+  /// A session is suspended mid-phase.
+  /// - Parameters:
+  ///   - phase: The phase that was active when the session was paused.
+  ///   - remaining: The number of seconds left when the session was paused.
+  case paused(phase: SessionPhase, remaining: TimeInterval)
 }
 
 /// Manages the Pomodoro state machine and owns all timer logic.
@@ -41,187 +41,187 @@ enum SessionState: Equatable {
 @Observable
 final class SessionEngine {
 
-    /// The current state of the session.
-    private(set) var state: SessionState = .idle
+  /// The current state of the session.
+  private(set) var state: SessionState = .idle
 
-    /// Seconds remaining in the current phase. Updated each second while running,
-    /// frozen while paused, and reset to `focusDuration` when idle.
-    private(set) var timeRemaining: TimeInterval
+  /// Seconds remaining in the current phase. Updated each second while running,
+  /// frozen while paused, and reset to `focusDuration` when idle.
+  private(set) var timeRemaining: TimeInterval
 
-    /// Length of a focus interval in seconds. Updated from settings at each phase boundary.
-    var focusDuration: TimeInterval
+  /// Length of a focus interval in seconds. Updated from settings at each phase boundary.
+  var focusDuration: TimeInterval
 
-    /// Length of a short break in seconds. Updated from settings at each phase boundary.
-    var shortBreakDuration: TimeInterval
+  /// Length of a short break in seconds. Updated from settings at each phase boundary.
+  var shortBreakDuration: TimeInterval
 
-    /// Length of a long break in seconds. Updated from settings at each phase boundary.
-    var longBreakDuration: TimeInterval
+  /// Length of a long break in seconds. Updated from settings at each phase boundary.
+  var longBreakDuration: TimeInterval
 
-    /// The next phase queued for manual start, set when a phase is skipped with auto-start disabled.
-    /// Cleared whenever `start()` or `stop()` is called.
-    private(set) var queuedPhase: SessionPhase? = nil
+  /// The next phase queued for manual start, set when a phase is skipped with auto-start disabled.
+  /// Cleared whenever `start()` or `stop()` is called.
+  private(set) var queuedPhase: SessionPhase?
 
-    /// Called whenever a phase ends — either naturally (time reaches zero) or via manual stop.
-    /// - Parameters:
-    ///   - phase: The phase that ended.
-    ///   - startedAt: Virtual start time, reflecting actual accumulated focus time.
-    ///   - endedAt: The wall-clock time the phase ended.
-    ///   - wasCompleted: `true` if time ran out naturally; `false` if the user stopped manually.
-    var onPhaseEnded: ((SessionPhase, Date, Date, Bool) -> Void)?
+  /// Called whenever a phase ends — either naturally (time reaches zero) or via manual stop.
+  /// - Parameters:
+  ///   - phase: The phase that ended.
+  ///   - startedAt: Virtual start time, reflecting actual accumulated focus time.
+  ///   - endedAt: The wall-clock time the phase ended.
+  ///   - wasCompleted: `true` if time ran out naturally; `false` if the user stopped manually.
+  var onPhaseEnded: ((SessionPhase, Date, Date, Bool) -> Void)?
 
-    private let now: () -> Date
-    private var tickTimer: Timer?
+  private let now: () -> Date
+  private var tickTimer: Timer?
 
-    /// - Parameters:
-    ///   - focusDuration: Length of a focus interval in seconds.
-    ///   - shortBreakDuration: Length of a short break in seconds.
-    ///   - longBreakDuration: Length of a long break in seconds.
-    ///   - now: Clock provider. Override in tests to control time.
-    init(
-        focusDuration: TimeInterval = 25 * 60,
-        shortBreakDuration: TimeInterval = 5 * 60,
-        longBreakDuration: TimeInterval = 15 * 60,
-        now: @escaping () -> Date = Date.init
-    ) {
-        self.focusDuration = focusDuration
-        self.shortBreakDuration = shortBreakDuration
-        self.longBreakDuration = longBreakDuration
-        self.now = now
-        self.timeRemaining = focusDuration
+  /// - Parameters:
+  ///   - focusDuration: Length of a focus interval in seconds.
+  ///   - shortBreakDuration: Length of a short break in seconds.
+  ///   - longBreakDuration: Length of a long break in seconds.
+  ///   - now: Clock provider. Override in tests to control time.
+  init(
+    focusDuration: TimeInterval = 25 * 60,
+    shortBreakDuration: TimeInterval = 5 * 60,
+    longBreakDuration: TimeInterval = 15 * 60,
+    now: @escaping () -> Date = Date.init
+  ) {
+    self.focusDuration = focusDuration
+    self.shortBreakDuration = shortBreakDuration
+    self.longBreakDuration = longBreakDuration
+    self.now = now
+    self.timeRemaining = focusDuration
+  }
+
+  /// `true` while a phase is actively counting down (not paused or idle).
+  var isRunning: Bool {
+    if case .running = state { return true }
+    return false
+  }
+
+  /// Begins a new session in the specified phase. Defaults to `.focus`. Has no effect if a session is already active or paused.
+  func start(phase: SessionPhase = .focus) {
+    guard case .idle = state else { return }
+    queuedPhase = nil
+    let dur = duration(for: phase)
+    timeRemaining = dur
+    state = .running(phase: phase, startedAt: now(), duration: dur)
+    startTicking()
+  }
+
+  /// Suspends the current phase, capturing the remaining time. Has no effect when idle or already paused.
+  func pause() {
+    guard case .running(let phase, _, _) = state else { return }
+    refreshTimeRemaining()
+    guard case .running = state else { return }  // completion may have fired during refresh
+    stopTicking()
+    state = .paused(phase: phase, remaining: timeRemaining)
+  }
+
+  /// Resumes a paused session from where it left off. Has no effect when running or idle.
+  func resume() {
+    guard case .paused(let phase, let remaining) = state else { return }
+    let duration = self.duration(for: phase)
+    timeRemaining = remaining
+    state = .running(
+      phase: phase,
+      startedAt: now().addingTimeInterval(-(duration - remaining)),
+      duration: duration
+    )
+    startTicking()
+  }
+
+  /// Stops the session, records a partial session if one was in progress, and returns to idle.
+  func stop() {
+    let endedAt = now()
+    switch state {
+    case .running(let phase, let startedAt, _):
+      stopTicking()
+      refreshTimeRemaining()
+      onPhaseEnded?(phase, startedAt, endedAt, false)
+    case .paused(let phase, let remaining):
+      let elapsed = duration(for: phase) - remaining
+      let startedAt = endedAt.addingTimeInterval(-elapsed)
+      onPhaseEnded?(phase, startedAt, endedAt, false)
+    case .idle:
+      return
     }
+    state = .idle
+    timeRemaining = focusDuration
+    queuedPhase = nil
+  }
 
-    /// `true` while a phase is actively counting down (not paused or idle).
-    var isRunning: Bool {
-        if case .running = state { return true }
-        return false
+  /// Advances to the next phase, preserving the current running state.
+  ///
+  /// - Running: the next phase starts immediately.
+  /// - Paused: the next phase begins paused at its full duration.
+  /// - Idle: queues focus as the next phase (cycling a pending break back to focus).
+  /// - Parameter nextBreak: The break phase to use when skipping from a focus phase. Defaults to `.shortBreak`.
+  func skip(nextBreak: SessionPhase = .shortBreak) {
+    let currentPhase: SessionPhase
+    let wasRunning: Bool
+    switch state {
+    case .running(let phase, _, _):
+      currentPhase = phase
+      wasRunning = true
+    case .paused(let phase, _):
+      currentPhase = phase
+      wasRunning = false
+    case .idle:
+      queuedPhase = .focus
+      return
     }
+    stopTicking()
+    let next: SessionPhase = (currentPhase == .focus) ? nextBreak : .focus
+    let dur = duration(for: next)
+    timeRemaining = dur
+    queuedPhase = nil
+    if wasRunning {
+      state = .running(phase: next, startedAt: now(), duration: dur)
+      startTicking()
+    } else {
+      state = .paused(phase: next, remaining: d)
+    }
+  }
 
-    /// Begins a new session in the specified phase. Defaults to `.focus`. Has no effect if a session is already active or paused.
-    func start(phase: SessionPhase = .focus) {
-        guard case .idle = state else { return }
-        queuedPhase = nil
-        let d = duration(for: phase)
-        timeRemaining = d
-        state = .running(phase: phase, startedAt: now(), duration: d)
-        startTicking()
-    }
+  /// Queues a phase to start next without beginning it. Only has effect when idle.
+  func enqueuePhase(_ phase: SessionPhase) {
+    guard case .idle = state else { return }
+    queuedPhase = phase
+  }
 
-    /// Suspends the current phase, capturing the remaining time. Has no effect when idle or already paused.
-    func pause() {
-        guard case .running(let phase, _, _) = state else { return }
-        refreshTimeRemaining()
-        guard case .running = state else { return } // completion may have fired during refresh
-        stopTicking()
-        state = .paused(phase: phase, remaining: timeRemaining)
+  // Recomputes timeRemaining from the stored start timestamp.
+  // Called on each timer tick and immediately before pausing.
+  // Detects natural phase completion when remaining time reaches zero.
+  private func refreshTimeRemaining() {
+    guard case .running(let phase, let startedAt, let duration) = state else { return }
+    let remaining = max(0, duration - now().timeIntervalSince(startedAt))
+    timeRemaining = remaining
+    if remaining <= 0 {
+      stopTicking()
+      state = .idle
+      timeRemaining = focusDuration
+      onPhaseEnded?(phase, startedAt, startedAt.addingTimeInterval(duration), true)
     }
+  }
 
-    /// Resumes a paused session from where it left off. Has no effect when running or idle.
-    func resume() {
-        guard case .paused(let phase, let remaining) = state else { return }
-        let duration = self.duration(for: phase)
-        timeRemaining = remaining
-        state = .running(
-            phase: phase,
-            startedAt: now().addingTimeInterval(-(duration - remaining)),
-            duration: duration
-        )
-        startTicking()
+  private func startTicking() {
+    stopTicking()
+    let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
+      self?.refreshTimeRemaining()
     }
+    // .common mode keeps the timer firing while menus and popovers are open.
+    RunLoop.main.add(timer, forMode: .common)
+    tickTimer = timer
+  }
 
-    /// Stops the session, records a partial session if one was in progress, and returns to idle.
-    func stop() {
-        let endedAt = now()
-        switch state {
-        case .running(let phase, let startedAt, _):
-            stopTicking()
-            refreshTimeRemaining()
-            onPhaseEnded?(phase, startedAt, endedAt, false)
-        case .paused(let phase, let remaining):
-            let elapsed = duration(for: phase) - remaining
-            let startedAt = endedAt.addingTimeInterval(-elapsed)
-            onPhaseEnded?(phase, startedAt, endedAt, false)
-        case .idle:
-            return
-        }
-        state = .idle
-        timeRemaining = focusDuration
-        queuedPhase = nil
-    }
+  private func stopTicking() {
+    tickTimer?.invalidate()
+    tickTimer = nil
+  }
 
-    /// Advances to the next phase, preserving the current running state.
-    ///
-    /// - Running: the next phase starts immediately.
-    /// - Paused: the next phase begins paused at its full duration.
-    /// - Idle: queues focus as the next phase (cycling a pending break back to focus).
-    /// - Parameter nextBreak: The break phase to use when skipping from a focus phase. Defaults to `.shortBreak`.
-    func skip(nextBreak: SessionPhase = .shortBreak) {
-        let currentPhase: SessionPhase
-        let wasRunning: Bool
-        switch state {
-        case .running(let p, _, _):
-            currentPhase = p
-            wasRunning = true
-        case .paused(let p, _):
-            currentPhase = p
-            wasRunning = false
-        case .idle:
-            queuedPhase = .focus
-            return
-        }
-        stopTicking()
-        let next: SessionPhase = (currentPhase == .focus) ? nextBreak : .focus
-        let d = duration(for: next)
-        timeRemaining = d
-        queuedPhase = nil
-        if wasRunning {
-            state = .running(phase: next, startedAt: now(), duration: d)
-            startTicking()
-        } else {
-            state = .paused(phase: next, remaining: d)
-        }
+  private func duration(for phase: SessionPhase) -> TimeInterval {
+    switch phase {
+    case .focus: return focusDuration
+    case .shortBreak: return shortBreakDuration
+    case .longBreak: return longBreakDuration
     }
-
-    /// Queues a phase to start next without beginning it. Only has effect when idle.
-    func enqueuePhase(_ phase: SessionPhase) {
-        guard case .idle = state else { return }
-        queuedPhase = phase
-    }
-
-    // Recomputes timeRemaining from the stored start timestamp.
-    // Called on each timer tick and immediately before pausing.
-    // Detects natural phase completion when remaining time reaches zero.
-    private func refreshTimeRemaining() {
-        guard case .running(let phase, let startedAt, let duration) = state else { return }
-        let remaining = max(0, duration - now().timeIntervalSince(startedAt))
-        timeRemaining = remaining
-        if remaining <= 0 {
-            stopTicking()
-            state = .idle
-            timeRemaining = focusDuration
-            onPhaseEnded?(phase, startedAt, startedAt.addingTimeInterval(duration), true)
-        }
-    }
-
-    private func startTicking() {
-        stopTicking()
-        let timer = Timer(timeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.refreshTimeRemaining()
-        }
-        // .common mode keeps the timer firing while menus and popovers are open.
-        RunLoop.main.add(timer, forMode: .common)
-        tickTimer = timer
-    }
-
-    private func stopTicking() {
-        tickTimer?.invalidate()
-        tickTimer = nil
-    }
-
-    private func duration(for phase: SessionPhase) -> TimeInterval {
-        switch phase {
-        case .focus: return focusDuration
-        case .shortBreak: return shortBreakDuration
-        case .longBreak: return longBreakDuration
-        }
-    }
+  }
 }

--- a/app/Taskmato/Session/SessionStore.swift
+++ b/app/Taskmato/Session/SessionStore.swift
@@ -3,8 +3,8 @@
 //  Taskmato
 //
 
-import Observation
 import Foundation
+import Observation
 
 /// Persists and provides access to the log of completed Pomodoro sessions.
 ///
@@ -13,100 +13,98 @@ import Foundation
 @Observable
 final class SessionStore {
 
-    /// All recorded sessions, ordered oldest-first.
-    private(set) var sessions: [Session] = []
+  /// All recorded sessions, ordered oldest-first.
+  private(set) var sessions: [Session] = []
 
-    private let fileURL: URL
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
+  private let fileURL: URL
+  private let encoder = JSONEncoder()
+  private let decoder = JSONDecoder()
 
-    /// Creates a store using the default production file path.
-    convenience init() {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        ).first!
-        let dir = appSupport.appendingPathComponent("Taskmato", isDirectory: true)
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        self.init(fileURL: dir.appendingPathComponent("sessions.json"))
+  /// Creates a store using the default production file path.
+  convenience init() {
+    let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask
+    ).first!
+    let dir = appSupport.appendingPathComponent("Taskmato", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    self.init(fileURL: dir.appendingPathComponent("sessions.json"))
+  }
+
+  /// Creates a store using a specific file URL. Pass a temporary path in tests.
+  init(fileURL: URL) {
+    self.fileURL = fileURL
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    decoder.dateDecodingStrategy = .iso8601
+    load()
+  }
+
+  /// Appends a session record to the log and writes it to disk.
+  func append(_ session: Session) {
+    sessions.append(session)
+    save()
+  }
+
+  /// Returns the phase that should begin when the user presses Start from idle.
+  ///
+  /// Returns the appropriate break type after a completed focus session, or `.focus` otherwise.
+  /// - Parameter longBreakAfter: Number of completed focus sessions before a long break.
+  func nextPhaseToStart(longBreakAfter: Int) -> SessionPhase {
+    guard let last = sessions.last, last.wasCompleted else { return .focus }
+    switch last.phase {
+    case .focus: return nextBreakPhase(longBreakAfter: longBreakAfter)
+    case .shortBreak, .longBreak: return .focus
     }
+  }
 
-    /// Creates a store using a specific file URL. Pass a temporary path in tests.
-    init(fileURL: URL) {
-        self.fileURL = fileURL
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        encoder.dateEncodingStrategy = .iso8601
-        decoder.dateDecodingStrategy = .iso8601
-        load()
+  /// Returns the appropriate break phase for the next session based on the history.
+  ///
+  /// Counts completed focus sessions since the last completed long break.
+  /// Partial sessions and skipped phases are excluded from the count.
+  /// - Parameter longBreakAfter: Number of completed focus sessions before a long break.
+  func nextBreakPhase(longBreakAfter: Int) -> SessionPhase {
+    let completedFocusSinceLastLongBreak =
+      sessions
+      .reversed()
+      .prefix(while: { !($0.phase == .longBreak && $0.wasCompleted) })
+      .filter({ $0.phase == .focus && $0.wasCompleted })
+      .count
+    guard completedFocusSinceLastLongBreak > 0,
+      completedFocusSinceLastLongBreak % longBreakAfter == 0
+    else {
+      return .shortBreak
     }
+    return .longBreak
+  }
 
-    /// Appends a session record to the log and writes it to disk.
-    func append(_ session: Session) {
-        sessions.append(session)
-        save()
-    }
+  /// Number of completed focus sessions that started today (calendar day, local time zone).
+  func todayFocusCount() -> Int {
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    return sessions.filter {
+      $0.phase == .focus && $0.wasCompleted && calendar.startOfDay(for: $0.startedAt) == today
+    }.count
+  }
 
-    /// Returns the phase that should begin when the user presses Start from idle.
-    ///
-    /// Returns the appropriate break type after a completed focus session, or `.focus` otherwise.
-    /// - Parameter longBreakAfter: Number of completed focus sessions before a long break.
-    func nextPhaseToStart(longBreakAfter: Int) -> SessionPhase {
-        guard let last = sessions.last, last.wasCompleted else { return .focus }
-        switch last.phase {
-        case .focus: return nextBreakPhase(longBreakAfter: longBreakAfter)
-        case .shortBreak, .longBreak: return .focus
-        }
-    }
+  /// Total elapsed minutes across all completed focus sessions that started today.
+  func todayFocusMinutes() -> Int {
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    let total = sessions.filter {
+      $0.phase == .focus && $0.wasCompleted && calendar.startOfDay(for: $0.startedAt) == today
+    }.reduce(0) { $0 + $1.duration }
+    return Int(total / 60)
+  }
 
-    /// Returns the appropriate break phase for the next session based on the history.
-    ///
-    /// Counts completed focus sessions since the last completed long break.
-    /// Partial sessions and skipped phases are excluded from the count.
-    /// - Parameter longBreakAfter: Number of completed focus sessions before a long break.
-    func nextBreakPhase(longBreakAfter: Int) -> SessionPhase {
-        let completedFocusSinceLastLongBreak = sessions
-            .reversed()
-            .prefix(while: { !($0.phase == .longBreak && $0.wasCompleted) })
-            .filter({ $0.phase == .focus && $0.wasCompleted })
-            .count
-        guard completedFocusSinceLastLongBreak > 0,
-              completedFocusSinceLastLongBreak % longBreakAfter == 0 else {
-            return .shortBreak
-        }
-        return .longBreak
-    }
+  // MARK: - Private
 
-    /// Number of completed focus sessions that started today (calendar day, local time zone).
-    func todayFocusCount() -> Int {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        return sessions.filter {
-            $0.phase == .focus &&
-            $0.wasCompleted &&
-            calendar.startOfDay(for: $0.startedAt) == today
-        }.count
-    }
+  private func load() {
+    guard let data = try? Data(contentsOf: fileURL) else { return }
+    sessions = (try? decoder.decode([Session].self, from: data)) ?? []
+  }
 
-    /// Total elapsed minutes across all completed focus sessions that started today.
-    func todayFocusMinutes() -> Int {
-        let calendar = Calendar.current
-        let today = calendar.startOfDay(for: Date())
-        let total = sessions.filter {
-            $0.phase == .focus &&
-            $0.wasCompleted &&
-            calendar.startOfDay(for: $0.startedAt) == today
-        }.reduce(0) { $0 + $1.duration }
-        return Int(total / 60)
-    }
-
-    // MARK: - Private
-
-    private func load() {
-        guard let data = try? Data(contentsOf: fileURL) else { return }
-        sessions = (try? decoder.decode([Session].self, from: data)) ?? []
-    }
-
-    private func save() {
-        guard let data = try? encoder.encode(sessions) else { return }
-        try? data.write(to: fileURL, options: .atomic)
-    }
+  private func save() {
+    guard let data = try? encoder.encode(sessions) else { return }
+    try? data.write(to: fileURL, options: .atomic)
+  }
 }

--- a/app/Taskmato/Settings/AppSettings.swift
+++ b/app/Taskmato/Settings/AppSettings.swift
@@ -3,8 +3,8 @@
 //  Taskmato
 //
 
-import Observation
 import Foundation
+import Observation
 
 /// Persists user preferences for session and break durations.
 ///
@@ -13,81 +13,81 @@ import Foundation
 @Observable
 final class AppSettings {
 
-    /// Length of a focus interval, in minutes.
-    var focusMinutes: Int {
-        didSet { defaults.set(focusMinutes, forKey: Keys.focusMinutes) }
-    }
+  /// Length of a focus interval, in minutes.
+  var focusMinutes: Int {
+    didSet { defaults.set(focusMinutes, forKey: Keys.focusMinutes) }
+  }
 
-    /// Length of a short break, in minutes.
-    var shortBreakMinutes: Int {
-        didSet { defaults.set(shortBreakMinutes, forKey: Keys.shortBreakMinutes) }
-    }
+  /// Length of a short break, in minutes.
+  var shortBreakMinutes: Int {
+    didSet { defaults.set(shortBreakMinutes, forKey: Keys.shortBreakMinutes) }
+  }
 
-    /// Length of a long break, in minutes.
-    var longBreakMinutes: Int {
-        didSet { defaults.set(longBreakMinutes, forKey: Keys.longBreakMinutes) }
-    }
+  /// Length of a long break, in minutes.
+  var longBreakMinutes: Int {
+    didSet { defaults.set(longBreakMinutes, forKey: Keys.longBreakMinutes) }
+  }
 
-    /// Number of completed focus sessions before a long break is taken.
-    var longBreakAfterSessions: Int {
-        didSet { defaults.set(longBreakAfterSessions, forKey: Keys.longBreakAfterSessions) }
-    }
+  /// Number of completed focus sessions before a long break is taken.
+  var longBreakAfterSessions: Int {
+    didSet { defaults.set(longBreakAfterSessions, forKey: Keys.longBreakAfterSessions) }
+  }
 
-    /// Whether a sound is played when a phase completes naturally.
-    var soundEnabled: Bool {
-        didSet { defaults.set(soundEnabled, forKey: Keys.soundEnabled) }
-    }
+  /// Whether a sound is played when a phase completes naturally.
+  var soundEnabled: Bool {
+    didSet { defaults.set(soundEnabled, forKey: Keys.soundEnabled) }
+  }
 
-    /// Whether a banner notification is shown when a phase completes naturally.
-    var notificationsEnabled: Bool {
-        didSet { defaults.set(notificationsEnabled, forKey: Keys.notificationsEnabled) }
-    }
+  /// Whether a banner notification is shown when a phase completes naturally.
+  var notificationsEnabled: Bool {
+    didSet { defaults.set(notificationsEnabled, forKey: Keys.notificationsEnabled) }
+  }
 
-    /// Whether the next phase starts automatically on natural completion, or waits for the user to press Start.
-    var autoStartNextPhase: Bool {
-        didSet { defaults.set(autoStartNextPhase, forKey: Keys.autoStartNextPhase) }
-    }
+  /// Whether the next phase starts automatically on natural completion, or waits for the user to press Start.
+  var autoStartNextPhase: Bool {
+    didSet { defaults.set(autoStartNextPhase, forKey: Keys.autoStartNextPhase) }
+  }
 
-    /// `focusMinutes` expressed as a `TimeInterval` in seconds.
-    var focusDuration: TimeInterval { TimeInterval(focusMinutes * 60) }
+  /// `focusMinutes` expressed as a `TimeInterval` in seconds.
+  var focusDuration: TimeInterval { TimeInterval(focusMinutes * 60) }
 
-    /// `shortBreakMinutes` expressed as a `TimeInterval` in seconds.
-    var shortBreakDuration: TimeInterval { TimeInterval(shortBreakMinutes * 60) }
+  /// `shortBreakMinutes` expressed as a `TimeInterval` in seconds.
+  var shortBreakDuration: TimeInterval { TimeInterval(shortBreakMinutes * 60) }
 
-    /// `longBreakMinutes` expressed as a `TimeInterval` in seconds.
-    var longBreakDuration: TimeInterval { TimeInterval(longBreakMinutes * 60) }
+  /// `longBreakMinutes` expressed as a `TimeInterval` in seconds.
+  var longBreakDuration: TimeInterval { TimeInterval(longBreakMinutes * 60) }
 
-    private let defaults: UserDefaults
+  private let defaults: UserDefaults
 
-    /// Creates settings backed by the standard `UserDefaults` suite.
-    convenience init() {
-        self.init(defaults: .standard)
-    }
+  /// Creates settings backed by the standard `UserDefaults` suite.
+  convenience init() {
+    self.init(defaults: .standard)
+  }
 
-    /// Creates settings backed by the provided `UserDefaults` instance. Pass a temporary suite in tests.
-    init(defaults: UserDefaults) {
-        self.defaults = defaults
-        focusMinutes           = defaults.integer(forKey: Keys.focusMinutes).nonZero ?? 25
-        shortBreakMinutes      = defaults.integer(forKey: Keys.shortBreakMinutes).nonZero ?? 5
-        longBreakMinutes       = defaults.integer(forKey: Keys.longBreakMinutes).nonZero ?? 15
-        longBreakAfterSessions = defaults.integer(forKey: Keys.longBreakAfterSessions).nonZero ?? 4
-        soundEnabled           = defaults.object(forKey: Keys.soundEnabled) as? Bool ?? true
-        notificationsEnabled   = defaults.object(forKey: Keys.notificationsEnabled) as? Bool ?? true
-        autoStartNextPhase     = defaults.object(forKey: Keys.autoStartNextPhase) as? Bool ?? false
-    }
+  /// Creates settings backed by the provided `UserDefaults` instance. Pass a temporary suite in tests.
+  init(defaults: UserDefaults) {
+    self.defaults = defaults
+    focusMinutes = defaults.integer(forKey: Keys.focusMinutes).nonZero ?? 25
+    shortBreakMinutes = defaults.integer(forKey: Keys.shortBreakMinutes).nonZero ?? 5
+    longBreakMinutes = defaults.integer(forKey: Keys.longBreakMinutes).nonZero ?? 15
+    longBreakAfterSessions = defaults.integer(forKey: Keys.longBreakAfterSessions).nonZero ?? 4
+    soundEnabled = defaults.object(forKey: Keys.soundEnabled) as? Bool ?? true
+    notificationsEnabled = defaults.object(forKey: Keys.notificationsEnabled) as? Bool ?? true
+    autoStartNextPhase = defaults.object(forKey: Keys.autoStartNextPhase) as? Bool ?? false
+  }
 
-    private enum Keys {
-        static let focusMinutes           = "focusMinutes"
-        static let shortBreakMinutes      = "shortBreakMinutes"
-        static let longBreakMinutes       = "longBreakMinutes"
-        static let longBreakAfterSessions = "longBreakAfterSessions"
-        static let soundEnabled            = "soundEnabled"
-        static let notificationsEnabled   = "notificationsEnabled"
-        static let autoStartNextPhase     = "autoStartNextPhase"
-    }
+  private enum Keys {
+    static let focusMinutes = "focusMinutes"
+    static let shortBreakMinutes = "shortBreakMinutes"
+    static let longBreakMinutes = "longBreakMinutes"
+    static let longBreakAfterSessions = "longBreakAfterSessions"
+    static let soundEnabled = "soundEnabled"
+    static let notificationsEnabled = "notificationsEnabled"
+    static let autoStartNextPhase = "autoStartNextPhase"
+  }
 }
 
-private extension Int {
-    /// Returns `self` if greater than zero, otherwise `nil`.
-    var nonZero: Int? { self > 0 ? self : nil }
+extension Int {
+  /// Returns `self` if greater than zero, otherwise `nil`.
+  fileprivate var nonZero: Int? { self > 0 ? self : nil }
 }

--- a/app/Taskmato/Settings/SettingsView.swift
+++ b/app/Taskmato/Settings/SettingsView.swift
@@ -9,81 +9,82 @@ import SwiftUI
 /// and as a standalone window opened via ⌘,.
 struct SettingsView: View {
 
-    @Bindable var settings: AppSettings
+  @Bindable var settings: AppSettings
 
-    var body: some View {
-        Form {
-            Section("Durations") {
-                DurationField("Focus", value: $settings.focusMinutes, range: 1...60)
-                DurationField("Short Break", value: $settings.shortBreakMinutes, range: 1...30)
-                DurationField("Long Break", value: $settings.longBreakMinutes, range: 1...60)
-            }
+  var body: some View {
+    Form {
+      Section("Durations") {
+        DurationField("Focus", value: $settings.focusMinutes, range: 1...60)
+        DurationField("Short Break", value: $settings.shortBreakMinutes, range: 1...30)
+        DurationField("Long Break", value: $settings.longBreakMinutes, range: 1...60)
+      }
 
-            Section("Long Break") {
-                DurationField("After every", value: $settings.longBreakAfterSessions, range: 1...8, unit: "sessions")
-            }
+      Section("Long Break") {
+        DurationField(
+          "After every", value: $settings.longBreakAfterSessions, range: 1...8, unit: "sessions")
+      }
 
-            Section("Behavior") {
-                Toggle("Play sound on phase completion", isOn: $settings.soundEnabled)
-                Toggle("Show notification on phase completion", isOn: $settings.notificationsEnabled)
-                Toggle("Auto-start next phase", isOn: $settings.autoStartNextPhase)
-            }
-        }
-        .formStyle(.grouped)
-        .navigationTitle("Taskmato Settings")
+      Section("Behavior") {
+        Toggle("Play sound on phase completion", isOn: $settings.soundEnabled)
+        Toggle("Show notification on phase completion", isOn: $settings.notificationsEnabled)
+        Toggle("Auto-start next phase", isOn: $settings.autoStartNextPhase)
+      }
     }
+    .formStyle(.grouped)
+    .navigationTitle("Taskmato Settings")
+  }
 }
 
 /// A labelled row combining a text field for direct input and a stepper for nudging.
 private struct DurationField: View {
 
-    let label: String
-    @Binding var value: Int
-    let range: ClosedRange<Int>
-    let unit: String
+  let label: String
+  @Binding var value: Int
+  let range: ClosedRange<Int>
+  let unit: String
 
-    @State private var text: String = ""
-    @FocusState private var isFocused: Bool
+  @State private var text: String = ""
+  @FocusState private var isFocused: Bool
 
-    init(_ label: String, value: Binding<Int>, range: ClosedRange<Int>, unit: String = "min") {
-        self.label = label
-        self._value = value
-        self.range = range
-        self.unit = unit
-        self._text = State(initialValue: "\(value.wrappedValue)")
-    }
+  init(_ label: String, value: Binding<Int>, range: ClosedRange<Int>, unit: String = "min") {
+    self.label = label
+    self._value = value
+    self.range = range
+    self.unit = unit
+    self._text = State(initialValue: "\(value.wrappedValue)")
+  }
 
-    var body: some View {
-        HStack {
-            Text(label)
-            Spacer()
-            TextField("", text: $text)
-                .multilineTextAlignment(.trailing)
-                .frame(width: 36)
-                .focused($isFocused)
-                .onSubmit { commit() }
-                .onChange(of: isFocused) { _, focused in
-                    if !focused { commit() }
-                }
-                .onChange(of: value) { _, new in
-                    if !isFocused { text = "\(new)" }
-                }
-            Text(unit)
-                .foregroundStyle(.secondary)
-            Stepper("", value: $value, in: range)
-                .labelsHidden()
+  var body: some View {
+    HStack {
+      Text(label)
+      Spacer()
+      TextField("", text: $text)
+        .multilineTextAlignment(.trailing)
+        .frame(width: 36)
+        .focused($isFocused)
+        .onSubmit { commit() }
+        .onChange(of: isFocused) { _, focused in
+          if !focused { commit() }
         }
-    }
-
-    /// Parses the text field input and updates `value` if valid, otherwise reverts the text.
-    private func commit() {
-        if let parsed = Int(text), range.contains(parsed) {
-            value = parsed
+        .onChange(of: value) { _, new in
+          if !isFocused { text = "\(new)" }
         }
-        text = "\(value)"
+      Text(unit)
+        .foregroundStyle(.secondary)
+      Stepper("", value: $value, in: range)
+        .labelsHidden()
     }
+  }
+
+  /// Parses the text field input and updates `value` if valid, otherwise reverts the text.
+  private func commit() {
+    if let parsed = Int(text), range.contains(parsed) {
+      value = parsed
+    }
+    text = "\(value)"
+  }
 }
 
 #Preview {
-    SettingsView(settings: AppSettings())
+  SettingsView(settings: AppSettings())
 }

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -10,79 +10,81 @@ import SwiftUI
 @main
 struct TaskmatoApp: App {
 
-    @State private var engine: SessionEngine
-    @State private var settings: AppSettings
-    @State private var store: SessionStore
-    @State private var notifications: NotificationService
-    @State private var sounds: SoundService
+  @State private var engine: SessionEngine
+  @State private var settings: AppSettings
+  @State private var store: SessionStore
+  @State private var notifications: NotificationService
+  @State private var sounds: SoundService
 
-    init() {
-        let engine = SessionEngine()
-        let settings = AppSettings()
-        let store = SessionStore()
-        let notifications = NotificationService()
-        let sounds = SoundService()
+  init() {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    let store = SessionStore()
+    let notifications = NotificationService()
+    let sounds = SoundService()
 
-        engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in
-            store.append(Session(
-                id: UUID(),
-                phase: phase,
-                startedAt: startedAt,
-                endedAt: endedAt,
-                wasCompleted: wasCompleted
-            ))
-            if wasCompleted {
-                if settings.soundEnabled         { sounds.play() }
-                if settings.notificationsEnabled { notifications.send(phase: phase) }
-                engine.focusDuration      = settings.focusDuration
-                engine.shortBreakDuration = settings.shortBreakDuration
-                engine.longBreakDuration  = settings.longBreakDuration
-                let next: SessionPhase
-                switch phase {
-                case .focus: next = store.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
-                case .shortBreak, .longBreak: next = .focus
-                }
-                if settings.autoStartNextPhase {
-                    engine.start(phase: next)
-                } else {
-                    engine.enqueuePhase(next)
-                }
-            }
+    engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in
+      store.append(
+        Session(
+          id: UUID(),
+          phase: phase,
+          startedAt: startedAt,
+          endedAt: endedAt,
+          wasCompleted: wasCompleted
+        ))
+      if wasCompleted {
+        if settings.soundEnabled { sounds.play() }
+        if settings.notificationsEnabled { notifications.send(phase: phase) }
+        engine.focusDuration = settings.focusDuration
+        engine.shortBreakDuration = settings.shortBreakDuration
+        engine.longBreakDuration = settings.longBreakDuration
+        let next: SessionPhase
+        switch phase {
+        case .focus: next = store.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+        case .shortBreak, .longBreak: next = .focus
         }
-
-        _engine = State(initialValue: engine)
-        _settings = State(initialValue: settings)
-        _store = State(initialValue: store)
-        _notifications = State(initialValue: notifications)
-        _sounds = State(initialValue: sounds)
-    }
-
-    var body: some Scene {
-        MenuBarExtra(menuBarLabel) {
-            TimerView(
-                engine: engine,
-                settings: settings,
-                store: store,
-                nextStartPhase: engine.queuedPhase ?? store.nextPhaseToStart(longBreakAfter: settings.longBreakAfterSessions),
-                nextBreakPhase: store.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
-            )
-        }
-        .menuBarExtraStyle(.window)
-
-        Settings {
-            SettingsView(settings: settings)
-        }
-        .windowResizability(.contentSize)
-    }
-
-    /// Formats the active or idle time as `"🍅 MM:SS"` for display in the menu bar.
-    private var menuBarLabel: String {
-        let seconds: Int
-        if case .idle = engine.state {
-            seconds = Int(settings.focusDuration)
+        if settings.autoStartNextPhase {
+          engine.start(phase: next)
         } else {
-            seconds = Int(engine.timeRemaining)
+          engine.enqueuePhase(next)
         }
-        return "🍅 \(String(format: "%02d:%02d", seconds / 60, seconds % 60))"
+      }
     }
+
+    _engine = State(initialValue: engine)
+    _settings = State(initialValue: settings)
+    _store = State(initialValue: store)
+    _notifications = State(initialValue: notifications)
+    _sounds = State(initialValue: sounds)
+  }
+
+  var body: some Scene {
+    MenuBarExtra(menuBarLabel) {
+      TimerView(
+        engine: engine,
+        settings: settings,
+        store: store,
+        nextStartPhase: engine.queuedPhase
+          ?? store.nextPhaseToStart(longBreakAfter: settings.longBreakAfterSessions),
+        nextBreakPhase: store.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+      )
+    }
+    .menuBarExtraStyle(.window)
+
+    Settings {
+      SettingsView(settings: settings)
+    }
+    .windowResizability(.contentSize)
+  }
+
+  /// Formats the active or idle time as `"🍅 MM:SS"` for display in the menu bar.
+  private var menuBarLabel: String {
+    let seconds: Int
+    if case .idle = engine.state {
+      seconds = Int(settings.focusDuration)
+    } else {
+      seconds = Int(engine.timeRemaining)
+    }
+    return "🍅 \(String(format: "%02d:%02d", seconds / 60, seconds % 60))"
+  }
 }

--- a/app/Taskmato/TimerView.swift
+++ b/app/Taskmato/TimerView.swift
@@ -10,239 +10,239 @@ import SwiftUI
 /// The main popover view shown when the user clicks the menu bar item.
 struct TimerView: View {
 
-    var engine: SessionEngine
-    var settings: AppSettings
-    var store: SessionStore
-    /// The phase to start when the user presses Start from idle.
-    var nextStartPhase: SessionPhase
-    /// The break type to use when skipping from a focus session.
-    var nextBreakPhase: SessionPhase
+  var engine: SessionEngine
+  var settings: AppSettings
+  var store: SessionStore
+  /// The phase to start when the user presses Start from idle.
+  var nextStartPhase: SessionPhase
+  /// The break type to use when skipping from a focus session.
+  var nextBreakPhase: SessionPhase
 
-    @Environment(\.openSettings) private var openSettings
+  @Environment(\.openSettings) private var openSettings
 
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Spacer()
-                Button {
-                    let popover = NSApplication.shared.keyWindow
-                    openSettings()
-                    popover?.close()
-                } label: {
-                    Image(systemName: "gearshape")
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 12)
-            .padding(.bottom, 8)
-
-            CircularTimerView(
-                progress: progress,
-                label: formattedTimeRemaining,
-                phase: phaseName
-            )
-
-            controls
-                .frame(height: 44)
-                .padding(.top, 16)
-
-            Divider()
-                .padding(.horizontal, 16)
-
-            SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack {
+        Spacer()
+        Button {
+          let popover = NSApplication.shared.keyWindow
+          openSettings()
+          popover?.close()
+        } label: {
+          Image(systemName: "gearshape")
+            .foregroundStyle(.secondary)
         }
-        .frame(width: 280)
+        .buttonStyle(.plain)
+      }
+      .padding(.horizontal, 16)
+      .padding(.top, 12)
+      .padding(.bottom, 8)
+
+      CircularTimerView(
+        progress: progress,
+        label: formattedTimeRemaining,
+        phase: phaseName
+      )
+
+      controls
+        .frame(height: 44)
+        .padding(.top, 16)
+
+      Divider()
+        .padding(.horizontal, 16)
+
+      SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
     }
+    .frame(width: 280)
+  }
 
-    // MARK: - Controls
+  // MARK: - Controls
 
-    private var controls: some View {
-        HStack(spacing: 12) {
-            if engine.isRunning {
-                ControlButton(label: "Pause", icon: "pause.fill") { engine.pause() }
-            } else if case .paused = engine.state {
-                ControlButton(label: "Resume", icon: "play.fill") { engine.resume() }
-            } else {
-                ControlButton(label: "Start", icon: "play.fill") { startSession() }
-            }
+  private var controls: some View {
+    HStack(spacing: 12) {
+      if engine.isRunning {
+        ControlButton(label: "Pause", icon: "pause.fill") { engine.pause() }
+      } else if case .paused = engine.state {
+        ControlButton(label: "Resume", icon: "play.fill") { engine.resume() }
+      } else {
+        ControlButton(label: "Start", icon: "play.fill") { startSession() }
+      }
 
-            ControlButton(label: "Skip", icon: "forward.fill") { skipPhase() }
+      ControlButton(label: "Skip", icon: "forward.fill") { skipPhase() }
 
-            ControlButton(label: "Stop", icon: "stop.fill") { engine.stop() }
-                .disabled(engine.state == .idle)
-        }
+      ControlButton(label: "Stop", icon: "stop.fill") { engine.stop() }
+        .disabled(engine.state == .idle)
     }
+  }
 
-    // MARK: - Actions
+  // MARK: - Actions
 
-    /// Syncs current settings into the engine, then starts the appropriate next phase.
-    private func startSession() {
-        engine.focusDuration      = settings.focusDuration
-        engine.shortBreakDuration = settings.shortBreakDuration
-        engine.longBreakDuration  = settings.longBreakDuration
-        engine.start(phase: nextStartPhase)
+  /// Syncs current settings into the engine, then starts the appropriate next phase.
+  private func startSession() {
+    engine.focusDuration = settings.focusDuration
+    engine.shortBreakDuration = settings.shortBreakDuration
+    engine.longBreakDuration = settings.longBreakDuration
+    engine.start(phase: nextStartPhase)
+  }
+
+  /// Syncs current settings into the engine, then skips to the next phase.
+  ///
+  /// The engine mirrors the current running state: running stays running, paused stays
+  /// paused (at the new phase's full duration), and idle queues the next phase.
+  private func skipPhase() {
+    engine.focusDuration = settings.focusDuration
+    engine.shortBreakDuration = settings.shortBreakDuration
+    engine.longBreakDuration = settings.longBreakDuration
+    engine.skip(nextBreak: nextBreakPhase)
+  }
+
+  // MARK: - Helpers
+
+  private var progress: Double {
+    switch engine.state {
+    case .idle:
+      return 1.0
+    case .running(_, _, let duration):
+      guard duration > 0 else { return 1 }
+      return engine.timeRemaining / duration
+    case .paused(let phase, _):
+      let duration: TimeInterval
+      switch phase {
+      case .focus: duration = engine.focusDuration
+      case .shortBreak: duration = engine.shortBreakDuration
+      case .longBreak: duration = engine.longBreakDuration
+      }
+      guard duration > 0 else { return 1 }
+      return engine.timeRemaining / duration
     }
+  }
 
-    /// Syncs current settings into the engine, then skips to the next phase.
-    ///
-    /// The engine mirrors the current running state: running stays running, paused stays
-    /// paused (at the new phase's full duration), and idle queues the next phase.
-    private func skipPhase() {
-        engine.focusDuration      = settings.focusDuration
-        engine.shortBreakDuration = settings.shortBreakDuration
-        engine.longBreakDuration  = settings.longBreakDuration
-        engine.skip(nextBreak: nextBreakPhase)
+  private var formattedTimeRemaining: String {
+    let seconds: Int
+    if case .idle = engine.state {
+      switch nextStartPhase {
+      case .focus: seconds = Int(settings.focusDuration)
+      case .shortBreak: seconds = Int(settings.shortBreakDuration)
+      case .longBreak: seconds = Int(settings.longBreakDuration)
+      }
+    } else {
+      seconds = Int(engine.timeRemaining)
     }
+    return String(format: "%02d:%02d", seconds / 60, seconds % 60)
+  }
 
-    // MARK: - Helpers
-
-    private var progress: Double {
-        switch engine.state {
-        case .idle:
-            return 1.0
-        case .running(_, _, let duration):
-            guard duration > 0 else { return 1 }
-            return engine.timeRemaining / duration
-        case .paused(let phase, _):
-            let duration: TimeInterval
-            switch phase {
-            case .focus:      duration = engine.focusDuration
-            case .shortBreak: duration = engine.shortBreakDuration
-            case .longBreak:  duration = engine.longBreakDuration
-            }
-            guard duration > 0 else { return 1 }
-            return engine.timeRemaining / duration
-        }
+  private var phaseName: String {
+    switch engine.state {
+    case .idle:
+      switch nextStartPhase {
+      case .focus: return "Ready to focus"
+      case .shortBreak: return "Short Break"
+      case .longBreak: return "Long Break"
+      }
+    case .running(let phase, _, _), .paused(let phase, _):
+      switch phase {
+      case .focus: return "Focus"
+      case .shortBreak: return "Short Break"
+      case .longBreak: return "Long Break"
+      }
     }
-
-    private var formattedTimeRemaining: String {
-        let seconds: Int
-        if case .idle = engine.state {
-            switch nextStartPhase {
-            case .focus:      seconds = Int(settings.focusDuration)
-            case .shortBreak: seconds = Int(settings.shortBreakDuration)
-            case .longBreak:  seconds = Int(settings.longBreakDuration)
-            }
-        } else {
-            seconds = Int(engine.timeRemaining)
-        }
-        return String(format: "%02d:%02d", seconds / 60, seconds % 60)
-    }
-
-    private var phaseName: String {
-        switch engine.state {
-        case .idle:
-            switch nextStartPhase {
-            case .focus:      return "Ready to focus"
-            case .shortBreak: return "Short Break"
-            case .longBreak:  return "Long Break"
-            }
-        case .running(let phase, _, _), .paused(let phase, _):
-            switch phase {
-            case .focus:      return "Focus"
-            case .shortBreak: return "Short Break"
-            case .longBreak:  return "Long Break"
-            }
-        }
-    }
+  }
 }
 
 /// A circular progress ring with a countdown label and phase name centered inside.
 private struct CircularTimerView: View {
 
-    /// Fraction of time remaining, from 1.0 (full) down to 0.0 (elapsed).
-    let progress: Double
-    /// The formatted time string displayed in the center, e.g. `"24:59"`.
-    let label: String
-    /// The phase name displayed below the time, e.g. `"Focus"`.
-    let phase: String
+  /// Fraction of time remaining, from 1.0 (full) down to 0.0 (elapsed).
+  let progress: Double
+  /// The formatted time string displayed in the center, e.g. `"24:59"`.
+  let label: String
+  /// The phase name displayed below the time, e.g. `"Focus"`.
+  let phase: String
 
-    private let ringDiameter: CGFloat = 180
-    private let strokeWidth: CGFloat = 10
+  private let ringDiameter: CGFloat = 180
+  private let strokeWidth: CGFloat = 10
 
-    var body: some View {
-        ZStack {
-            Circle()
-                .stroke(Color.secondary.opacity(0.2), lineWidth: strokeWidth)
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(Color.secondary.opacity(0.2), lineWidth: strokeWidth)
 
-            // Elapsed arc grows clockwise from 12 o'clock as time passes.
-            Circle()
-                .trim(from: 0, to: 1 - progress)
-                .stroke(
-                    Color.accentColor,
-                    style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
-                )
-                .rotationEffect(.degrees(-90))
-                .animation(.linear(duration: 1), value: progress)
+      // Elapsed arc grows clockwise from 12 o'clock as time passes.
+      Circle()
+        .trim(from: 0, to: 1 - progress)
+        .stroke(
+          Color.accentColor,
+          style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+        )
+        .rotationEffect(.degrees(-90))
+        .animation(.linear(duration: 1), value: progress)
 
-            VStack(spacing: 4) {
-                Text(label)
-                    .font(.system(size: 36, weight: .light, design: .monospaced))
-                    .foregroundStyle(.primary)
-                Text(phase)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .frame(width: ringDiameter, height: ringDiameter)
+      VStack(spacing: 4) {
+        Text(label)
+          .font(.system(size: 36, weight: .light, design: .monospaced))
+          .foregroundStyle(.primary)
+        Text(phase)
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
+      }
     }
+    .frame(width: ringDiameter, height: ringDiameter)
+  }
 }
 
 /// A compact icon-only button used in the timer controls row.
 private struct ControlButton: View {
 
-    let label: String
-    let icon: String
-    let action: () -> Void
+  let label: String
+  let icon: String
+  let action: () -> Void
 
-    var body: some View {
-        Button(action: action) {
-            Label(label, systemImage: icon)
-                .labelStyle(.iconOnly)
-                .frame(width: 32, height: 32)
-        }
-        .buttonStyle(.bordered)
-        .help(label)
+  var body: some View {
+    Button(action: action) {
+      Label(label, systemImage: icon)
+        .labelStyle(.iconOnly)
+        .frame(width: 32, height: 32)
     }
+    .buttonStyle(.bordered)
+    .help(label)
+  }
 }
 
 /// A compact summary row showing today's focus session count and total focused time.
 private struct SessionStatsView: View {
 
-    /// Number of completed focus sessions today.
-    let count: Int
-    /// Total minutes of completed focus time today.
-    let minutes: Int
+  /// Number of completed focus sessions today.
+  let count: Int
+  /// Total minutes of completed focus time today.
+  let minutes: Int
 
-    var body: some View {
-        HStack {
-            Label(sessionLabel, systemImage: "timer")
-            Spacer()
-            Label(minuteLabel, systemImage: "clock")
-        }
-        .font(.caption)
-        .foregroundStyle(.secondary)
+  var body: some View {
+    HStack {
+      Label(sessionLabel, systemImage: "timer")
+      Spacer()
+      Label(minuteLabel, systemImage: "clock")
     }
+    .font(.caption)
+    .foregroundStyle(.secondary)
+  }
 
-    private var sessionLabel: String {
-        count == 1 ? "1 session today" : "\(count) sessions today"
-    }
+  private var sessionLabel: String {
+    count == 1 ? "1 session today" : "\(count) sessions today"
+  }
 
-    private var minuteLabel: String {
-        "\(minutes) min focused"
-    }
+  private var minuteLabel: String {
+    "\(minutes) min focused"
+  }
 }
 
 #Preview {
-    TimerView(
-        engine: SessionEngine(),
-        settings: AppSettings(),
-        store: SessionStore(),
-        nextStartPhase: .focus,
-        nextBreakPhase: .shortBreak
-    )
+  TimerView(
+    engine: SessionEngine(),
+    settings: AppSettings(),
+    store: SessionStore(),
+    nextStartPhase: .focus,
+    nextBreakPhase: .shortBreak
+  )
 }

--- a/app/TaskmatoTests/AppSettingsTests.swift
+++ b/app/TaskmatoTests/AppSettingsTests.swift
@@ -3,87 +3,88 @@
 //  TaskmatoTests
 //
 
-import Testing
-@testable import Taskmato
 import Foundation
+import Testing
+
+@testable import Taskmato
 
 struct AppSettingsTests {
 
-    /// Returns settings backed by an isolated, temporary UserDefaults suite.
-    private func makeSettings() -> AppSettings {
-        AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
-    }
+  /// Returns settings backed by an isolated, temporary UserDefaults suite.
+  private func makeSettings() -> AppSettings {
+    AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+  }
 
-    // MARK: - Duration conversions
+  // MARK: - Duration conversions
 
-    @Test func focusDurationIsMinutesInSeconds() {
-        let settings = makeSettings()
-        settings.focusMinutes = 30
-        #expect(settings.focusDuration == 30 * 60)
-    }
+  @Test func focusDurationIsMinutesInSeconds() {
+    let settings = makeSettings()
+    settings.focusMinutes = 30
+    #expect(settings.focusDuration == 30 * 60)
+  }
 
-    @Test func shortBreakDurationIsMinutesInSeconds() {
-        let settings = makeSettings()
-        settings.shortBreakMinutes = 10
-        #expect(settings.shortBreakDuration == 10 * 60)
-    }
+  @Test func shortBreakDurationIsMinutesInSeconds() {
+    let settings = makeSettings()
+    settings.shortBreakMinutes = 10
+    #expect(settings.shortBreakDuration == 10 * 60)
+  }
 
-    @Test func longBreakDurationIsMinutesInSeconds() {
-        let settings = makeSettings()
-        settings.longBreakMinutes = 20
-        #expect(settings.longBreakDuration == 20 * 60)
-    }
+  @Test func longBreakDurationIsMinutesInSeconds() {
+    let settings = makeSettings()
+    settings.longBreakMinutes = 20
+    #expect(settings.longBreakDuration == 20 * 60)
+  }
 
-    // MARK: - Default values
+  // MARK: - Default values
 
-    @Test func defaultFocusIsPositive() {
-        #expect(makeSettings().focusMinutes > 0)
-    }
+  @Test func defaultFocusIsPositive() {
+    #expect(makeSettings().focusMinutes > 0)
+  }
 
-    @Test func defaultShortBreakIsPositive() {
-        #expect(makeSettings().shortBreakMinutes > 0)
-    }
+  @Test func defaultShortBreakIsPositive() {
+    #expect(makeSettings().shortBreakMinutes > 0)
+  }
 
-    @Test func defaultLongBreakIsPositive() {
-        #expect(makeSettings().longBreakMinutes > 0)
-    }
+  @Test func defaultLongBreakIsPositive() {
+    #expect(makeSettings().longBreakMinutes > 0)
+  }
 
-    @Test func defaultLongBreakIsLongerThanShortBreak() {
-        let settings = makeSettings()
-        #expect(settings.longBreakMinutes > settings.shortBreakMinutes)
-    }
+  @Test func defaultLongBreakIsLongerThanShortBreak() {
+    let settings = makeSettings()
+    #expect(settings.longBreakMinutes > settings.shortBreakMinutes)
+  }
 
-    @Test func defaultLongBreakAfterSessionsIsFour() {
-        #expect(makeSettings().longBreakAfterSessions == 4)
-    }
+  @Test func defaultLongBreakAfterSessionsIsFour() {
+    #expect(makeSettings().longBreakAfterSessions == 4)
+  }
 
-    // MARK: - Boolean defaults
+  // MARK: - Boolean defaults
 
-    @Test func defaultSoundEnabledIsTrue() {
-        #expect(makeSettings().soundEnabled == true)
-    }
+  @Test func defaultSoundEnabledIsTrue() {
+    #expect(makeSettings().soundEnabled == true)
+  }
 
-    @Test func defaultNotificationsEnabledIsTrue() {
-        #expect(makeSettings().notificationsEnabled == true)
-    }
+  @Test func defaultNotificationsEnabledIsTrue() {
+    #expect(makeSettings().notificationsEnabled == true)
+  }
 
-    @Test func defaultAutoStartNextPhaseIsFalse() {
-        #expect(makeSettings().autoStartNextPhase == false)
-    }
+  @Test func defaultAutoStartNextPhaseIsFalse() {
+    #expect(makeSettings().autoStartNextPhase == false)
+  }
 
-    // MARK: - Persistence
+  // MARK: - Persistence
 
-    @Test func settingPersistsAcrossInstances() {
-        let suite = UUID().uuidString
-        let defaults = UserDefaults(suiteName: suite)!
-        let writer = AppSettings(defaults: defaults)
-        writer.focusMinutes = 42
-        writer.soundEnabled = false
-        writer.autoStartNextPhase = true
+  @Test func settingPersistsAcrossInstances() {
+    let suite = UUID().uuidString
+    let defaults = UserDefaults(suiteName: suite)!
+    let writer = AppSettings(defaults: defaults)
+    writer.focusMinutes = 42
+    writer.soundEnabled = false
+    writer.autoStartNextPhase = true
 
-        let reader = AppSettings(defaults: defaults)
-        #expect(reader.focusMinutes == 42)
-        #expect(reader.soundEnabled == false)
-        #expect(reader.autoStartNextPhase == true)
-    }
+    let reader = AppSettings(defaults: defaults)
+    #expect(reader.focusMinutes == 42)
+    #expect(reader.soundEnabled == false)
+    #expect(reader.autoStartNextPhase == true)
+  }
 }

--- a/app/TaskmatoTests/SessionEngineCompletionTests.swift
+++ b/app/TaskmatoTests/SessionEngineCompletionTests.swift
@@ -1,0 +1,159 @@
+//
+//  SessionEngineCompletionTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+struct SessionEngineCompletionTests {
+
+  // MARK: - Phase completion
+
+  @Test func phaseCompletionTransitionsToIdle() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()  // triggers refreshTimeRemaining, which detects completion
+    #expect(engine.state == .idle)
+  }
+
+  @Test func phaseCompletionResetsTimeRemaining() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+    #expect(engine.timeRemaining == 60)
+  }
+
+  @Test func phaseCompletionFiresCallback() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    var firedPhase: SessionPhase?
+    engine.onPhaseEnded = { phase, _, _, _ in firedPhase = phase }
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+    #expect(firedPhase == .focus)
+  }
+
+  @Test func phaseCompletionCallbackReceivesCorrectTimes() {
+    let startTime = Date(timeIntervalSinceReferenceDate: 1000)
+    var currentTime = startTime
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    var capturedStart: Date?
+    var capturedEnd: Date?
+    engine.onPhaseEnded = { _, start, end, _ in
+      capturedStart = start
+      capturedEnd = end
+    }
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+    #expect(capturedStart == startTime)
+    #expect(capturedEnd == startTime.addingTimeInterval(60))
+  }
+
+  @Test func naturalCompletionMarksWasCompletedTrue() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    var wasCompleted: Bool?
+    engine.onPhaseEnded = { _, _, _, completed in wasCompleted = completed }
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+    #expect(wasCompleted == true)
+  }
+
+  @Test func manualStopFiresCallbackWithWasCompletedFalse() {
+    let engine = SessionEngine()
+    var wasCompleted: Bool?
+    engine.onPhaseEnded = { _, _, _, completed in wasCompleted = completed }
+    engine.start()
+    engine.stop()
+    #expect(wasCompleted == false)
+  }
+
+  @Test func manualStopFromPausedFiresCallback() {
+    let engine = SessionEngine()
+    var fired = false
+    engine.onPhaseEnded = { _, _, _, _ in fired = true }
+    engine.start()
+    engine.pause()
+    engine.stop()
+    #expect(fired)
+  }
+
+  @Test func stopFromIdleDoesNotFireCallback() {
+    let engine = SessionEngine()
+    var fired = false
+    engine.onPhaseEnded = { _, _, _, _ in fired = true }
+    engine.stop()
+    #expect(!fired)
+  }
+
+  @Test func skipDoesNotFireCallback() {
+    let engine = SessionEngine()
+    var fired = false
+    engine.onPhaseEnded = { _, _, _, _ in fired = true }
+    engine.start()
+    engine.skip()
+    #expect(!fired)
+  }
+
+  @Test func skipUsesProvidedBreakPhase() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.skip(nextBreak: .longBreak)
+    guard case .running(let phase, _, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
+    }
+    #expect(phase == .longBreak)
+  }
+
+  // MARK: - enqueuePhase
+
+  @Test func enqueuePhaseSetQueuedPhaseWhenIdle() {
+    let engine = SessionEngine()
+    engine.enqueuePhase(.shortBreak)
+    #expect(engine.queuedPhase == .shortBreak)
+    #expect(engine.state == .idle)
+  }
+
+  @Test func enqueuePhaseIsNoOpWhenRunning() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.enqueuePhase(.shortBreak)
+    #expect(engine.queuedPhase == nil)
+  }
+
+  @Test func enqueuePhaseIsNoOpWhenPaused() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.pause()
+    engine.enqueuePhase(.shortBreak)
+    #expect(engine.queuedPhase == nil)
+  }
+
+  @Test func startClearsQueuedPhase() {
+    let engine = SessionEngine()
+    engine.enqueuePhase(.shortBreak)
+    #expect(engine.queuedPhase != nil)
+    engine.start(phase: engine.queuedPhase ?? .focus)
+    #expect(engine.queuedPhase == nil)
+  }
+
+  @Test func stopClearsQueuedPhase() {
+    let engine = SessionEngine()
+    engine.enqueuePhase(.shortBreak)
+    #expect(engine.queuedPhase != nil)
+    engine.start()
+    engine.stop()
+    #expect(engine.queuedPhase == nil)
+  }
+}

--- a/app/TaskmatoTests/SessionEngineTests.swift
+++ b/app/TaskmatoTests/SessionEngineTests.swift
@@ -3,359 +3,228 @@
 //  TaskmatoTests
 //
 
-import Testing
-@testable import Taskmato
 import Foundation
+import Testing
+
+@testable import Taskmato
 
 struct SessionEngineTests {
 
-    @Test func startTransitionsToFocus() {
-        let engine = SessionEngine()
-        engine.start()
-        guard case .running(let phase, _, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(phase == .focus)
+  @Test func startTransitionsToFocus() {
+    let engine = SessionEngine()
+    engine.start()
+    guard case .running(let phase, _, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
+    #expect(phase == .focus)
+  }
 
-    @Test func pauseCapturesRemainingTime() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(10)
-        engine.pause()
-        guard case .paused(_, let remaining) = engine.state else {
-            Issue.record("Expected paused state"); return
-        }
-        #expect(remaining == 50)
+  @Test func pauseCapturesRemainingTime() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(10)
+    engine.pause()
+    guard case .paused(_, let remaining) = engine.state else {
+      Issue.record("Expected paused state")
+      return
     }
+    #expect(remaining == 50)
+  }
 
-    @Test func resumeRestoresFocusPhase() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.pause()
-        engine.resume()
-        guard case .running(let phase, _, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(phase == .focus)
+  @Test func resumeRestoresFocusPhase() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.pause()
+    engine.resume()
+    guard case .running(let phase, _, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
+    #expect(phase == .focus)
+  }
 
-    @Test func resumePreservesRemainingTime() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(10)
-        engine.pause()
-        engine.resume()
-        #expect(engine.timeRemaining == 50)
+  @Test func resumePreservesRemainingTime() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(10)
+    engine.pause()
+    engine.resume()
+    #expect(engine.timeRemaining == 50)
+  }
+
+  @Test func stopResetsToIdle() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.stop()
+    #expect(engine.state == .idle)
+  }
+
+  @Test func skipFocusStartsShortBreak() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.skip()
+    guard case .running(let phase, _, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
+    #expect(phase == .shortBreak)
+  }
 
-    @Test func stopResetsToIdle() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.stop()
-        #expect(engine.state == .idle)
+  @Test func skipBreakStartsFocus() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.skip()
+    engine.skip()
+    guard case .running(let phase, _, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
+    #expect(phase == .focus)
+  }
 
-    @Test func skipFocusStartsShortBreak() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.skip()
-        guard case .running(let phase, _, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(phase == .shortBreak)
+  @Test func timeRemainingDecreasesWithElapsedTime() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(20)
+    engine.pause()  // triggers timestamp refresh before freezing
+    #expect(engine.timeRemaining == 40)
+  }
+
+  @Test func idleTimeRemainingIsFocusDuration() {
+    let engine = SessionEngine(focusDuration: 1500)
+    #expect(engine.timeRemaining == 1500)
+  }
+
+  @Test func stopResetsTimeRemaining() {
+    let engine = SessionEngine(focusDuration: 1500)
+    engine.start()
+    engine.stop()
+    #expect(engine.timeRemaining == 1500)
+  }
+
+  @Test func skipFromPausedMovesToPausedNextPhase() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.pause()
+    engine.skip()
+    guard case .paused(let phase, _) = engine.state else {
+      Issue.record("Expected paused state")
+      return
     }
+    #expect(phase == .shortBreak)
+  }
 
-    @Test func skipBreakStartsFocus() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.skip()
-        engine.skip()
-        guard case .running(let phase, _, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(phase == .focus)
+  @Test func skipFromPausedPreservesFullDuration() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, shortBreakDuration: 300, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(20)  // 40s remaining in focus
+    engine.pause()
+    engine.skip()  // skip to short break — should start at full 300s, not leftover 40s
+    guard case .paused(_, let remaining) = engine.state else {
+      Issue.record("Expected paused state")
+      return
     }
+    #expect(remaining == 300)
+  }
 
-    @Test func timeRemainingDecreasesWithElapsedTime() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(20)
-        engine.pause() // triggers timestamp refresh before freezing
-        #expect(engine.timeRemaining == 40)
+  @Test func isRunningWhileActive() {
+    let engine = SessionEngine()
+    engine.start()
+    #expect(engine.isRunning == true)
+  }
+
+  @Test func isRunningFalseWhenPaused() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.pause()
+    #expect(engine.isRunning == false)
+  }
+
+  @Test func isRunningFalseWhenIdle() {
+    let engine = SessionEngine()
+    #expect(engine.isRunning == false)
+  }
+
+  // MARK: - Guard / no-op behaviours
+
+  @Test func startIsNoOpWhenRunning() {
+    let engine = SessionEngine()
+    engine.start()
+    guard case .running(_, let startedAt, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
-
-    @Test func idleTimeRemainingIsFocusDuration() {
-        let engine = SessionEngine(focusDuration: 1500)
-        #expect(engine.timeRemaining == 1500)
+    engine.start()  // should be ignored
+    guard case .running(_, let startedAtAfter, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
+    #expect(startedAt == startedAtAfter)
+  }
 
-    @Test func stopResetsTimeRemaining() {
-        let engine = SessionEngine(focusDuration: 1500)
-        engine.start()
-        engine.stop()
-        #expect(engine.timeRemaining == 1500)
+  @Test func pauseIsNoOpWhenIdle() {
+    let engine = SessionEngine()
+    engine.pause()
+    #expect(engine.state == .idle)
+  }
+
+  @Test func resumeIsNoOpWhenRunning() {
+    let engine = SessionEngine()
+    engine.start()
+    guard case .running(_, let startedAt, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
-
-    @Test func skipFromPausedMovesToPausedNextPhase() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.pause()
-        engine.skip()
-        guard case .paused(let phase, _) = engine.state else {
-            Issue.record("Expected paused state"); return
-        }
-        #expect(phase == .shortBreak)
+    engine.resume()  // should be ignored
+    guard case .running(_, let startedAtAfter, _) = engine.state else {
+      Issue.record("Expected running state")
+      return
     }
+    #expect(startedAt == startedAtAfter)
+  }
 
-    @Test func skipFromPausedPreservesFullDuration() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, shortBreakDuration: 300, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(20) // 40s remaining in focus
-        engine.pause()
-        engine.skip() // skip to short break — should start at full 300s, not leftover 40s
-        guard case .paused(_, let remaining) = engine.state else {
-            Issue.record("Expected paused state"); return
-        }
-        #expect(remaining == 300)
+  @Test func startIsNoOpWhenPaused() {
+    let engine = SessionEngine()
+    engine.start()
+    engine.pause()
+    engine.start()  // should be ignored
+    guard case .paused = engine.state else {
+      Issue.record("Expected paused state")
+      return
     }
+  }
 
-    @Test func isRunningWhileActive() {
-        let engine = SessionEngine()
-        engine.start()
-        #expect(engine.isRunning == true)
+  @Test func pauseIsNoOpWhenPaused() {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(10)
+    engine.pause()
+    currentTime = currentTime.addingTimeInterval(10)  // time passes while paused
+    engine.pause()  // should be ignored — remaining should not change
+    guard case .paused(_, let remaining) = engine.state else {
+      Issue.record("Expected paused state")
+      return
     }
+    #expect(remaining == 50)
+  }
 
-    @Test func isRunningFalseWhenPaused() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.pause()
-        #expect(engine.isRunning == false)
-    }
+  @Test func resumeIsNoOpWhenIdle() {
+    let engine = SessionEngine()
+    engine.resume()
+    #expect(engine.state == .idle)
+  }
 
-    @Test func isRunningFalseWhenIdle() {
-        let engine = SessionEngine()
-        #expect(engine.isRunning == false)
-    }
+  @Test func skipFromIdleSetsQueuedFocus() {
+    let engine = SessionEngine()
+    engine.skip()
+    #expect(engine.state == .idle)
+    #expect(engine.queuedPhase == .focus)
+  }
 
-    // MARK: - Guard / no-op behaviours
-
-    @Test func startIsNoOpWhenRunning() {
-        let engine = SessionEngine()
-        engine.start()
-        guard case .running(_, let startedAt, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        engine.start() // should be ignored
-        guard case .running(_, let startedAtAfter, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(startedAt == startedAtAfter)
-    }
-
-    @Test func pauseIsNoOpWhenIdle() {
-        let engine = SessionEngine()
-        engine.pause()
-        #expect(engine.state == .idle)
-    }
-
-    @Test func resumeIsNoOpWhenRunning() {
-        let engine = SessionEngine()
-        engine.start()
-        guard case .running(_, let startedAt, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        engine.resume() // should be ignored
-        guard case .running(_, let startedAtAfter, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(startedAt == startedAtAfter)
-    }
-
-    @Test func startIsNoOpWhenPaused() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.pause()
-        engine.start() // should be ignored
-        guard case .paused = engine.state else {
-            Issue.record("Expected paused state"); return
-        }
-    }
-
-    @Test func pauseIsNoOpWhenPaused() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(10)
-        engine.pause()
-        currentTime = currentTime.addingTimeInterval(10) // time passes while paused
-        engine.pause() // should be ignored — remaining should not change
-        guard case .paused(_, let remaining) = engine.state else {
-            Issue.record("Expected paused state"); return
-        }
-        #expect(remaining == 50)
-    }
-
-    @Test func resumeIsNoOpWhenIdle() {
-        let engine = SessionEngine()
-        engine.resume()
-        #expect(engine.state == .idle)
-    }
-
-    @Test func skipFromIdleSetsQueuedFocus() {
-        let engine = SessionEngine()
-        engine.skip()
-        #expect(engine.state == .idle)
-        #expect(engine.queuedPhase == .focus)
-    }
-
-    // MARK: - Phase completion
-
-    @Test func phaseCompletionTransitionsToIdle() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(60)
-        engine.pause() // triggers refreshTimeRemaining, which detects completion
-        #expect(engine.state == .idle)
-    }
-
-    @Test func phaseCompletionResetsTimeRemaining() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(60)
-        engine.pause()
-        #expect(engine.timeRemaining == 60)
-    }
-
-    @Test func phaseCompletionFiresCallback() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        var firedPhase: SessionPhase?
-        engine.onPhaseEnded = { phase, _, _, _ in firedPhase = phase }
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(60)
-        engine.pause()
-        #expect(firedPhase == .focus)
-    }
-
-    @Test func phaseCompletionCallbackReceivesCorrectTimes() {
-        let startTime = Date(timeIntervalSinceReferenceDate: 1000)
-        var currentTime = startTime
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        var capturedStart: Date?
-        var capturedEnd: Date?
-        engine.onPhaseEnded = { _, start, end, _ in
-            capturedStart = start
-            capturedEnd = end
-        }
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(60)
-        engine.pause()
-        #expect(capturedStart == startTime)
-        #expect(capturedEnd == startTime.addingTimeInterval(60))
-    }
-
-    @Test func naturalCompletionMarksWasCompletedTrue() {
-        var currentTime = Date(timeIntervalSinceReferenceDate: 0)
-        let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-        var wasCompleted: Bool?
-        engine.onPhaseEnded = { _, _, _, completed in wasCompleted = completed }
-        engine.start()
-        currentTime = currentTime.addingTimeInterval(60)
-        engine.pause()
-        #expect(wasCompleted == true)
-    }
-
-    @Test func manualStopFiresCallbackWithWasCompletedFalse() {
-        let engine = SessionEngine()
-        var wasCompleted: Bool?
-        engine.onPhaseEnded = { _, _, _, completed in wasCompleted = completed }
-        engine.start()
-        engine.stop()
-        #expect(wasCompleted == false)
-    }
-
-    @Test func manualStopFromPausedFiresCallback() {
-        let engine = SessionEngine()
-        var fired = false
-        engine.onPhaseEnded = { _, _, _, _ in fired = true }
-        engine.start()
-        engine.pause()
-        engine.stop()
-        #expect(fired)
-    }
-
-    @Test func stopFromIdleDoesNotFireCallback() {
-        let engine = SessionEngine()
-        var fired = false
-        engine.onPhaseEnded = { _, _, _, _ in fired = true }
-        engine.stop()
-        #expect(!fired)
-    }
-
-    @Test func skipDoesNotFireCallback() {
-        let engine = SessionEngine()
-        var fired = false
-        engine.onPhaseEnded = { _, _, _, _ in fired = true }
-        engine.start()
-        engine.skip()
-        #expect(!fired)
-    }
-
-    @Test func skipUsesProvidedBreakPhase() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.skip(nextBreak: .longBreak)
-        guard case .running(let phase, _, _) = engine.state else {
-            Issue.record("Expected running state"); return
-        }
-        #expect(phase == .longBreak)
-    }
-
-    // MARK: - enqueuePhase
-
-    @Test func enqueuePhaseSetQueuedPhaseWhenIdle() {
-        let engine = SessionEngine()
-        engine.enqueuePhase(.shortBreak)
-        #expect(engine.queuedPhase == .shortBreak)
-        #expect(engine.state == .idle)
-    }
-
-    @Test func enqueuePhaseIsNoOpWhenRunning() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.enqueuePhase(.shortBreak)
-        #expect(engine.queuedPhase == nil)
-    }
-
-    @Test func enqueuePhaseIsNoOpWhenPaused() {
-        let engine = SessionEngine()
-        engine.start()
-        engine.pause()
-        engine.enqueuePhase(.shortBreak)
-        #expect(engine.queuedPhase == nil)
-    }
-
-    @Test func startClearsQueuedPhase() {
-        let engine = SessionEngine()
-        engine.enqueuePhase(.shortBreak)
-        #expect(engine.queuedPhase != nil)
-        engine.start(phase: engine.queuedPhase ?? .focus)
-        #expect(engine.queuedPhase == nil)
-    }
-
-    @Test func stopClearsQueuedPhase() {
-        let engine = SessionEngine()
-        engine.enqueuePhase(.shortBreak)
-        #expect(engine.queuedPhase != nil)
-        engine.start()
-        engine.stop()
-        #expect(engine.queuedPhase == nil)
-    }
 }

--- a/app/TaskmatoTests/SessionStoreTests.swift
+++ b/app/TaskmatoTests/SessionStoreTests.swift
@@ -3,162 +3,167 @@
 //  TaskmatoTests
 //
 
-import Testing
-@testable import Taskmato
 import Foundation
+import Testing
+
+@testable import Taskmato
 
 struct SessionStoreTests {
 
-    /// Returns a store backed by a unique temporary file that won't affect production data.
-    private func makeStore() -> SessionStore {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + ".json")
-        return SessionStore(fileURL: url)
+  /// Returns a store backed by a unique temporary file that won't affect production data.
+  private func makeStore() -> SessionStore {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    return SessionStore(fileURL: url)
+  }
+
+  private func makeSession(phase: SessionPhase = .focus, wasCompleted: Bool = true) -> Session {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    return Session(
+      id: UUID(), phase: phase, startedAt: start, endedAt: start.addingTimeInterval(1500),
+      wasCompleted: wasCompleted)
+  }
+
+  @Test func appendIncreasesCount() {
+    let store = makeStore()
+    store.append(makeSession())
+    #expect(store.sessions.count == 1)
+  }
+
+  @Test func appendedSessionIsRetrievable() {
+    let store = makeStore()
+    let session = makeSession(phase: .shortBreak)
+    store.append(session)
+    #expect(store.sessions.first?.id == session.id)
+    #expect(store.sessions.first?.phase == .shortBreak)
+  }
+
+  @Test func multipleSessionsAreOrderedOldestFirst() {
+    let store = makeStore()
+    let first = makeSession(phase: .focus)
+    let second = makeSession(phase: .shortBreak)
+    store.append(first)
+    store.append(second)
+    #expect(store.sessions.first?.id == first.id)
+    #expect(store.sessions.last?.id == second.id)
+  }
+
+  @Test func sessionsRoundTripThroughDisk() throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+
+    let session = makeSession(phase: .focus)
+
+    let writer = SessionStore(fileURL: url)
+    writer.append(session)
+
+    let reader = SessionStore(fileURL: url)
+    #expect(reader.sessions.count == 1)
+    #expect(reader.sessions.first?.id == session.id)
+    #expect(reader.sessions.first?.phase == .focus)
+  }
+
+  @Test func sessionDurationIsEndMinusStart() {
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let session = Session(
+      id: UUID(), phase: .focus, startedAt: start, endedAt: start.addingTimeInterval(1500),
+      wasCompleted: true)
+    #expect(session.duration == 1500)
+  }
+
+  // MARK: - nextBreakPhase
+
+  @Test func nextBreakPhaseIsShortBreakWithNoHistory() {
+    let store = makeStore()
+    #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
+  }
+
+  @Test func nextBreakPhaseIsShortBreakAfterFirstFocus() {
+    let store = makeStore()
+    store.append(makeSession(phase: .focus))
+    #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
+  }
+
+  @Test func nextBreakPhaseIsLongBreakAfterNFocusSessions() {
+    let store = makeStore()
+    for _ in 0..<4 {
+      store.append(makeSession(phase: .focus))
     }
+    #expect(store.nextBreakPhase(longBreakAfter: 4) == .longBreak)
+  }
 
-    private func makeSession(phase: SessionPhase = .focus, wasCompleted: Bool = true) -> Session {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        return Session(id: UUID(), phase: phase, startedAt: start, endedAt: start.addingTimeInterval(1500), wasCompleted: wasCompleted)
+  @Test func nextBreakPhaseResetsAfterCompletedLongBreak() {
+    let store = makeStore()
+    for _ in 0..<4 {
+      store.append(makeSession(phase: .focus))
     }
+    store.append(makeSession(phase: .longBreak, wasCompleted: true))
+    store.append(makeSession(phase: .focus))
+    #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
+  }
 
-    @Test func appendIncreasesCount() {
-        let store = makeStore()
-        store.append(makeSession())
-        #expect(store.sessions.count == 1)
+  @Test func nextBreakPhaseExcludesPartialFocusSessions() {
+    let store = makeStore()
+    for _ in 0..<3 {
+      store.append(makeSession(phase: .focus, wasCompleted: true))
     }
+    store.append(makeSession(phase: .focus, wasCompleted: false))
+    #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
+  }
 
-    @Test func appendedSessionIsRetrievable() {
-        let store = makeStore()
-        let session = makeSession(phase: .shortBreak)
-        store.append(session)
-        #expect(store.sessions.first?.id == session.id)
-        #expect(store.sessions.first?.phase == .shortBreak)
+  @Test func nextBreakPhaseDoesNotResetAfterIncompleteLongBreak() {
+    let store = makeStore()
+    for _ in 0..<4 {
+      store.append(makeSession(phase: .focus))
     }
+    store.append(makeSession(phase: .longBreak, wasCompleted: false))
+    #expect(store.nextBreakPhase(longBreakAfter: 4) == .longBreak)
+  }
 
-    @Test func multipleSessionsAreOrderedOldestFirst() {
-        let store = makeStore()
-        let first = makeSession(phase: .focus)
-        let second = makeSession(phase: .shortBreak)
-        store.append(first)
-        store.append(second)
-        #expect(store.sessions.first?.id == first.id)
-        #expect(store.sessions.last?.id == second.id)
+  @Test func nextBreakPhaseRespectsCustomInterval() {
+    let store = makeStore()
+    for _ in 0..<2 {
+      store.append(makeSession(phase: .focus))
     }
+    #expect(store.nextBreakPhase(longBreakAfter: 2) == .longBreak)
+  }
 
-    @Test func sessionsRoundTripThroughDisk() throws {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + ".json")
+  // MARK: - nextPhaseToStart
 
-        let session = makeSession(phase: .focus)
+  @Test func nextPhaseToStartWithNoHistoryReturnsFocus() {
+    let store = makeStore()
+    #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
+  }
 
-        let writer = SessionStore(fileURL: url)
-        writer.append(session)
+  @Test func nextPhaseToStartAfterCompletedFocusReturnsShortBreak() {
+    let store = makeStore()
+    store.append(makeSession(phase: .focus, wasCompleted: true))
+    #expect(store.nextPhaseToStart(longBreakAfter: 4) == .shortBreak)
+  }
 
-        let reader = SessionStore(fileURL: url)
-        #expect(reader.sessions.count == 1)
-        #expect(reader.sessions.first?.id == session.id)
-        #expect(reader.sessions.first?.phase == .focus)
+  @Test func nextPhaseToStartAfterCompletedFocusReturnsLongBreak() {
+    let store = makeStore()
+    for _ in 0..<4 {
+      store.append(makeSession(phase: .focus, wasCompleted: true))
     }
+    #expect(store.nextPhaseToStart(longBreakAfter: 4) == .longBreak)
+  }
 
-    @Test func sessionDurationIsEndMinusStart() {
-        let start = Date(timeIntervalSinceReferenceDate: 0)
-        let session = Session(id: UUID(), phase: .focus, startedAt: start, endedAt: start.addingTimeInterval(1500), wasCompleted: true)
-        #expect(session.duration == 1500)
-    }
+  @Test func nextPhaseToStartAfterCompletedShortBreakReturnsFocus() {
+    let store = makeStore()
+    store.append(makeSession(phase: .shortBreak, wasCompleted: true))
+    #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
+  }
 
-    // MARK: - nextBreakPhase
+  @Test func nextPhaseToStartAfterCompletedLongBreakReturnsFocus() {
+    let store = makeStore()
+    store.append(makeSession(phase: .longBreak, wasCompleted: true))
+    #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
+  }
 
-    @Test func nextBreakPhaseIsShortBreakWithNoHistory() {
-        let store = makeStore()
-        #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
-    }
-
-    @Test func nextBreakPhaseIsShortBreakAfterFirstFocus() {
-        let store = makeStore()
-        store.append(makeSession(phase: .focus))
-        #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
-    }
-
-    @Test func nextBreakPhaseIsLongBreakAfterNFocusSessions() {
-        let store = makeStore()
-        for _ in 0..<4 {
-            store.append(makeSession(phase: .focus))
-        }
-        #expect(store.nextBreakPhase(longBreakAfter: 4) == .longBreak)
-    }
-
-    @Test func nextBreakPhaseResetsAfterCompletedLongBreak() {
-        let store = makeStore()
-        for _ in 0..<4 {
-            store.append(makeSession(phase: .focus))
-        }
-        store.append(makeSession(phase: .longBreak, wasCompleted: true))
-        store.append(makeSession(phase: .focus))
-        #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
-    }
-
-    @Test func nextBreakPhaseExcludesPartialFocusSessions() {
-        let store = makeStore()
-        for _ in 0..<3 {
-            store.append(makeSession(phase: .focus, wasCompleted: true))
-        }
-        store.append(makeSession(phase: .focus, wasCompleted: false))
-        #expect(store.nextBreakPhase(longBreakAfter: 4) == .shortBreak)
-    }
-
-    @Test func nextBreakPhaseDoesNotResetAfterIncompleteLongBreak() {
-        let store = makeStore()
-        for _ in 0..<4 {
-            store.append(makeSession(phase: .focus))
-        }
-        store.append(makeSession(phase: .longBreak, wasCompleted: false))
-        #expect(store.nextBreakPhase(longBreakAfter: 4) == .longBreak)
-    }
-
-    @Test func nextBreakPhaseRespectsCustomInterval() {
-        let store = makeStore()
-        for _ in 0..<2 {
-            store.append(makeSession(phase: .focus))
-        }
-        #expect(store.nextBreakPhase(longBreakAfter: 2) == .longBreak)
-    }
-
-    // MARK: - nextPhaseToStart
-
-    @Test func nextPhaseToStartWithNoHistoryReturnsFocus() {
-        let store = makeStore()
-        #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
-    }
-
-    @Test func nextPhaseToStartAfterCompletedFocusReturnsShortBreak() {
-        let store = makeStore()
-        store.append(makeSession(phase: .focus, wasCompleted: true))
-        #expect(store.nextPhaseToStart(longBreakAfter: 4) == .shortBreak)
-    }
-
-    @Test func nextPhaseToStartAfterCompletedFocusReturnsLongBreak() {
-        let store = makeStore()
-        for _ in 0..<4 {
-            store.append(makeSession(phase: .focus, wasCompleted: true))
-        }
-        #expect(store.nextPhaseToStart(longBreakAfter: 4) == .longBreak)
-    }
-
-    @Test func nextPhaseToStartAfterCompletedShortBreakReturnsFocus() {
-        let store = makeStore()
-        store.append(makeSession(phase: .shortBreak, wasCompleted: true))
-        #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
-    }
-
-    @Test func nextPhaseToStartAfterCompletedLongBreakReturnsFocus() {
-        let store = makeStore()
-        store.append(makeSession(phase: .longBreak, wasCompleted: true))
-        #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
-    }
-
-    @Test func nextPhaseToStartAfterPartialFocusReturnsFocus() {
-        let store = makeStore()
-        store.append(makeSession(phase: .focus, wasCompleted: false))
-        #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
-    }
+  @Test func nextPhaseToStartAfterPartialFocusReturnsFocus() {
+    let store = makeStore()
+    store.append(makeSession(phase: .focus, wasCompleted: false))
+    #expect(store.nextPhaseToStart(longBreakAfter: 4) == .focus)
+  }
 }

--- a/app/TaskmatoTests/TaskmatoTests.swift
+++ b/app/TaskmatoTests/TaskmatoTests.swift
@@ -6,14 +6,15 @@
 //
 
 import Testing
+
 @testable import Taskmato
 
 struct TaskmatoTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
-        // Swift Testing Documentation
-        // https://developer.apple.com/documentation/testing
-    }
+  @Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    // Swift Testing Documentation
+    // https://developer.apple.com/documentation/testing
+  }
 
 }

--- a/app/TaskmatoUITests/TaskmatoUITests.swift
+++ b/app/TaskmatoUITests/TaskmatoUITests.swift
@@ -9,35 +9,35 @@ import XCTest
 
 final class TaskmatoUITests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+  override func setUpWithError() throws {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
 
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    continueAfterFailure = false
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+  }
+
+  override func tearDownWithError() throws {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+  }
+
+  @MainActor
+  func testExample() throws {
+    // UI tests must launch the application that they test.
+    let app = XCUIApplication()
+    app.launch()
+
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    // XCUIAutomation Documentation
+    // https://developer.apple.com/documentation/xcuiautomation
+  }
+
+  @MainActor
+  func testLaunchPerformance() throws {
+    // This measures how long it takes to launch your application.
+    measure(metrics: [XCTApplicationLaunchMetric()]) {
+      XCUIApplication().launch()
     }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // XCUIAutomation Documentation
-        // https://developer.apple.com/documentation/xcuiautomation
-    }
-
-    @MainActor
-    func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
-        }
-    }
+  }
 }

--- a/app/TaskmatoUITests/TaskmatoUITestsLaunchTests.swift
+++ b/app/TaskmatoUITests/TaskmatoUITestsLaunchTests.swift
@@ -9,27 +9,27 @@ import XCTest
 
 final class TaskmatoUITestsLaunchTests: XCTestCase {
 
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        true
-    }
+  override static var runsForEachTargetApplicationUIConfiguration: Bool {
+    true
+  }
 
-    override func setUpWithError() throws {
-        continueAfterFailure = false
-    }
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+  }
 
-    @MainActor
-    func testLaunch() throws {
-        let app = XCUIApplication()
-        app.launch()
+  @MainActor
+  func testLaunch() throws {
+    let app = XCUIApplication()
+    app.launch()
 
-        // Insert steps here to perform after app launch but before taking a screenshot,
-        // such as logging into a test account or navigating somewhere in the app
-        // XCUIAutomation Documentation
-        // https://developer.apple.com/documentation/xcuiautomation
+    // Insert steps here to perform after app launch but before taking a screenshot,
+    // such as logging into a test account or navigating somewhere in the app
+    // XCUIAutomation Documentation
+    // https://developer.apple.com/documentation/xcuiautomation
 
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "Launch Screen"
-        attachment.lifetime = .keepAlways
-        add(attachment)
-    }
+    let attachment = XCTAttachment(screenshot: app.screenshot())
+    attachment.name = "Launch Screen"
+    attachment.lifetime = .keepAlways
+    add(attachment)
+  }
 }


### PR DESCRIPTION
## Summary

- Configures VS Code with SweetPad for building, launching, and debugging the Xcode project without leaving the editor — CodeLLDB attaches after a background build task
- Adds a Makefile with `build`, `test`, `lint`, `format`, `format-check`, and `clean` targets (all using `xcrun` so no extra installs needed locally)
- Introduces `.swiftlint.yml` with a curated set of opt-in rules and applies `xcrun swift-format` across all source targets (2-space indentation)
- Adds three CI workflows: **Format and lint** (swift-format + SwiftLint --strict), **Test** (xcodebuild + lcov conversion), and **Report Coverage** (ReportGenerator → sticky PR comment via `marocchino/sticky-pull-request-comment`)

## Notes

- `sorted_imports` is excluded from SwiftLint because swift-format and SwiftLint use different sort orderings (case-sensitive vs case-insensitive) and conflict on mixed-framework files
- `report-coverage.yaml` uses `danielpalme/ReportGenerator-GitHub-Action` and `marocchino/sticky-pull-request-comment` — both need to be allowed in repo Actions settings

## Test plan

- [ ] Install recommended VS Code extensions, open the project, and verify Build and Launch works via the Run & Debug panel
- [ ] `make lint` and `make format-check` both exit 0 locally
- [ ] `make test` runs the full suite
- [ ] Open a PR and confirm the coverage comment appears and updates on subsequent pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)