### PR TITLE
Built-in task provider, session stats, and popover stats link (P0/P1/P6)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,17 +8,26 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 
 - [x] Define `TaskRef`, `TaskPriority`, `TaskList`, `TaskItem` value types ([#281](https://github.com/richwklein/taskmato/pull/281))
 - [x] Define `TaskProvider` (read) and `MutableTaskProvider` (write/close-back) protocols ([#281](https://github.com/richwklein/taskmato/pull/281))
+- [x] Add `completedTasks() async throws -> [TaskItem]` to `MutableTaskProvider`; default implementation returns `[]`
 - [x] Implement `TaskRegistry` supporting multiple concurrent providers ([#281](https://github.com/richwklein/taskmato/pull/281))
 - [x] Implement `TaskSelectionStore` (active task, last-used per provider) ([#281](https://github.com/richwklein/taskmato/pull/281))
 - [x] Migrate `Session.reminderID` → `Session.taskRef` ([#281](https://github.com/richwklein/taskmato/pull/281))
 - [x] Update `TaskmatoApp.onPhaseEnded` to stamp `taskRef` onto persisted sessions ([#281](https://github.com/richwklein/taskmato/pull/281))
+- [x] Session cycle state (`completedFocusCount`, `nextBreakPhase`) moved into `SessionEngine`; `SessionStore` is now stats-only; app always starts a fresh focus phase on launch
 
 ## Built-in task provider (P1)
 
-- [ ] `LocalTask` model (title, notes, priority, due date, list) persisted to JSON in App Support ([#279](https://github.com/richwklein/taskmato/issues/279))
-- [ ] `LocalProvider` conforming to `TaskProvider` + `MutableTaskProvider`; `entitlement = .free`; not the default provider ([#279](https://github.com/richwklein/taskmato/issues/279))
-- [ ] Inline task creation from the picker ("+" button: title, priority, optional due date, optional list) ([#279](https://github.com/richwklein/taskmato/issues/279))
-- [ ] User-managed lists (create, rename, delete) ([#279](https://github.com/richwklein/taskmato/issues/279))
+- [x] `LocalTask` model (title, notes, priority, due date, list) persisted to JSON in App Support ([#279](https://github.com/richwklein/taskmato/issues/279))
+- [x] `LocalProvider` conforming to `TaskProvider` + `MutableTaskProvider`; `entitlement = .free`; not the default provider ([#279](https://github.com/richwklein/taskmato/issues/279))
+- [x] Inline task creation from the picker ("+" button: title, priority, optional due date, list) ([#279](https://github.com/richwklein/taskmato/issues/279))
+- [x] User-managed lists ([#279](https://github.com/richwklein/taskmato/issues/279)):
+  - [x] Create list
+  - [x] Rename list (inline TextField in settings, committed on submit/blur)
+  - [x] Delete list (moves tasks to fallback; auto-creates "Default" if last list removed; trash button disabled when only one list)
+- [x] Implement `completedTasks() async throws -> [TaskItem]` on `LocalProvider` (returns soft-deleted tasks, sorted by completion date descending)
+- [x] `LocalProvider` unit tests (CRUD, default list creation, orphan reassignment, error paths)
+
+> All P1 items complete. [#279](https://github.com/richwklein/taskmato/issues/279) GH issue still open — needs closing.
 
 ## Apple Reminders provider (P2)
 
@@ -29,25 +38,30 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 
 ## Picker UI + close-back affordance (P3)
 
-- [ ] Task picker view in main window Tasks tab (search across providers, grouped) ([#257](https://github.com/richwklein/taskmato/issues/257))
+- [x] Main window with Timer, Tasks, and Stats tabs (TabView navigation skeleton) ([#294](https://github.com/richwklein/taskmato/issues/294))
+- [x] Task picker view in main window Tasks tab (search across providers, grouped by list) ([#257](https://github.com/richwklein/taskmato/issues/257) partial — provider section headers and priority badges remain)
+- [ ] Two-level picker grouping when multiple providers active: provider section header → list → tasks; "+" add-task button in local provider section header ([#298](https://github.com/richwklein/taskmato/issues/298))
+- [ ] List and grid view toggle for the task picker (list = current row layout, grid = card layout) ([#299](https://github.com/richwklein/taskmato/issues/299))
+- [ ] "View Completed" sheet in picker for any enabled `MutableTaskProvider`; calls `completedTasks()` with restore (`reopen`) and permanent-delete affordances ([#300](https://github.com/richwklein/taskmato/issues/300))
 - [x] Active task label in popover and main window timer tab: provider-conditional complete (checkmark) button, always-visible clear button, hidden when no task active ([#258](https://github.com/richwklein/taskmato/issues/258))
-- [ ] Mid-session task swap (does not stop the timer) ([#258](https://github.com/richwklein/taskmato/issues/258))
+- [ ] Mid-session task swap (does not stop the timer) ([#296](https://github.com/richwklein/taskmato/issues/296))
 - [ ] Honor priority and due-date hints in the picker (sort and badge) ([#257](https://github.com/richwklein/taskmato/issues/257))
 - [ ] Always-on-top mode for the timer popover (detached floating window, toggle in popover header, persisted setting) ([#260](https://github.com/richwklein/taskmato/issues/260))
 - [ ] Per-provider list scoping (choose which lists each provider exposes in the picker; persisted per provider) ([#276](https://github.com/richwklein/taskmato/issues/276))
-- [ ] Render task notes/description as markdown where displayed (picker detail, active task label); add `NoteFormat` (.plainText / .markdown) to `TaskItem` ([#278](https://github.com/richwklein/taskmato/issues/278))
+- [x] Render task notes/description as markdown where displayed (picker detail, active task label); add `NoteFormat` (.plainText / .markdown) to `TaskItem` ([#278](https://github.com/richwklein/taskmato/issues/278))
 - [ ] Explore full / minimized mode: minimized keeps the compact popover, full mode opens/focuses the main window on menu bar click and on session start ([#293](https://github.com/richwklein/taskmato/issues/293))
 
 ## Obsidian / Markdown provider (P4)
 
-- [ ] Vault root setting + folder access scoped bookmark ([#261](https://github.com/richwklein/taskmato/issues/261))
-- [ ] Parser for [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) emoji subset: ([#262](https://github.com/richwklein/taskmato/issues/262))
-  - [ ] Checkbox states `- [ ]`, `- [x]`, `- [-]`
-  - [ ] Priorities `🔺 ⏫ 🔼 🔽 ⏬`
-  - [ ] Dates `📅 ⏳ 🛫 ➕ ✅ ❌` (`YYYY-MM-DD`)
-  - [ ] Parse-tolerant for `🔁`, `🏁`, `🆔`, `⛔` (preserved on round-trip, not authoritative)
+- [x] Vault root setting + folder access scoped bookmark ([#261](https://github.com/richwklein/taskmato/issues/261) — GH issue still open, needs closing)
+- [x] Parser for [obsidian-tasks](https://github.com/obsidian-tasks-group/obsidian-tasks) emoji subset: ([#262](https://github.com/richwklein/taskmato/issues/262))
+  - [x] Checkbox states `- [ ]`, `- [x]`, `- [-]`
+  - [x] Priorities `🔺 ⏫ 🔼 🔽 ⏬`
+  - [x] Dates `📅 ⏳ 🛫 ➕ ✅ ❌` (`YYYY-MM-DD`)
+  - [x] Parse-tolerant for `🔁`, `🏁`, `🆔`, `⛔` (preserved on round-trip, not authoritative)
 - [ ] FSEvents-based live updates with debouncing ([#263](https://github.com/richwklein/taskmato/issues/263))
-- [ ] `MutableTaskProvider.complete` rewrites `- [ ]` → `- [x]` and appends `✅ <today>` ([#263](https://github.com/richwklein/taskmato/issues/263))
+- [x] `MutableTaskProvider.complete` rewrites `- [ ]` → `- [x]` and appends `✅ <today>` ([#263](https://github.com/richwklein/taskmato/issues/263))
+- [ ] Implement `completedTasks()` for `ObsidianProvider` (scans vault for `- [x]` tasks) ([#301](https://github.com/richwklein/taskmato/issues/301))
 
 ## CLI / URL scheme provider (P5)
 
@@ -59,12 +73,17 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 
 ## Stats visualization (P6)
 
-- [ ] `StatsView` reachable from popover footer ([#269](https://github.com/richwklein/taskmato/issues/269))
-- [ ] Today: per-task focus minutes (Swift Charts bar chart) ([#270](https://github.com/richwklein/taskmato/issues/270))
+- [x] `StatsView` reachable from popover footer (tapping the session stats row opens the main window Stats tab) ([#269](https://github.com/richwklein/taskmato/issues/269) — GH issue still open, needs closing)
+- [x] Today: per-task focus time breakdown (donut/sector chart in main window Stats tab) ([#270](https://github.com/richwklein/taskmato/issues/270) partial — 7-day and all-time remain)
 - [ ] 7-day: focus minutes per day, stacked by provider ([#270](https://github.com/richwklein/taskmato/issues/270))
 - [ ] All-time: per-task table sortable by total focus ([#270](https://github.com/richwklein/taskmato/issues/270))
 - [ ] Daily focus total and current streak in popover header ([#271](https://github.com/richwklein/taskmato/issues/271))
-- [ ] `SessionStore.focusTotals(by: TaskRef)` aggregation + tests ([#268](https://github.com/richwklein/taskmato/issues/268))
+- [ ] `SessionStore` aggregation helpers + tests ([#268](https://github.com/richwklein/taskmato/issues/268)):
+  - [ ] `focusTotals(by ref: TaskRef) -> TimeInterval`
+  - [ ] `focusTotalsByTask(in range: DateInterval) -> [TaskRef: TimeInterval]`
+  - [ ] `focusTotalsByDay(in range: DateInterval) -> [Date: TimeInterval]` (keyed at start-of-day; needed for 7-day chart)
+  - [ ] `focusTotalsByProvider(in range: DateInterval) -> [String: TimeInterval]` (needed for 7-day stacked chart)
+  - [ ] `currentStreak(now: Date) -> Int` (needed for popover header)
 
 ## Monetization (P7)
 
@@ -92,6 +111,7 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 - [ ] Add GitHub Actions release workflow triggered on version tags (`v*`) ([#284](https://github.com/richwklein/taskmato/issues/284))
 - [ ] Configure App Store Connect for App Store distribution (separate from Developer ID path) ([#285](https://github.com/richwklein/taskmato/issues/285))
 - [ ] Update `Makefile` `SIGN_FLAGS` docs to clarify dev-only scope ([#282](https://github.com/richwklein/taskmato/issues/282))
+- [x] Ad-hoc code signing in dev Makefile targets to prevent Gatekeeper "damaged" popup
 
 ## Marketing Site (GitHub Pages)
 
@@ -111,25 +131,20 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 
 ## GitHub / CI
 
+- [x] Issue and pull request templates
 - [ ] Add a documentation deploy action (if needed) ([#290](https://github.com/richwklein/taskmato/issues/290))
 - [ ] Make deploys dependent on build and require build checks ([#291](https://github.com/richwklein/taskmato/issues/291))
 - [ ] Re-enable the GitHub ruleset when rules are finalized ([#292](https://github.com/richwklein/taskmato/issues/292))
 
-## Already shipped (reference)
+## General foundations (pre-pivot, already shipped)
 
-- [x] App shell, menu bar countdown, popover circular timer, settings panel
-- [x] Timer engine (start / pause / resume / stop / skip, breaks, long break, auto-start)
+- [x] App shell: menu bar countdown, popover circular timer, settings panel
+- [x] Timer engine: start / pause / resume / stop / skip, breaks, long break, auto-start
 - [x] Phase completion notifications and sounds
 - [x] Persist settings to UserDefaults; persist completed sessions to JSON
-- [x] Issue and pull request templates
 - [x] Settings window brought to foreground on open (MenuBarExtra activation fix)
 - [x] Spacing between transport controls and session stats in popover
-- [x] Task domain foundation: `TaskRef`, `TaskItem`, `TaskProvider`, `TaskRegistry`, `TaskSelectionStore`; `Session.taskRef` migration ([#281](https://github.com/richwklein/taskmato/pull/281))
-- [x] Main window with Timer, Tasks, and Stats tabs (TabView navigation skeleton)
 - [x] Compact menu bar popover with quick timer controls and "Open Taskmato" button
 - [x] User-controlled Dock icon setting (Show Dock icon toggle in Settings; applied on next launch)
 - [x] `Bundle.main.appName` extension for dynamic app name used throughout all UI
-- [x] Ad-hoc code signing in dev Makefile targets to prevent Gatekeeper "damaged" popup
-- [x] Active task label row wired into both popover and main window timer tab ([#258](https://github.com/richwklein/taskmato/issues/258))
-- [x] Session cycle state (`completedFocusCount`, `nextBreakPhase`) moved into `SessionEngine`; `SessionStore` is now stats-only; app always starts a fresh focus phase on launch
 - [x] Menu bar label shows the correct duration for the queued phase (focus / short break / long break) when idle

--- a/app/Taskmato/AppNotifications.swift
+++ b/app/Taskmato/AppNotifications.swift
@@ -10,4 +10,9 @@ extension Notification.Name {
   ///
   /// `MainWindowView` listens for this and switches to the Tasks tab.
   static let showTasksTab = Notification.Name("Taskmato.showTasksTab")
+
+  /// Posted by the compact popover when the user taps the session stats row.
+  ///
+  /// `MainWindowView` listens for this and switches to the Stats tab.
+  static let showStatsTab = Notification.Name("Taskmato.showStatsTab")
 }

--- a/app/Taskmato/MainWindow/MainWindowView.swift
+++ b/app/Taskmato/MainWindow/MainWindowView.swift
@@ -43,12 +43,15 @@ struct MainWindowView: View {
       }
 
       Tab("Stats", systemImage: "chart.bar", value: 2) {
-        StatsTabView()
+        StatsTabView(store: store)
       }
     }
     .frame(minWidth: 480, minHeight: 400)
     .onReceive(NotificationCenter.default.publisher(for: .showTasksTab)) { _ in
       selectedTab = 1
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .showStatsTab)) { _ in
+      selectedTab = 2
     }
     .toolbar {
       ToolbarItem(placement: .automatic) {

--- a/app/Taskmato/MainWindow/StatsTabView.swift
+++ b/app/Taskmato/MainWindow/StatsTabView.swift
@@ -3,23 +3,189 @@
 //  Taskmato
 //
 
+import Charts
 import SwiftUI
 
 /// The statistics tab shown in the main application window.
 ///
-/// Displays focus time charts and session history.
-/// Populated in milestone P6 (stats visualization).
+/// Displays a scope picker (Today / 7 Days), four summary stat cards, and a donut
+/// chart of focus time broken down by task. Data is derived from ``SessionStore``.
 struct StatsTabView: View {
 
+  var store: SessionStore
+
+  @State private var scope: StatScope = .today
+
   var body: some View {
-    ContentUnavailableView(
-      "No Sessions Yet",
-      systemImage: "chart.bar",
-      description: Text("Complete a focus session to see your statistics here.")
-    )
+    VStack(spacing: 0) {
+      scopePicker
+
+      if store.sessions.isEmpty {
+        ContentUnavailableView(
+          "No Sessions Yet",
+          systemImage: "chart.bar",
+          description: Text("Complete a focus session to see your statistics here.")
+        )
+      } else {
+        let summary = currentSummary
+        ScrollView {
+          VStack(alignment: .leading, spacing: 20) {
+            statGrid(summary)
+            if !summary.taskBreakdown.isEmpty {
+              taskBreakdownSection(summary)
+            }
+          }
+          .padding()
+        }
+      }
+    }
+  }
+
+  // MARK: - Scope picker
+
+  private var scopePicker: some View {
+    Picker("Scope", selection: $scope) {
+      ForEach(StatScope.allCases, id: \.self) { statScope in
+        Text(statScope.label).tag(statScope)
+      }
+    }
+    .pickerStyle(.segmented)
+    .padding([.horizontal, .top])
+    .padding(.bottom, 8)
+  }
+
+  // MARK: - Stat grid
+
+  private func statGrid(_ summary: SessionSummary) -> some View {
+    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+      StatCardView(icon: "target", value: "\(summary.focusCount)", label: "Sessions")
+      StatCardView(
+        icon: "timer",
+        value: formatDuration(summary.focusSeconds),
+        label: "Focus Time"
+      )
+      StatCardView(icon: "cup.and.saucer", value: "\(summary.breakCount)", label: "Breaks")
+      StatCardView(icon: "repeat", value: "\(summary.cycleCount)", label: "Cycles")
+    }
+  }
+
+  // MARK: - Task breakdown
+
+  private func taskBreakdownSection(_ summary: SessionSummary) -> some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Task Breakdown")
+        .font(.headline)
+
+      Chart(summary.taskBreakdown) { slice in
+        SectorMark(
+          angle: .value("Time", slice.seconds),
+          innerRadius: .ratio(0.5),
+          angularInset: 1.5
+        )
+        .cornerRadius(3)
+        .foregroundStyle(by: .value("Task", slice.label))
+      }
+      .chartForegroundStyleScale(
+        domain: summary.taskBreakdown.map(\.label),
+        range: chartColors(count: summary.taskBreakdown.count)
+      )
+      .chartLegend(.hidden)
+      .frame(height: 160)
+
+      VStack(spacing: 6) {
+        ForEach(Array(summary.taskBreakdown.enumerated()), id: \.element.id) { idx, slice in
+          HStack(spacing: 8) {
+            Circle()
+              .fill(sliceColor(idx))
+              .frame(width: 10, height: 10)
+            Text(slice.label)
+              .lineLimit(1)
+            Spacer()
+            let pct =
+              summary.focusSeconds > 0
+              ? Int(slice.seconds / summary.focusSeconds * 100) : 0
+            Text("\(slice.minutes) min · \(pct)%")
+              .foregroundStyle(.secondary)
+              .font(.caption)
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Helpers
+
+  private var currentSummary: SessionSummary {
+    scope == .today ? store.todaySummary() : store.thisWeekSummary()
+  }
+
+  private static let palette: [Color] = [
+    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,
+  ]
+
+  private func sliceColor(_ index: Int) -> Color {
+    Self.palette[index % Self.palette.count]
+  }
+
+  private func chartColors(count: Int) -> [Color] {
+    (0..<count).map { sliceColor($0) }
+  }
+
+  /// Formats a duration in seconds as `"Xh Ym"` when ≥ 60 min, otherwise `"Xm"`.
+  private func formatDuration(_ seconds: TimeInterval) -> String {
+    let minutes = Int(seconds / 60)
+    if minutes >= 60 {
+      let hours = minutes / 60
+      let mins = minutes % 60
+      return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h"
+    }
+    return "\(minutes)m"
+  }
+}
+
+// MARK: - Scope
+
+private enum StatScope: CaseIterable {
+  case today
+  case thisWeek
+
+  var label: String {
+    switch self {
+    case .today: return "Today"
+    case .thisWeek: return "7 Days"
+    }
+  }
+}
+
+// MARK: - StatCardView
+
+/// A compact summary card showing a single metric with an icon, value, and label.
+private struct StatCardView: View {
+
+  let icon: String
+  let value: String
+  let label: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Image(systemName: icon)
+        .font(.title2)
+        .foregroundStyle(.secondary)
+      Text(value)
+        .font(.title)
+        .fontWeight(.semibold)
+        .monospacedDigit()
+      Text(label)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(12)
+    .background(.background.secondary)
+    .clipShape(RoundedRectangle(cornerRadius: 8))
   }
 }
 
 #Preview {
-  StatsTabView()
+  StatsTabView(store: SessionStore())
 }

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -19,6 +19,17 @@ struct TasksTabView: View {
   @State private var groupedLists: [TaskGroup] = []
   @State private var isLoading: Bool = false
   @State private var expandedGroups: [String: Bool] = [:]
+  @State private var isAddingTask = false
+
+  /// The local provider instance looked up from the registry, if registered.
+  private var localProvider: LocalProvider? {
+    registry.providers.first(where: { $0 is LocalProvider }) as? LocalProvider
+  }
+
+  /// `true` when the local provider is registered and currently enabled.
+  private var localProviderEnabled: Bool {
+    localProvider.map { registry.isEnabled($0.id) } ?? false
+  }
 
   var body: some View {
     Group {
@@ -48,6 +59,26 @@ struct TasksTabView: View {
     .searchable(text: $query, prompt: "Search tasks")
     .task(id: query) { await loadTasks() }
     .onAppear { Task { await loadTasks() } }
+    .onChange(of: isAddingTask) { _, adding in
+      if !adding { Task { await loadTasks() } }
+    }
+    .sheet(isPresented: $isAddingTask) {
+      if let provider = localProvider {
+        AddTaskView(provider: provider, isPresented: $isAddingTask)
+      }
+    }
+    .toolbar {
+      if localProviderEnabled {
+        ToolbarItem(placement: .automatic) {
+          Button {
+            isAddingTask = true
+          } label: {
+            Label("Add Task", systemImage: "plus")
+          }
+          .help("Add a local task")
+        }
+      }
+    }
   }
 
   // MARK: - Task list

--- a/app/Taskmato/Session/Session.swift
+++ b/app/Taskmato/Session/Session.swift
@@ -26,6 +26,12 @@ struct Session: Codable, Identifiable {
   /// The task associated with this session, if one was selected when the phase ran.
   var taskRef: TaskRef?
 
+  /// The display title of the associated task, captured at session end.
+  ///
+  /// Stored alongside `taskRef` so stats can show task names even after a task is
+  /// renamed or deleted from its provider.
+  var taskTitle: String?
+
   /// Actual elapsed duration of this phase in seconds.
   var duration: TimeInterval { endedAt.timeIntervalSince(startedAt) }
 }

--- a/app/Taskmato/Session/SessionStore.swift
+++ b/app/Taskmato/Session/SessionStore.swift
@@ -45,6 +45,28 @@ final class SessionStore {
     save()
   }
 
+  /// Returns a ``SessionSummary`` for sessions whose `startedAt` falls within `interval`.
+  /// - Parameter interval: The date range to scope results to.
+  func summary(for interval: DateInterval) -> SessionSummary {
+    SessionSummary(sessions: sessions, over: interval)
+  }
+
+  /// Returns a summary scoped to the current calendar day (local time zone).
+  func todaySummary() -> SessionSummary {
+    let calendar = Calendar.current
+    let start = calendar.startOfDay(for: Date())
+    let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
+    return summary(for: DateInterval(start: start, end: end))
+  }
+
+  /// Returns a summary scoped to a rolling seven-day window ending now.
+  func thisWeekSummary() -> SessionSummary {
+    let calendar = Calendar.current
+    let todayStart = calendar.startOfDay(for: Date())
+    let start = calendar.date(byAdding: .day, value: -6, to: todayStart) ?? todayStart
+    return summary(for: DateInterval(start: start, end: Date()))
+  }
+
   /// Number of completed focus sessions that started today (calendar day, local time zone).
   func todayFocusCount() -> Int {
     let calendar = Calendar.current

--- a/app/Taskmato/Session/SessionSummary.swift
+++ b/app/Taskmato/Session/SessionSummary.swift
@@ -1,0 +1,101 @@
+//
+//  SessionSummary.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Aggregated statistics computed from a set of session records over a date interval.
+///
+/// Constructed by ``SessionStore/summary(for:)`` or its convenience methods. All properties
+/// are eagerly computed at init time from the provided sessions; the value is immutable.
+struct SessionSummary {
+
+  /// Number of naturally completed focus sessions within the interval.
+  let focusCount: Int
+
+  /// Total elapsed time across completed focus sessions, in seconds.
+  let focusSeconds: TimeInterval
+
+  /// Number of naturally completed break sessions (short or long) within the interval.
+  let breakCount: Int
+
+  /// Number of completed full Pomodoro cycles within the interval.
+  ///
+  /// One cycle = one completed long break. A long break is only taken after the user
+  /// finishes N consecutive focus sessions, so each completed long break represents
+  /// one full cycle.
+  let cycleCount: Int
+
+  /// Focus time grouped by task, sorted by total duration descending.
+  let taskBreakdown: [TaskSlice]
+
+  /// Total focus time expressed in whole minutes.
+  var focusMinutes: Int { Int(focusSeconds / 60) }
+
+  /// A single task's share of focus time within the summary interval.
+  struct TaskSlice: Identifiable {
+
+    /// Stable grouping key derived from the task's provider ID and native ID.
+    let id: String
+
+    /// Human-readable task title shown in the pie chart legend.
+    let label: String
+
+    /// Total focus seconds attributed to this task.
+    let seconds: TimeInterval
+
+    /// Focus time expressed in whole minutes.
+    var minutes: Int { Int(seconds / 60) }
+  }
+
+  /// Computes a summary from sessions whose `startedAt` falls within `interval`.
+  ///
+  /// - Parameters:
+  ///   - sessions: The full session log, as returned by ``SessionStore``.
+  ///   - interval: The date range to scope results to.
+  init(sessions: [Session], over interval: DateInterval) {
+    let scoped = sessions.filter { interval.contains($0.startedAt) }
+    let completedFocus = scoped.filter { $0.phase == .focus && $0.wasCompleted }
+
+    focusCount = completedFocus.count
+    focusSeconds = completedFocus.reduce(0) { $0 + $1.duration }
+
+    breakCount =
+      scoped.filter {
+        ($0.phase == .shortBreak || $0.phase == .longBreak) && $0.wasCompleted
+      }.count
+
+    cycleCount = scoped.filter { $0.phase == .longBreak && $0.wasCompleted }.count
+
+    // Group completed focus sessions by task, preserving first-seen insertion order
+    // so the breakdown order is deterministic before the final sort.
+    var ordered: [String] = []
+    var accumulated: [String: (label: String, seconds: TimeInterval)] = [:]
+
+    for session in completedFocus {
+      let key: String
+      let label: String
+      if let ref = session.taskRef {
+        key = "\(ref.providerID):\(ref.nativeID)"
+        label = session.taskTitle ?? "Unknown Task"
+      } else {
+        key = "__untracked__"
+        label = "Untracked"
+      }
+      if accumulated[key] == nil {
+        ordered.append(key)
+        accumulated[key] = (label: label, seconds: 0)
+      }
+      accumulated[key]!.seconds += session.duration
+    }
+
+    taskBreakdown =
+      ordered
+      .compactMap { key -> TaskSlice? in
+        guard let entry = accumulated[key] else { return nil }
+        return TaskSlice(id: key, label: entry.label, seconds: entry.seconds)
+      }
+      .sorted { $0.seconds > $1.seconds }
+  }
+}

--- a/app/Taskmato/Settings/LocalSettingsView.swift
+++ b/app/Taskmato/Settings/LocalSettingsView.swift
@@ -1,0 +1,86 @@
+//
+//  LocalSettingsView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// List-management rows for the local task provider.
+///
+/// Rendered inside a "Local Tasks" `Section` in ``SettingsView`` when the local
+/// provider is enabled. Supports creating, renaming (via inline text fields), and
+/// deleting lists. Does not include a `Section` wrapper — the caller is responsible.
+@MainActor
+struct LocalSettingsView: View {
+
+  var provider: LocalProvider
+
+  @State private var newListName = ""
+  @State private var pendingNames: [UUID: String] = [:]
+
+  var body: some View {
+    Group {
+      LabeledContent("Active tasks", value: "\(provider.activeTaskCount)")
+
+      ForEach(provider.taskLists) { list in
+        listRow(list)
+      }
+
+      HStack {
+        TextField("New list name", text: $newListName)
+          .onSubmit { addList() }
+        Button("Add") { addList() }
+          .disabled(newListName.trimmingCharacters(in: .whitespaces).isEmpty)
+      }
+    }
+  }
+
+  // MARK: - List row
+
+  private func listRow(_ list: LocalList) -> some View {
+    HStack {
+      TextField(
+        "List name",
+        text: Binding(
+          get: { pendingNames[list.id] ?? list.name },
+          set: { pendingNames[list.id] = $0 }
+        )
+      )
+      .textFieldStyle(.plain)
+      .onSubmit { commitRename(list) }
+
+      Button(role: .destructive) {
+        provider.deleteList(list.id)
+        pendingNames.removeValue(forKey: list.id)
+      } label: {
+        Image(systemName: "trash")
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.red)
+      .disabled(provider.taskLists.count == 1)
+    }
+    .onChange(of: list.name) { _, newName in
+      // Keep the editing buffer in sync if provider updates the name externally.
+      if pendingNames[list.id] == list.name { pendingNames.removeValue(forKey: list.id) }
+      _ = newName
+    }
+  }
+
+  // MARK: - Actions
+
+  private func commitRename(_ list: LocalList) {
+    guard let pending = pendingNames[list.id] else { return }
+    let trimmed = pending.trimmingCharacters(in: .whitespaces)
+    if !trimmed.isEmpty && trimmed != list.name {
+      try? provider.renameList(list.id, name: trimmed)
+    }
+    pendingNames.removeValue(forKey: list.id)
+  }
+
+  private func addList() {
+    let trimmed = newListName.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+    provider.createList(name: trimmed)
+    newListName = ""
+  }
+}

--- a/app/Taskmato/Settings/SettingsView.swift
+++ b/app/Taskmato/Settings/SettingsView.swift
@@ -13,6 +13,7 @@ struct SettingsView: View {
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   var obsidianProvider: ObsidianProvider
+  var localProvider: LocalProvider
 
   var body: some View {
     Form {
@@ -58,6 +59,10 @@ struct SettingsView: View {
             )
             if provider.id == ObsidianProvider.providerID && registry.isEnabled(provider.id) {
               ObsidianSettingsView(provider: obsidianProvider)
+                .padding(.leading, 16)
+            }
+            if provider.id == LocalProvider.providerID && registry.isEnabled(provider.id) {
+              LocalSettingsView(provider: localProvider)
                 .padding(.leading, 16)
             }
           }
@@ -145,6 +150,7 @@ private struct DurationField: View {
     settings: AppSettings(),
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
-    obsidianProvider: ObsidianProvider()
+    obsidianProvider: ObsidianProvider(),
+    localProvider: LocalProvider()
   )
 }

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -34,6 +34,7 @@ struct TaskmatoApp: App {
   @State private var notifications: NotificationService
   @State private var sounds: SoundService
   @State private var obsidianProvider: ObsidianProvider
+  @State private var localProvider: LocalProvider
 
   init() {
     let engine = SessionEngine()
@@ -44,7 +45,9 @@ struct TaskmatoApp: App {
     let notifications = NotificationService()
     let sounds = SoundService()
     let obsidianProvider = ObsidianProvider()
+    let localProvider = LocalProvider()
     registry.register(obsidianProvider)
+    registry.register(localProvider)
 
     engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in
       store.append(
@@ -54,7 +57,8 @@ struct TaskmatoApp: App {
           startedAt: startedAt,
           endedAt: endedAt,
           wasCompleted: wasCompleted,
-          taskRef: selectionStore.activeTask?.id
+          taskRef: selectionStore.activeTask?.id,
+          taskTitle: selectionStore.activeTask?.title
         ))
       if wasCompleted {
         if settings.soundEnabled { sounds.play() }
@@ -83,6 +87,7 @@ struct TaskmatoApp: App {
     _notifications = State(initialValue: notifications)
     _sounds = State(initialValue: sounds)
     _obsidianProvider = State(initialValue: obsidianProvider)
+    _localProvider = State(initialValue: localProvider)
   }
 
   var body: some Scene {
@@ -116,7 +121,8 @@ struct TaskmatoApp: App {
         settings: settings,
         selectionStore: selectionStore,
         registry: registry,
-        obsidianProvider: obsidianProvider
+        obsidianProvider: obsidianProvider,
+        localProvider: localProvider
       )
     }
     .windowResizability(.contentSize)

--- a/app/Taskmato/Tasks/Local/AddTaskView.swift
+++ b/app/Taskmato/Tasks/Local/AddTaskView.swift
@@ -1,0 +1,136 @@
+//
+//  AddTaskView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A sheet for creating a new task in ``LocalProvider``.
+///
+/// Displayed as a modal sheet from the Tasks tab when the local provider is active.
+/// The title field is auto-focused on appear. Submitting with an empty title is disabled.
+struct AddTaskView: View {
+
+  var provider: LocalProvider
+  @Binding var isPresented: Bool
+
+  @State private var title = ""
+  @State private var notes = ""
+  @State private var priority: TaskPriority = .none
+  @State private var selectedListID: UUID = UUID()
+  @State private var hasDueDate = false
+  @State private var dueDate = Date()
+  @State private var showNotes = false
+
+  @FocusState private var isTitleFocused: Bool
+
+  private var canSubmit: Bool {
+    !title.trimmingCharacters(in: .whitespaces).isEmpty
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text("New Task")
+        .font(.headline)
+
+      TextField("Task title", text: $title)
+        .textFieldStyle(.roundedBorder)
+        .focused($isTitleFocused)
+        .onSubmit { if canSubmit { submit() } }
+
+      Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 10) {
+        GridRow {
+          Text("List")
+            .foregroundStyle(.secondary)
+          Picker("List", selection: $selectedListID) {
+            ForEach(provider.taskLists) { list in
+              Text(list.name).tag(list.id)
+            }
+          }
+          .labelsHidden()
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        GridRow {
+          Text("Priority")
+            .foregroundStyle(.secondary)
+          Picker("Priority", selection: $priority) {
+            ForEach(TaskPriority.allCases, id: \.self) { level in
+              Text(level.displayLabel).tag(level)
+            }
+          }
+          .labelsHidden()
+          .pickerStyle(.menu)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        GridRow {
+          Text("Due date")
+            .foregroundStyle(.secondary)
+          HStack {
+            Toggle("", isOn: $hasDueDate)
+              .labelsHidden()
+            if hasDueDate {
+              DatePicker("", selection: $dueDate, displayedComponents: .date)
+                .labelsHidden()
+            }
+          }
+        }
+      }
+
+      DisclosureGroup("Notes", isExpanded: $showNotes) {
+        TextEditor(text: $notes)
+          .frame(height: 72)
+          .font(.body)
+      }
+
+      HStack {
+        Spacer()
+        Button("Cancel") { isPresented = false }
+          .keyboardShortcut(.cancelAction)
+        Button("Add Task") { submit() }
+          .keyboardShortcut(.defaultAction)
+          .disabled(!canSubmit)
+      }
+    }
+    .padding()
+    .frame(width: 360)
+    .onAppear {
+      isTitleFocused = true
+      if let first = provider.taskLists.first {
+        selectedListID = first.id
+      }
+    }
+  }
+
+  // MARK: - Private
+
+  private func submit() {
+    var draft = TaskDraft()
+    draft.title = title.trimmingCharacters(in: .whitespaces)
+    draft.notes = notes
+    draft.priority = priority
+    draft.dueDate = hasDueDate ? dueDate : nil
+    draft.listID =
+      provider.taskLists.first(where: { $0.id == selectedListID })?.id
+      ?? provider.taskLists.first?.id
+    provider.addTask(draft)
+    isPresented = false
+  }
+}
+
+// MARK: - TaskPriority display
+
+extension TaskPriority {
+  /// Short label used in the priority picker inside ``AddTaskView``.
+  fileprivate var displayLabel: String {
+    switch self {
+    case .none: return "None"
+    case .lowest: return "Lowest"
+    case .low: return "Low"
+    case .medium: return "Medium"
+    case .high: return "High"
+    case .highest: return "Highest"
+    }
+  }
+}

--- a/app/Taskmato/Tasks/Local/LocalList.swift
+++ b/app/Taskmato/Tasks/Local/LocalList.swift
@@ -1,0 +1,21 @@
+//
+//  LocalList.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A named grouping of tasks managed by ``LocalProvider``.
+struct LocalList: Codable, Identifiable, Hashable {
+
+  /// Stable unique identifier for this list.
+  let id: UUID
+
+  /// User-visible name shown in the task picker and add-task sheet.
+  var name: String
+
+  /// Returns this list expressed as the provider-agnostic ``TaskList`` type.
+  var asTaskList: TaskList {
+    TaskList(id: id.uuidString, providerID: LocalProvider.providerID, name: name)
+  }
+}

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -1,0 +1,229 @@
+//
+//  LocalProvider.swift
+//  Taskmato
+//
+
+import Foundation
+import Observation
+
+/// A built-in task provider that persists tasks and lists to a JSON file in Application Support.
+///
+/// Unlike the Obsidian provider, `LocalProvider` does not scan any external directory. All
+/// task CRUD happens in-process; `observe()` returns `nil` because the `@Observable` machinery
+/// propagates changes directly to SwiftUI views. Completion state is stored as a soft-delete
+/// so completed tasks can be surfaced via ``completedTasks()``.
+@Observable
+@MainActor
+final class LocalProvider: MutableTaskProvider {
+
+  /// Stable provider identifier used in ``TaskRef`` values.
+  static let providerID = "local"
+
+  let id: String = LocalProvider.providerID
+  let displayName: String = "Local"
+  let entitlement: ProviderEntitlement = .free
+
+  /// Lists managed by this provider, in creation order.
+  private(set) var taskLists: [LocalList] = []
+
+  /// Number of incomplete tasks currently in the store.
+  var activeTaskCount: Int { allTasks.filter { !$0.isCompleted }.count }
+
+  private var allTasks: [LocalTask] = []
+  private let fileURL: URL
+  private let encoder = JSONEncoder()
+  private let decoder = JSONDecoder()
+
+  /// Creates a provider backed by the default production file path.
+  convenience init() {
+    let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask
+    ).first!
+    let dir = appSupport.appendingPathComponent("Taskmato", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    self.init(fileURL: dir.appendingPathComponent("local-tasks.json"))
+  }
+
+  /// Creates a provider backed by a specific file URL. Pass a temporary path in tests.
+  init(fileURL: URL) {
+    self.fileURL = fileURL
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    decoder.dateDecodingStrategy = .iso8601
+    load()
+  }
+
+  // MARK: - TaskProvider
+
+  /// No-op — local tasks require no external authorization.
+  func authorize() async throws {}
+
+  /// Returns the managed lists expressed as provider-agnostic ``TaskList`` values.
+  func lists() async throws -> [TaskList] {
+    taskLists.map(\.asTaskList)
+  }
+
+  /// Returns incomplete tasks, optionally scoped to a single list.
+  ///
+  /// - Parameter list: Scope results to a specific list, or `nil` for all incomplete tasks.
+  func tasks(in list: TaskList?) async throws -> [TaskItem] {
+    let incomplete = allTasks.filter { !$0.isCompleted }
+    if let list {
+      let listID = UUID(uuidString: list.id)
+      return incomplete.filter { $0.listID == listID }.map { $0.asTaskItem(lists: taskLists) }
+    }
+    return incomplete.map { $0.asTaskItem(lists: taskLists) }
+  }
+
+  /// Returns `nil` — mutations are in-process and `@Observable` propagates changes directly.
+  func observe() -> AsyncStream<[TaskItem]>? { nil }
+
+  // MARK: - MutableTaskProvider
+
+  /// Soft-deletes the task by setting `isCompleted = true` and recording `completedAt`.
+  func complete(_ ref: TaskRef) async throws {
+    guard let idx = allTasks.firstIndex(where: { $0.id.uuidString == ref.nativeID }) else {
+      throw LocalProviderError.taskNotFound(ref.nativeID)
+    }
+    allTasks[idx].isCompleted = true
+    allTasks[idx].completedAt = Date()
+    save()
+  }
+
+  /// Restores a completed task by clearing `isCompleted` and `completedAt`.
+  func reopen(_ ref: TaskRef) async throws {
+    guard let idx = allTasks.firstIndex(where: { $0.id.uuidString == ref.nativeID }) else {
+      throw LocalProviderError.taskNotFound(ref.nativeID)
+    }
+    allTasks[idx].isCompleted = false
+    allTasks[idx].completedAt = nil
+    save()
+  }
+
+  /// Returns all soft-deleted tasks, sorted by completion date descending.
+  func completedTasks() async throws -> [TaskItem] {
+    allTasks
+      .filter { $0.isCompleted }
+      .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
+      .map { $0.asTaskItem(lists: taskLists) }
+  }
+
+  // MARK: - Task CRUD
+
+  /// Appends a new task built from `draft` to the store.
+  ///
+  /// If `draft.listID` is `nil`, the task is assigned to the first available list.
+  func addTask(_ draft: TaskDraft) {
+    var resolved = draft
+    if resolved.listID == nil {
+      resolved.listID = taskLists.first?.id
+    }
+    allTasks.append(LocalTask(from: resolved))
+    save()
+  }
+
+  /// Applies `draft` to the task identified by `ref`.
+  func updateTask(_ ref: TaskRef, draft: TaskDraft) throws {
+    guard let idx = allTasks.firstIndex(where: { $0.id.uuidString == ref.nativeID }) else {
+      throw LocalProviderError.taskNotFound(ref.nativeID)
+    }
+    allTasks[idx].apply(draft)
+    save()
+  }
+
+  /// Permanently removes the task identified by `ref` from the store.
+  func deleteTask(_ ref: TaskRef) throws {
+    guard allTasks.contains(where: { $0.id.uuidString == ref.nativeID }) else {
+      throw LocalProviderError.taskNotFound(ref.nativeID)
+    }
+    allTasks.removeAll { $0.id.uuidString == ref.nativeID }
+    save()
+  }
+
+  // MARK: - List CRUD
+
+  /// Appends a new list with the given name.
+  func createList(name: String) {
+    taskLists.append(LocalList(id: UUID(), name: name))
+    save()
+  }
+
+  /// Renames the list with `listID` to `name`.
+  func renameList(_ listID: UUID, name: String) throws {
+    guard let idx = taskLists.firstIndex(where: { $0.id == listID }) else {
+      throw LocalProviderError.listNotFound(listID.uuidString)
+    }
+    taskLists[idx].name = name
+    save()
+  }
+
+  /// Deletes the list with `listID` and moves its tasks to the next available list,
+  /// creating a "Default" list first if this was the last one.
+  func deleteList(_ listID: UUID) {
+    taskLists.removeAll { $0.id == listID }
+    if taskLists.isEmpty {
+      taskLists.append(LocalList(id: UUID(), name: "Default"))
+    }
+    let fallbackID = taskLists[0].id
+    for idx in allTasks.indices where allTasks[idx].listID == listID {
+      allTasks[idx].listID = fallbackID
+    }
+    save()
+  }
+
+  // MARK: - Persistence
+
+  private func load() {
+    if let data = try? Data(contentsOf: fileURL) {
+      let stored = try? decoder.decode(LocalStore.self, from: data)
+      taskLists = stored?.lists ?? []
+      allTasks = stored?.tasks ?? []
+    }
+    var dirty = false
+    if taskLists.isEmpty {
+      taskLists.append(LocalList(id: UUID(), name: "Default"))
+      dirty = true
+    }
+    let defaultID = taskLists[0].id
+    for idx in allTasks.indices where allTasks[idx].listID == nil {
+      allTasks[idx].listID = defaultID
+      dirty = true
+    }
+    if dirty { save() }
+  }
+
+  private func save() {
+    let store = LocalStore(lists: taskLists, tasks: allTasks)
+    guard let data = try? encoder.encode(store) else { return }
+    try? data.write(to: fileURL, options: [])
+  }
+}
+
+// MARK: - Persistence container
+
+/// Top-level JSON container for the local task store.
+private struct LocalStore: Codable {
+  var lists: [LocalList]
+  var tasks: [LocalTask]
+}
+
+// MARK: - Errors
+
+/// Errors thrown by ``LocalProvider`` operations.
+enum LocalProviderError: LocalizedError {
+
+  /// No task matching the given native ID exists in the store.
+  case taskNotFound(String)
+
+  /// No list matching the given ID exists in the store.
+  case listNotFound(String)
+
+  var errorDescription: String? {
+    switch self {
+    case .taskNotFound(let nativeID):
+      return "Could not find task \"\(nativeID)\"."
+    case .listNotFound(let listID):
+      return "Could not find list \"\(listID)\"."
+    }
+  }
+}

--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -1,0 +1,95 @@
+//
+//  LocalTask.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A single task stored in the local JSON task store.
+///
+/// Extends the core ``TaskItem`` properties with completion state. The ``asTaskItem(lists:)``
+/// method converts to the provider-agnostic representation used by the picker and session log.
+struct LocalTask: Codable, Identifiable {
+
+  /// Stable unique identifier for this task.
+  let id: UUID
+
+  /// The task title shown in the picker and active-task label.
+  var title: String
+
+  /// Optional supplementary notes or description.
+  var notes: String?
+
+  /// Priority level, used for sorting and badging in the picker.
+  var priority: TaskPriority
+
+  /// The date by which the task is due.
+  var dueDate: Date?
+
+  /// The date the task is scheduled to be worked on.
+  var scheduledDate: Date?
+
+  /// The earliest date the task should appear in the picker.
+  var startDate: Date?
+
+  /// The list this task belongs to, or `nil` if uncategorized.
+  var listID: UUID?
+
+  /// `true` when the task has been marked complete via ``LocalProvider/complete(_:)``.
+  var isCompleted: Bool
+
+  /// Wall-clock time when the task was completed, or `nil` if still open.
+  var completedAt: Date?
+
+  /// Wall-clock time when the task was first created.
+  let createdAt: Date
+
+  /// Converts this task to the provider-agnostic ``TaskItem`` used by the picker and registry.
+  ///
+  /// - Parameter lists: The full list of ``LocalList`` values managed by the provider,
+  ///   used to resolve `listID` into a display name.
+  func asTaskItem(lists: [LocalList]) -> TaskItem {
+    let taskList =
+      listID
+      .flatMap { lid in lists.first { $0.id == lid } }
+      .map { TaskList(id: $0.id.uuidString, providerID: LocalProvider.providerID, name: $0.name) }
+    return TaskItem(
+      id: TaskRef(providerID: LocalProvider.providerID, nativeID: id.uuidString),
+      title: title,
+      notes: notes,
+      format: .plainText,
+      priority: priority,
+      dueDate: dueDate,
+      scheduledDate: scheduledDate,
+      startDate: startDate,
+      list: taskList
+    )
+  }
+
+  /// Applies the editable fields of `draft` to this task in place.
+  mutating func apply(_ draft: TaskDraft) {
+    title = draft.title
+    notes = draft.notes.isEmpty ? nil : draft.notes
+    priority = draft.priority
+    dueDate = draft.dueDate
+    listID = draft.listID
+  }
+}
+
+extension LocalTask {
+
+  /// Creates a new incomplete task from a ``TaskDraft``.
+  init(from draft: TaskDraft) {
+    id = UUID()
+    title = draft.title
+    notes = draft.notes.isEmpty ? nil : draft.notes
+    priority = draft.priority
+    dueDate = draft.dueDate
+    scheduledDate = nil
+    startDate = nil
+    listID = draft.listID
+    isCompleted = false
+    completedAt = nil
+    createdAt = Date()
+  }
+}

--- a/app/Taskmato/Tasks/Local/TaskDraft.swift
+++ b/app/Taskmato/Tasks/Local/TaskDraft.swift
@@ -1,0 +1,29 @@
+//
+//  TaskDraft.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Mutable form state for creating or editing a ``LocalTask``.
+///
+/// Passed to ``LocalProvider/addTask(_:)`` and ``LocalProvider/updateTask(_:draft:)``
+/// to apply user input to the task store without exposing the full ``LocalTask`` model
+/// to the view layer.
+struct TaskDraft {
+
+  /// The task title. Must be non-empty before submission.
+  var title: String = ""
+
+  /// Optional notes for the task.
+  var notes: String = ""
+
+  /// Priority level.
+  var priority: TaskPriority = .none
+
+  /// Due date, or `nil` if no due date is set.
+  var dueDate: Date?
+
+  /// The list this task should belong to, or `nil` for uncategorized.
+  var listID: UUID?
+}

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -49,4 +49,14 @@ protocol MutableTaskProvider: TaskProvider {
   /// Reopens a previously completed task in the source system.
   /// - Parameter ref: The stable reference to the task to reopen.
   func reopen(_ ref: TaskRef) async throws
+
+  /// Returns tasks that have been marked complete, for display in a "View Completed" sheet.
+  ///
+  /// The default implementation returns an empty array. Override when the provider
+  /// supports surfacing completed tasks (e.g. a local JSON store or an Obsidian vault).
+  func completedTasks() async throws -> [TaskItem]
+}
+
+extension MutableTaskProvider {
+  func completedTasks() async throws -> [TaskItem] { [] }
 }

--- a/app/Taskmato/TimerView.swift
+++ b/app/Taskmato/TimerView.swift
@@ -93,9 +93,18 @@ struct TimerView: View {
       Divider()
         .padding(.horizontal, 16)
 
-      SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
+      Button {
+        let popover = NSApp.keyWindow
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: "main")
+        NotificationCenter.default.post(name: .showStatsTab, object: nil)
+        DispatchQueue.main.async { popover?.close() }
+      } label: {
+        SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
+      }
+      .buttonStyle(.plain)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 10)
     }
     .frame(width: 280)
   }

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -1,0 +1,302 @@
+//
+//  LocalProviderTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+// MARK: - Helpers for orphan-reassignment test
+
+/// A parallel Codable container used to write a raw JSON fixture with nil listIDs,
+/// simulating pre-list-enforcement data for the orphan-reassignment test.
+private struct RawLocalStore: Codable {
+  struct RawTask: Codable {
+    let id: UUID
+    var title: String
+    var notes: String?
+    var priority: TaskPriority
+    var dueDate: Date?
+    var scheduledDate: Date?
+    var startDate: Date?
+    var listID: UUID?
+    var isCompleted: Bool
+    var completedAt: Date?
+    let createdAt: Date
+  }
+  struct RawList: Codable {
+    let id: UUID
+    var name: String
+  }
+  var lists: [RawList]
+  var tasks: [RawTask]
+}
+
+// MARK: - Tests
+
+@Suite("LocalProvider")
+@MainActor
+struct LocalProviderTests {
+
+  /// Creates a provider backed by a unique temporary file so tests are fully isolated.
+  private func makeProvider() -> LocalProvider {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    return LocalProvider(fileURL: url)
+  }
+
+  // MARK: - Default list
+
+  @Test func createsDefaultListOnFirstLoad() {
+    let provider = makeProvider()
+    #expect(provider.taskLists.count == 1)
+    #expect(provider.taskLists[0].name == "Default")
+  }
+
+  @Test func doesNotDuplicateDefaultListOnReload() {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    let first = LocalProvider(fileURL: url)
+    let defaultID = first.taskLists[0].id
+
+    let second = LocalProvider(fileURL: url)
+    #expect(second.taskLists.count == 1)
+    #expect(second.taskLists[0].id == defaultID)
+  }
+
+  @Test func orphanedTasksAssignedToDefaultListOnLoad() async throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+
+    let rawList = RawLocalStore.RawList(id: UUID(), name: "Existing")
+    let rawTask = RawLocalStore.RawTask(
+      id: UUID(),
+      title: "Orphan",
+      priority: .none,
+      isCompleted: false,
+      createdAt: Date()
+    )
+    let raw = RawLocalStore(lists: [rawList], tasks: [rawTask])
+    let data = try encoder.encode(raw)
+    try data.write(to: url, options: [])
+
+    let provider = LocalProvider(fileURL: url)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks.count == 1)
+    #expect(tasks[0].title == "Orphan")
+    #expect(tasks[0].list?.id == rawList.id.uuidString)
+  }
+
+  // MARK: - Task CRUD
+
+  @Test func addTaskAppearsInActiveTasks() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "My task"
+    provider.addTask(draft)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks.count == 1)
+    #expect(tasks[0].title == "My task")
+  }
+
+  @Test func addTaskUsesDefaultListWhenNoDraftListID() async throws {
+    let provider = makeProvider()
+    let defaultListID = provider.taskLists[0].id
+    var draft = TaskDraft()
+    draft.title = "Orphan"
+    provider.addTask(draft)
+
+    let list = TaskList(
+      id: defaultListID.uuidString,
+      providerID: LocalProvider.providerID,
+      name: "Default"
+    )
+    let tasks = try await provider.tasks(in: list)
+    #expect(tasks.map(\.title).contains("Orphan"))
+  }
+
+  @Test func addTaskPersistsAcrossReload() async throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    let first = LocalProvider(fileURL: url)
+    var draft = TaskDraft()
+    draft.title = "Persisted"
+    first.addTask(draft)
+
+    let second = LocalProvider(fileURL: url)
+    let tasks = try await second.tasks(in: nil)
+    #expect(tasks.map(\.title).contains("Persisted"))
+  }
+
+  @Test func completeRemovesTaskFromActiveTasks() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "To complete"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    try await provider.complete(ref)
+    let remaining = try await provider.tasks(in: nil)
+    #expect(remaining.isEmpty)
+  }
+
+  @Test func completeAppearsInCompletedTasks() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Done"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    try await provider.complete(ref)
+    let completed = try await provider.completedTasks()
+    #expect(completed.count == 1)
+    #expect(completed[0].title == "Done")
+  }
+
+  @Test func reopenRestoresTaskToActive() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Reopen me"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    try await provider.complete(ref)
+    try await provider.reopen(ref)
+    let active = try await provider.tasks(in: nil)
+    #expect(active.count == 1)
+    let completed = try await provider.completedTasks()
+    #expect(completed.isEmpty)
+  }
+
+  @Test func completedTasksExcludesActiveTasks() async throws {
+    let provider = makeProvider()
+    for title in ["A", "B", "C"] {
+      var draft = TaskDraft()
+      draft.title = title
+      provider.addTask(draft)
+    }
+    let active = try await provider.tasks(in: nil)
+    // Complete only the first two.
+    try await provider.complete(active[0].id)
+    try await provider.complete(active[1].id)
+    let completed = try await provider.completedTasks()
+    #expect(completed.count == 2)
+    let remaining = try await provider.tasks(in: nil)
+    #expect(remaining.count == 1)
+  }
+
+  @Test func deleteTaskRemovesPermanently() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Delete me"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    try provider.deleteTask(ref)
+    #expect(try await provider.tasks(in: nil).isEmpty)
+    #expect(try await provider.completedTasks().isEmpty)
+  }
+
+  @Test func updateTaskAppliesNewTitle() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Original"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    var updated = TaskDraft()
+    updated.title = "Updated"
+    try provider.updateTask(ref, draft: updated)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks[0].title == "Updated")
+  }
+
+  @Test func activeTaskCountExcludesCompleted() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Count me"
+    provider.addTask(draft)
+    #expect(provider.activeTaskCount == 1)
+    let ref = try await provider.tasks(in: nil)[0].id
+    try await provider.complete(ref)
+    #expect(provider.activeTaskCount == 0)
+  }
+
+  // MARK: - List CRUD
+
+  @Test func createListAddsToProvider() {
+    let provider = makeProvider()
+    provider.createList(name: "Work")
+    #expect(provider.taskLists.count == 2)
+    #expect(provider.taskLists.map(\.name).contains("Work"))
+  }
+
+  @Test func renameListUpdatesName() throws {
+    let provider = makeProvider()
+    let listID = provider.taskLists[0].id
+    try provider.renameList(listID, name: "Personal")
+    #expect(provider.taskLists[0].name == "Personal")
+  }
+
+  @Test func deleteListMovesTasksToFallback() async throws {
+    let provider = makeProvider()
+    provider.createList(name: "Secondary")
+    let primaryID = provider.taskLists[0].id
+    let secondaryID = provider.taskLists[1].id
+
+    var draft = TaskDraft()
+    draft.title = "Orphaned"
+    draft.listID = primaryID
+    provider.addTask(draft)
+
+    provider.deleteList(primaryID)
+
+    let secondaryList = TaskList(
+      id: secondaryID.uuidString,
+      providerID: LocalProvider.providerID,
+      name: "Secondary"
+    )
+    let tasks = try await provider.tasks(in: secondaryList)
+    #expect(tasks.map(\.title).contains("Orphaned"))
+  }
+
+  @Test func deleteLastListCreatesNewDefault() {
+    let provider = makeProvider()
+    let listID = provider.taskLists[0].id
+    provider.deleteList(listID)
+    #expect(provider.taskLists.count == 1)
+    #expect(provider.taskLists[0].name == "Default")
+  }
+
+  @Test func deleteLastListMovesTasksToNewDefault() async throws {
+    let provider = makeProvider()
+    let listID = provider.taskLists[0].id
+    var draft = TaskDraft()
+    draft.title = "Survivor"
+    draft.listID = listID
+    provider.addTask(draft)
+
+    provider.deleteList(listID)
+
+    #expect(provider.taskLists.count == 1)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks.map(\.title).contains("Survivor"))
+  }
+
+  @Test func renameListThrowsForUnknownID() {
+    let provider = makeProvider()
+    let unknown = UUID()
+    #expect(throws: (any Error).self) {
+      try provider.renameList(unknown, name: "Ghost")
+    }
+  }
+
+  @Test func deleteTaskThrowsForUnknownRef() {
+    let provider = makeProvider()
+    let ref = TaskRef(providerID: LocalProvider.providerID, nativeID: UUID().uuidString)
+    #expect(throws: (any Error).self) {
+      try provider.deleteTask(ref)
+    }
+  }
+}

--- a/app/TaskmatoTests/SessionSummaryTests.swift
+++ b/app/TaskmatoTests/SessionSummaryTests.swift
@@ -1,0 +1,161 @@
+//
+//  SessionSummaryTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+struct SessionSummaryTests {
+
+  // MARK: - Helpers
+
+  private static let epoch = Date(timeIntervalSinceReferenceDate: 0)
+  private static let day: TimeInterval = 86_400
+  private static let focusDuration: TimeInterval = 1_500  // 25 min
+
+  private static let todayInterval: DateInterval = {
+    let cal = Calendar.current
+    let start = cal.startOfDay(for: epoch)
+    let end = cal.date(byAdding: .day, value: 1, to: start)!
+    return DateInterval(start: start, end: end)
+  }()
+
+  private func makeSession(
+    phase: SessionPhase = .focus,
+    startedAt: Date = epoch,
+    duration: TimeInterval = focusDuration,
+    wasCompleted: Bool = true,
+    taskRef: TaskRef? = nil,
+    taskTitle: String? = nil
+  ) -> Session {
+    Session(
+      id: UUID(),
+      phase: phase,
+      startedAt: startedAt,
+      endedAt: startedAt.addingTimeInterval(duration),
+      wasCompleted: wasCompleted,
+      taskRef: taskRef,
+      taskTitle: taskTitle
+    )
+  }
+
+  // MARK: - Empty input
+
+  @Test func emptySessionsProducesAllZeros() {
+    let summary = SessionSummary(sessions: [], over: Self.todayInterval)
+    #expect(summary.focusCount == 0)
+    #expect(summary.focusSeconds == 0)
+    #expect(summary.breakCount == 0)
+    #expect(summary.cycleCount == 0)
+    #expect(summary.taskBreakdown.isEmpty)
+  }
+
+  // MARK: - Interval scoping
+
+  @Test func sessionOutsideIntervalIsExcluded() {
+    let outside = makeSession(startedAt: Self.epoch.addingTimeInterval(-Self.day))
+    let summary = SessionSummary(sessions: [outside], over: Self.todayInterval)
+    #expect(summary.focusCount == 0)
+  }
+
+  @Test func sessionInsideIntervalIsCounted() {
+    let inside = makeSession(startedAt: Self.epoch)
+    let summary = SessionSummary(sessions: [inside], over: Self.todayInterval)
+    #expect(summary.focusCount == 1)
+  }
+
+  // MARK: - Focus counting
+
+  @Test func incompleteFocusSessionExcludedFromCount() {
+    let partial = makeSession(wasCompleted: false)
+    let summary = SessionSummary(sessions: [partial], over: Self.todayInterval)
+    #expect(summary.focusCount == 0)
+    #expect(summary.focusSeconds == 0)
+  }
+
+  @Test func focusSecondsAccumulatesCompletedDurations() {
+    let first = makeSession(duration: 1_500)
+    let second = makeSession(duration: 900)
+    let summary = SessionSummary(sessions: [first, second], over: Self.todayInterval)
+    #expect(summary.focusSeconds == 2_400)
+    #expect(summary.focusMinutes == 40)
+  }
+
+  // MARK: - Break counting
+
+  @Test func shortBreakCountedAsBreak() {
+    let session = makeSession(phase: .shortBreak)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.breakCount == 1)
+  }
+
+  @Test func longBreakCountedAsBreakAndCycle() {
+    let session = makeSession(phase: .longBreak)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.breakCount == 1)
+    #expect(summary.cycleCount == 1)
+  }
+
+  @Test func shortBreakDoesNotIncrementCycleCount() {
+    let session = makeSession(phase: .shortBreak)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.cycleCount == 0)
+  }
+
+  @Test func incompleteLongBreakExcludedFromCycleCount() {
+    let session = makeSession(phase: .longBreak, wasCompleted: false)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.cycleCount == 0)
+  }
+
+  // MARK: - Task breakdown
+
+  @Test func untrackedSessionAppearsAsUntracked() {
+    let session = makeSession(taskRef: nil, taskTitle: nil)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.taskBreakdown.count == 1)
+    #expect(summary.taskBreakdown.first?.label == "Untracked")
+  }
+
+  @Test func sessionWithTitleUsesStoredTitle() {
+    let ref = TaskRef(providerID: "local", nativeID: "abc")
+    let session = makeSession(taskRef: ref, taskTitle: "Design Review")
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.taskBreakdown.first?.label == "Design Review")
+  }
+
+  @Test func sessionWithRefButNoTitleFallsBackToUnknown() {
+    let ref = TaskRef(providerID: "local", nativeID: "abc")
+    let session = makeSession(taskRef: ref, taskTitle: nil)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.taskBreakdown.first?.label == "Unknown Task")
+  }
+
+  @Test func sessionsForSameTaskAreGrouped() {
+    let ref = TaskRef(providerID: "local", nativeID: "abc")
+    let first = makeSession(duration: 1_500, taskRef: ref, taskTitle: "Design Review")
+    let second = makeSession(duration: 900, taskRef: ref, taskTitle: "Design Review")
+    let summary = SessionSummary(sessions: [first, second], over: Self.todayInterval)
+    #expect(summary.taskBreakdown.count == 1)
+    #expect(summary.taskBreakdown.first?.seconds == 2_400)
+  }
+
+  @Test func breakdownSortedByDurationDescending() {
+    let refA = TaskRef(providerID: "local", nativeID: "a")
+    let refB = TaskRef(providerID: "local", nativeID: "b")
+    let short = makeSession(duration: 600, taskRef: refA, taskTitle: "Short")
+    let long = makeSession(duration: 1_500, taskRef: refB, taskTitle: "Long")
+    let summary = SessionSummary(sessions: [short, long], over: Self.todayInterval)
+    #expect(summary.taskBreakdown.first?.label == "Long")
+    #expect(summary.taskBreakdown.last?.label == "Short")
+  }
+
+  @Test func breakSessionsExcludedFromTaskBreakdown() {
+    let session = makeSession(phase: .shortBreak)
+    let summary = SessionSummary(sessions: [session], over: Self.todayInterval)
+    #expect(summary.taskBreakdown.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

- **P0:** Adds `completedTasks() async throws -> [TaskItem]` to `MutableTaskProvider` with a default `[]` implementation so any mutable provider can opt in to surfacing completed tasks without breaking existing conformances.
- **P1:** Implements `LocalProvider` — a JSON-backed built-in task provider with full list management, inline task creation, and soft-delete. Tasks always belong to a list; a "Default" list is created automatically and is guaranteed to exist at all times.
- **P6:** Introduces `SessionSummary` (pure value type over the session log), a rewritten `StatsTabView` with today/this-week scope, a 2×2 stat grid, and a per-task donut chart. The compact popover's session stats row is now a button that navigates to the Stats tab.

## Linked issue

Closes #279
Closes #269

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**LocalProvider** (`app/Taskmato/Tasks/Local/`)
- `LocalList`, `LocalTask`, `TaskDraft` — Codable model types
- `LocalProvider` — `@Observable @MainActor` class; persists to `~/Library/Application Support/Taskmato/local-tasks.json`; `observe()` returns `nil` because `@Observable` propagates changes directly to SwiftUI
- `load()` guarantees at least one list: creates "Default" on first run and reassigns any legacy `nil`-listID tasks (backward-compat shim for pre-list-enforcement data)
- `deleteList()` auto-creates "Default" and moves orphaned tasks to it when the last list is deleted
- `completedTasks()` returns soft-deleted tasks sorted by `completedAt` descending

**Add-task UI** (`AddTaskView`, `TasksTabView`, `LocalSettingsView`, `SettingsView`)
- `AddTaskView` always shows the list picker with no Uncategorized option; pre-selects the first list on appear; "Add Task" button is disabled when the title is empty
- `LocalSettingsView` provides inline rename (TextField + onSubmit/blur), create, and delete; trash button is disabled when only one list remains
- Local provider settings are now nested under the Local toggle in `SettingsView`, matching the Obsidian provider pattern
- `TasksTabView` shows a "+" toolbar button only when `LocalProvider` is enabled; refreshes task list on sheet dismissal

**Stats** (`SessionSummary`, `StatsTabView`, `TimerView`)
- `Session.taskTitle: String?` stamped at phase-end so stats survive task rename/deletion (nil for old JSON records → renders as "Untracked")
- `SessionSummary` computes focusCount, focusSeconds, breakCount, cycleCount (1 completed long break = 1 cycle), and `[TaskSlice]` keyed by task title
- `SessionStore.summary(for:)`, `todaySummary()`, `thisWeekSummary()` convenience methods
- `StatsTabView` uses Swift Charts `SectorMark` with `chartForegroundStyleScale(domain:range:)` for consistent color across chart and legend
- Popover session stats row is now a `Button` using `openWindow(id: "main")` + `showStatsTab` notification, closing the popover — same pattern as "Browse Tasks…"

**TODO housekeeping** (`TODO.md`)
- All P1 items marked complete; P0 `completedTasks()` item marked complete
- P3/P4/P6 shipped work marked; "Already shipped" section renamed "General foundations" with P-specific items moved into their phase blocks
- New issues linked: #298 (two-level picker grouping), #299 (list/grid toggle), #300 ("View Completed" sheet), #301 (`ObsidianProvider.completedTasks()`)
- Mid-session task swap corrected to #296; #261/#269/#279 flagged as implemented but GH issues still open

## Validation

- [x] Built the app locally
- [x] Unit tests pass locally
- [ ] UI tests pass locally, if applicable
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [x] Documentation updated where appropriate

## Reviewer notes

**Issues that need to be closed separately on GitHub (work was done in prior PRs or this branch but the issues were left open):**
- #261 — Obsidian vault bookmark (implemented in #297)
- #279 — LocalProvider (closed by this PR)
- #269 — StatsView from popover (closed by this PR; the implementation navigates to the main window Stats tab rather than a sheet as originally described — functionally equivalent and avoids duplicating the stats surface)

**P6 remaining work not in this PR:** 7-day stacked chart, all-time table, and popover streak header (#268 sub-tasks, #270, #271) are explicitly tracked and left as `[ ]` in the TODO.