### PR TITLE
feat(release): use GitHub App token so release PRs trigger checks

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,7 +11,14 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Mirrors [richwklein/repo-template-astro#14](https://github.com/richwklein/repo-template-astro/pull/14). Switches release-please from default `GITHUB_TOKEN` to a GitHub App-issued token so release PRs trigger downstream `pull_request` workflows normally.

## Type of change

- [x] Feature

## Details

Adds `actions/create-github-app-token@v1` step before release-please. Token generated at runtime from secrets `RELEASE_BOT_APP_ID` and `RELEASE_BOT_PRIVATE_KEY` (already in place).

## Release / deploy impact

- [x] Safe to label `no-deploy`

## Validation

- [x] Workflow YAML valid