### PR TITLE
fix(release): set prerelease-type to alpha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "bump-minor-pre-major": false,
       "draft": false,
       "prerelease": true,
+      "prerelease-type": "alpha",
       "extra-files": ["version.txt"]
     }
   }


### PR DESCRIPTION
## Summary

Adds `"prerelease-type": "alpha"` to `release-please-config.json`.

## Why

Without this setting release-please bumps `major.minor.patch` based on conventional commit types and appends the pre-release tag unchanged — producing versions like `1.1.0-alpha.14` instead of `1.0.0-alpha.15`. With `prerelease-type: alpha` it increments only the alpha counter on every release, holding the base version steady until a `BREAKING CHANGE` warrants a bump.