### PR TITLE
Task-session state coupling: swap, guard start, confirm clear/complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,7 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 - [ ] List and grid view toggle for the task picker (list = current row layout, grid = card layout) ([#299](https://github.com/richwklein/taskmato/issues/299))
 - [ ] "View Completed" sheet in picker for any enabled `MutableTaskProvider`; calls `completedTasks()` with restore (`reopen`) and permanent-delete affordances ([#300](https://github.com/richwklein/taskmato/issues/300))
 - [x] Active task label in popover and main window timer tab: provider-conditional complete (checkmark) button, always-visible clear button, hidden when no task active ([#258](https://github.com/richwklein/taskmato/issues/258))
-- [ ] Mid-session task swap (does not stop the timer) ([#296](https://github.com/richwklein/taskmato/issues/296))
+- [x] Mid-session task swap (does not stop the timer) ([#296](https://github.com/richwklein/taskmato/issues/296))
 - [ ] Honor priority and due-date hints in the picker (sort and badge) ([#257](https://github.com/richwklein/taskmato/issues/257))
 - [ ] Always-on-top mode for the timer popover (detached floating window, toggle in popover header, persisted setting) ([#260](https://github.com/richwklein/taskmato/issues/260))
 - [ ] Per-provider list scoping (choose which lists each provider exposes in the picker; persisted per provider) ([#276](https://github.com/richwklein/taskmato/issues/276))

--- a/app/Taskmato/ActiveTaskView.swift
+++ b/app/Taskmato/ActiveTaskView.swift
@@ -7,8 +7,9 @@ import SwiftUI
 
 /// A label row displaying the currently selected task with provider-conditional action buttons.
 ///
-/// Hidden entirely when no task is selected. The clear and complete buttons are disabled
-/// while a session is running so the active task cannot be changed mid-session.
+/// Hidden when no task is selected. Clearing or completing mid-session shows a confirmation
+/// that stops the timer and routes to the task picker. A swap button (active-session only)
+/// pauses the timer and opens the task picker without stopping the session.
 @MainActor
 struct ActiveTaskView: View {
 
@@ -18,7 +19,11 @@ struct ActiveTaskView: View {
   /// When `true`, renders task notes and source link below the title.
   var showNotes: Bool = false
 
+  @Environment(\.openWindow) private var openWindow
+
   @State private var isCompletionHovered: Bool = false
+  @State private var confirmClear: Bool = false
+  @State private var confirmComplete: Bool = false
 
   private var sessionIsActive: Bool { engine.state != .idle }
 
@@ -46,19 +51,72 @@ struct ActiveTaskView: View {
           }
         }
 
+        if sessionIsActive {
+          Button {
+            if engine.isRunning { engine.pause() }
+            NSApp.activate(ignoringOtherApps: true)
+            openWindow(id: "main")
+            NotificationCenter.default.post(name: .showTasksTab, object: nil)
+          } label: {
+            Image(systemName: "arrow.triangle.swap")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+          }
+          .buttonStyle(.plain)
+          .help("Swap task — pauses the session and opens the task list")
+        }
+
         Button {
-          selectionStore.clearActiveTask()
+          if sessionIsActive {
+            confirmClear = true
+          } else {
+            selectionStore.clearActiveTask()
+          }
         } label: {
           Image(systemName: "xmark")
             .font(.caption2)
             .foregroundStyle(.secondary)
         }
         .buttonStyle(.plain)
-        .disabled(sessionIsActive)
-        .help(sessionIsActive ? "Cannot clear task during an active session" : "Clear task")
+        .help("Clear task")
+        .confirmationDialog(
+          "End the current session?",
+          isPresented: $confirmClear,
+          titleVisibility: .visible
+        ) {
+          Button("Stop & Clear", role: .destructive) {
+            engine.stop()
+            selectionStore.clearActiveTask()
+            NotificationCenter.default.post(name: .showTasksTab, object: nil)
+          }
+          Button("Cancel", role: .cancel) {}
+        } message: {
+          Text("Clearing the task will stop the timer.")
+        }
       }
       .padding(.horizontal, 16)
       .padding(.vertical, 8)
+      .confirmationDialog(
+        "End the current session?",
+        isPresented: $confirmComplete,
+        titleVisibility: .visible
+      ) {
+        Button("Stop & Complete", role: .destructive) {
+          guard let task = selectionStore.activeTask,
+            let provider = registry.mutableProvider(for: task.id)
+          else { return }
+          let ref = task.id
+          engine.stop()
+          Task {
+            try? await provider.complete(ref)
+            selectionStore.clearActiveTask()
+            NotificationCenter.default.post(name: .showTasksTab, object: nil)
+          }
+        }
+        Button("Cancel", role: .cancel) {}
+      } message: {
+        Text("Completing the task will stop the timer and mark it done.")
+      }
     }
   }
 
@@ -101,10 +159,14 @@ struct ActiveTaskView: View {
   private func leadingIndicator(for task: TaskItem) -> some View {
     if let provider = registry.mutableProvider(for: task.id) {
       Button {
-        let ref = task.id
-        Task {
-          try? await provider.complete(ref)
-          selectionStore.clearActiveTask()
+        if sessionIsActive {
+          confirmComplete = true
+        } else {
+          let ref = task.id
+          Task {
+            try? await provider.complete(ref)
+            selectionStore.clearActiveTask()
+          }
         }
       } label: {
         Image(systemName: isCompletionHovered ? "checkmark.circle" : "circle")
@@ -112,9 +174,8 @@ struct ActiveTaskView: View {
           .foregroundStyle(Color.accentColor)
       }
       .buttonStyle(.plain)
-      .disabled(sessionIsActive)
-      .onHover { isCompletionHovered = $0 && !sessionIsActive }
-      .help(sessionIsActive ? "Cannot complete task during an active session" : "Mark done")
+      .onHover { isCompletionHovered = $0 }
+      .help(sessionIsActive ? "Complete task (will stop timer)" : "Mark done")
     } else {
       Image(systemName: "circle.fill")
         .font(.caption2)

--- a/app/Taskmato/AppNotifications.swift
+++ b/app/Taskmato/AppNotifications.swift
@@ -15,4 +15,11 @@ extension Notification.Name {
   ///
   /// `MainWindowView` listens for this and switches to the Stats tab.
   static let showStatsTab = Notification.Name("Taskmato.showStatsTab")
+
+  /// Posted when a task is selected programmatically (URL handler, disambiguation) so the main
+  /// window switches to the Timer tab and surfaces the selected task.
+  static let showTimerTab = Notification.Name("Taskmato.showTimerTab")
+
+  /// Posted by the URL handler to request that the main window be opened and brought to front.
+  static let openMainWindow = Notification.Name("Taskmato.openMainWindow")
 }

--- a/app/Taskmato/MainWindow/MainWindowView.swift
+++ b/app/Taskmato/MainWindow/MainWindowView.swift
@@ -47,6 +47,9 @@ struct MainWindowView: View {
       }
     }
     .frame(minWidth: 480, minHeight: 400)
+    .onReceive(NotificationCenter.default.publisher(for: .showTimerTab)) { _ in
+      selectedTab = 0
+    }
     .onReceive(NotificationCenter.default.publisher(for: .showTasksTab)) { _ in
       selectedTab = 1
     }

--- a/app/Taskmato/MainWindow/TimerTabView.swift
+++ b/app/Taskmato/MainWindow/TimerTabView.swift
@@ -75,6 +75,8 @@ struct TimerTabView: View {
         ControlButton(label: "Resume", icon: "play.fill") { engine.resume() }
       } else {
         ControlButton(label: "Start", icon: "play.fill") { startSession() }
+          .disabled(selectionStore.activeTask == nil)
+          .help(selectionStore.activeTask == nil ? "Select a task before starting" : "")
       }
 
       ControlButton(label: "Skip", icon: "forward.fill") { skipPhase() }

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -159,6 +159,7 @@ struct TaskmatoApp: App {
           Button(task.title) {
             selectionStore.select(task)
             urlHandler.pendingDisambiguation = nil
+            NotificationCenter.default.post(name: .showTimerTab, object: nil)
           }
         }
         if let params = urlHandler.pendingAdHocParams {
@@ -166,6 +167,7 @@ struct TaskmatoApp: App {
             let task = urlHandler.makeAdHocTask(from: params)
             selectionStore.select(task)
             urlHandler.pendingDisambiguation = nil
+            NotificationCenter.default.post(name: .showTimerTab, object: nil)
           }
         }
         Button("Cancel", role: .cancel) {

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -18,7 +18,8 @@ struct AdHocTaskParams {
   let listName: String?
 }
 
-/// Parses and dispatches `taskmato://` deep links to select a task and optionally start a session.
+/// Parses and dispatches `taskmato://` deep links to select a task and, when auto-start is
+/// enabled, start a focus session.
 ///
 /// Resolution precedence for `taskmato://start`:
 /// 1. `provider` + `id` — exact native-ID lookup within the named provider
@@ -59,7 +60,8 @@ final class URLSchemeHandler {
     self.localProvider = localProvider
   }
 
-  /// Handles the given URL, selecting the resolved task and starting a focus session if idle.
+  /// Handles the given URL, selecting the resolved task and starting a focus session if
+  /// the engine is idle and auto-start is enabled.
   func handle(_ url: URL) async {
     guard url.scheme?.lowercased() == "taskmato",
       url.host?.lowercased() == "start",
@@ -70,7 +72,9 @@ final class URLSchemeHandler {
     guard let task = await resolve(params: params) else { return }
 
     selectionStore.select(task)
-    if case .idle = engine.state {
+    NotificationCenter.default.post(name: .openMainWindow, object: nil)
+    NotificationCenter.default.post(name: .showTimerTab, object: nil)
+    if case .idle = engine.state, settings.autoStartNextPhase {
       engine.focusDuration = settings.focusDuration
       engine.shortBreakDuration = settings.shortBreakDuration
       engine.longBreakDuration = settings.longBreakDuration

--- a/app/Taskmato/TimerView.swift
+++ b/app/Taskmato/TimerView.swift
@@ -107,6 +107,10 @@ struct TimerView: View {
       .padding(.vertical, 10)
     }
     .frame(width: 280)
+    .onReceive(NotificationCenter.default.publisher(for: .openMainWindow)) { _ in
+      NSApp.activate(ignoringOtherApps: true)
+      openWindow(id: "main")
+    }
   }
 
   // MARK: - Controls
@@ -119,6 +123,8 @@ struct TimerView: View {
         ControlButton(label: "Resume", icon: "play.fill") { engine.resume() }
       } else {
         ControlButton(label: "Start", icon: "play.fill") { startSession() }
+          .disabled(selectionStore.activeTask == nil)
+          .help(selectionStore.activeTask == nil ? "Select a task before starting" : "")
       }
 
       ControlButton(label: "Skip", icon: "forward.fill") { skipPhase() }


### PR DESCRIPTION
## Summary

Tightens the coupling between task selection and session state to make task selection the explicit anchor of every session. Previously the timer could run with no task selected, URL deep links always force-started a focus session regardless of the auto-start setting, and there was no way to swap tasks mid-session without stopping the timer.

## Linked issue

Closes #296

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

Six behaviours changed:

1. **Start guarded by task selection** — the Start button is disabled in both the popover and the main window Timer tab when no task is active. A tooltip explains why.

2. **URL handler respects `autoStartNextPhase`** — `taskmato://start` previously always started a focus session if the engine was idle. It now only auto-starts when the `autoStartNextPhase` setting is on, matching the behaviour at phase boundaries.

3. **URL deep links surface the Timer tab** — after a URL resolves a task (including disambiguation picks), the main window is opened/focused and switched to the Timer tab via two new `NotificationCenter` names: `.openMainWindow` and `.showTimerTab`.

4. **Swap button (mid-session only)** — a new `arrow.triangle.swap` button appears on `ActiveTaskView` while a session is active or paused. Tapping it pauses the timer (if running) and opens the main window on the Tasks tab so the user can pick a different task without losing the session.

5. **Complete task mid-session** — previously blocked. Now allowed with a confirmation dialog ("Stop & Complete") that stops the timer, marks the task done in its provider, and routes to the task picker.

6. **Clear task mid-session** — previously blocked. Now allowed with a confirmation dialog ("Stop & Clear") that stops the timer, clears the active task, and routes to the task picker.

Partial sessions logged on confirmed stop/clear/complete are recorded by the existing `onPhaseEnded(wasCompleted: false)` path — no session data is lost.

Reviewers: the main changes are in `ActiveTaskView.swift` (swap button + confirmation dialogs) and `URLSchemeHandler.swift` (auto-start guard + window routing). The two new notification names in `AppNotifications.swift` are the routing primitive used across both contexts.

## Validation

- [x] Built the app locally
- [x] Unit tests pass locally
- [ ] UI tests pass locally, if applicable
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

- The swap button only appears when `sessionIsActive` (running or paused), so it is invisible at idle — users can navigate to Tasks normally without it.
- `ActiveTaskView` now uses `@Environment(\.openWindow)` to open the main window from a swap; this works from both the popover and the main window tab (calling `openWindow` on an already-open window just focuses it).
- The `onHover` on the complete button no longer gates on `!sessionIsActive` — hover now works freely; the session guard is handled by the confirmation flow instead.
- Follow-up: unit tests for the URL handler's auto-start branches would be a good addition (tracked separately).