### PR TITLE
fix(release): add v prefix to release-please tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.0.0-alpha.14](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.13...1.0.0-alpha.14) (2025-10-08)
+## [1.0.0-alpha.14](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.13...v1.0.0-alpha.14) (2025-10-08)
 
 ### Bug Fixes
 
@@ -10,25 +10,25 @@
 
 - another WIP ([#196](https://github.com/richwklein/taskmato/pull/196)) ([bc99d53](https://github.com/richwklein/taskmato/commit/bc99d53))
 
-## [1.0.0-alpha.13](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.12...1.0.0-alpha.13) (2025-10-07)
+## [1.0.0-alpha.13](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.12...v1.0.0-alpha.13) (2025-10-07)
 
 ### Miscellaneous Changes
 
 - change dependabot interval and ignore patch versions ([#194](https://github.com/richwklein/taskmato/pull/194)) ([9b4dbfd](https://github.com/richwklein/taskmato/commit/9b4dbfd))
 
-## [1.0.0-alpha.12](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.11...1.0.0-alpha.12) (2025-09-18)
+## [1.0.0-alpha.12](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.11...v1.0.0-alpha.12) (2025-09-18)
 
 ### Miscellaneous Changes
 
 - dependency update ([#170](https://github.com/richwklein/taskmato/pull/170)) ([3ccfe19](https://github.com/richwklein/taskmato/commit/3ccfe19))
 
-## [1.0.0-alpha.11](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.10...1.0.0-alpha.11) (2025-09-16)
+## [1.0.0-alpha.11](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.10...v1.0.0-alpha.11) (2025-09-16)
 
 ### Miscellaneous Changes
 
 - update to more recent dependencies ([#162](https://github.com/richwklein/taskmato/pull/162)) ([f2276ff](https://github.com/richwklein/taskmato/commit/f2276ff))
 
-## [1.0.0-alpha.10](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.9...1.0.0-alpha.10) (2025-08-20)
+## [1.0.0-alpha.10](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.9...v1.0.0-alpha.10) (2025-08-20)
 
 ### Miscellaneous Changes
 
@@ -37,7 +37,7 @@
 - dependency upgrades ([#103](https://github.com/richwklein/taskmato/pull/103)) ([d20c472](https://github.com/richwklein/taskmato/commit/d20c472))
 - bump dependency versions ([#75](https://github.com/richwklein/taskmato/pull/75)) ([1fc2c69](https://github.com/richwklein/taskmato/commit/1fc2c69))
 
-## [1.0.0-alpha.9](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.8...1.0.0-alpha.9) (2025-06-07)
+## [1.0.0-alpha.9](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.8...v1.0.0-alpha.9) (2025-06-07)
 
 ### Bug Fixes
 
@@ -49,7 +49,7 @@
 - bump the vitest group with 2 updates ([#22](https://github.com/richwklein/taskmato/pull/22)) ([e56ef2f](https://github.com/richwklein/taskmato/commit/e56ef2f))
 - bump netlify-cli from 21.4.0 to 21.4.1 ([#17](https://github.com/richwklein/taskmato/pull/17)) ([60c42d0](https://github.com/richwklein/taskmato/commit/60c42d0))
 
-## [1.0.0-alpha.8](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.7...1.0.0-alpha.8) (2025-05-15)
+## [1.0.0-alpha.8](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.7...v1.0.0-alpha.8) (2025-05-15)
 
 ### Miscellaneous Changes
 
@@ -58,32 +58,32 @@
 - bump mui-markdown from 1.2.6 to 2.0.1 ([#13](https://github.com/richwklein/taskmato/pull/13)) ([5c17f76](https://github.com/richwklein/taskmato/commit/5c17f76))
 - bump the mui group with 2 updates ([#11](https://github.com/richwklein/taskmato/pull/11)) ([6478e2f](https://github.com/richwklein/taskmato/commit/6478e2f))
 
-## [1.0.0-alpha.7](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.6...1.0.0-alpha.7) (2025-05-14)
+## [1.0.0-alpha.7](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.6...v1.0.0-alpha.7) (2025-05-14)
 
 ### Miscellaneous Changes
 
 - make sure tools are setup ([d94700f](https://github.com/richwklein/taskmato/commit/d94700f))
 
-## [1.0.0-alpha.6](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.5...1.0.0-alpha.6) (2025-05-14)
+## [1.0.0-alpha.6](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.5...v1.0.0-alpha.6) (2025-05-14)
 
 ### Miscellaneous Changes
 
 - spawn jobs ([68fe8b6](https://github.com/richwklein/taskmato/commit/68fe8b6))
 
-## [1.0.0-alpha.5](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.4...1.0.0-alpha.5) (2025-05-14)
+## [1.0.0-alpha.5](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.4...v1.0.0-alpha.5) (2025-05-14)
 
 ### Miscellaneous Changes
 
 - supply upload credentials ([c27e305](https://github.com/richwklein/taskmato/commit/c27e305))
 
-## [1.0.0-alpha.4](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.3...1.0.0-alpha.4) (2025-05-14)
+## [1.0.0-alpha.4](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.3...v1.0.0-alpha.4) (2025-05-14)
 
 ### Miscellaneous Changes
 
 - only run if released ([be13aba](https://github.com/richwklein/taskmato/commit/be13aba))
 - move deploy into the tag workflow ([eae6b6c](https://github.com/richwklein/taskmato/commit/eae6b6c))
 
-## [1.0.0-alpha.3](https://github.com/richwklein/taskmato/compare/1.0.0-alpha.2...1.0.0-alpha.3) (2025-05-14)
+## [1.0.0-alpha.3](https://github.com/richwklein/taskmato/compare/v1.0.0-alpha.2...v1.0.0-alpha.3) (2025-05-14)
 
 ### Features
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
       "release-type": "simple",
       "package-name": "taskmato",
       "changelog-path": "CHANGELOG.md",
-      "include-v-in-tag": false,
+      "include-v-in-tag": true,
       "include-component-in-tag": false,
       "bump-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
## Summary

- Changes `include-v-in-tag` from `false` to `true` in `release-please-config.json`
- Updates all CHANGELOG compare links to match the renamed `v1.0.0-alpha.*` tags

## Why

Aligns `taskmato` with the canonical `v{version}` tag format used across all projects. All 13 historical alpha tags have been renamed from `1.0.0-alpha.X` to `v1.0.0-alpha.X`.

## Note on release assets

`taskmato` has immutable releases enabled. The 9 historical releases that previously had assets were recreated without assets — once a release is published with immutable releases on, assets cannot be uploaded after the fact. The git tags and release notes are intact; only the attached tarballs are absent from the historical records.