### PR TITLE
feat(picker): list/grid view toggle with card grid and flat section headers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 - [x] Main window with Timer, Tasks, and Stats tabs (TabView navigation skeleton) ([#294](https://github.com/richwklein/taskmato/issues/294))
 - [x] Task picker view in main window Tasks tab (search across providers, grouped by list) ([#257](https://github.com/richwklein/taskmato/issues/257) partial — provider section headers and priority badges remain)
 - [ ] Two-level picker grouping when multiple providers active: provider section header → list → tasks; "+" add-task button in local provider section header ([#298](https://github.com/richwklein/taskmato/issues/298))
-- [ ] List and grid view toggle for the task picker (list = current row layout, grid = card layout) ([#299](https://github.com/richwklein/taskmato/issues/299))
+- [x] List and grid view toggle for the task picker (list = current row layout, grid = card layout) ([#299](https://github.com/richwklein/taskmato/issues/299))
 - [ ] "View Completed" sheet in picker for any enabled `MutableTaskProvider`; calls `completedTasks()` with restore (`reopen`) and permanent-delete affordances ([#300](https://github.com/richwklein/taskmato/issues/300))
 - [x] Active task label in popover and main window timer tab: provider-conditional complete (checkmark) button, always-visible clear button, hidden when no task active ([#258](https://github.com/richwklein/taskmato/issues/258))
 - [x] Mid-session task swap (does not stop the timer) ([#296](https://github.com/richwklein/taskmato/issues/296))
@@ -62,6 +62,7 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 - [ ] FSEvents-based live updates with debouncing ([#263](https://github.com/richwklein/taskmato/issues/263))
 - [x] `MutableTaskProvider.complete` rewrites `- [ ]` → `- [x]` and appends `✅ <today>` ([#263](https://github.com/richwklein/taskmato/issues/263))
 - [ ] Implement `completedTasks()` for `ObsidianProvider` (scans vault for `- [x]` tasks) ([#301](https://github.com/richwklein/taskmato/issues/301))
+- [ ] Restore dynamic date token expansion in `ObsidianProvider` file patterns (`{year}`, `{week}`, `{month}`, `{day}` → current date values) so patterns like `**/Weekly/{year}-W{week}.md` resolve to real file paths
 
 ## CLI / URL scheme provider (P5)
 

--- a/app/Taskmato/MainWindow/MainWindowView.swift
+++ b/app/Taskmato/MainWindow/MainWindowView.swift
@@ -17,7 +17,6 @@ struct MainWindowView: View {
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
 
-  @Environment(\.openSettings) private var openSettings
   @State private var selectedTab: Int = 0
 
   var body: some View {
@@ -38,7 +37,8 @@ struct MainWindowView: View {
         TasksTabView(
           selectionStore: selectionStore,
           registry: registry,
-          selectedTab: $selectedTab
+          selectedTab: $selectedTab,
+          settings: settings
         )
       }
 
@@ -55,16 +55,6 @@ struct MainWindowView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .showStatsTab)) { _ in
       selectedTab = 2
-    }
-    .toolbar {
-      ToolbarItem(placement: .automatic) {
-        Button {
-          openSettings()
-        } label: {
-          Label("Settings", systemImage: "gearshape")
-        }
-        .help("Open Settings (⌘,)")
-      }
     }
   }
 }

--- a/app/Taskmato/MainWindow/StatsTabView.swift
+++ b/app/Taskmato/MainWindow/StatsTabView.swift
@@ -15,6 +15,7 @@ struct StatsTabView: View {
   var store: SessionStore
 
   @State private var scope: StatScope = .today
+  @Environment(\.openSettings) private var openSettings
 
   var body: some View {
     VStack(spacing: 0) {
@@ -37,6 +38,16 @@ struct StatsTabView: View {
           }
           .padding()
         }
+      }
+    }
+    .toolbar {
+      ToolbarItem(placement: .automatic) {
+        Button {
+          openSettings()
+        } label: {
+          Label("Settings", systemImage: "gearshape")
+        }
+        .help("Open Settings (⌘,)")
       }
     }
   }

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -5,20 +5,24 @@
 
 import SwiftUI
 
-/// The task picker tab, showing tasks grouped by list and section with live search.
+/// The task picker tab, showing tasks grouped into sections with live search.
 ///
 /// Selecting a task sets it as the active task and switches to the Timer tab.
-/// Each list group is collapsible via a `DisclosureGroup` with a document icon.
+/// Section headers are formatted as "List: Section" when multiple lists are active,
+/// or just "Section" when only one list is active. Supports toggling between a list
+/// and an adaptive card grid layout.
 struct TasksTabView: View {
 
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   @Binding var selectedTab: Int
+  @Bindable var settings: AppSettings
+
+  @Environment(\.openSettings) private var openSettings
 
   @State private var query: String = ""
   @State private var groupedLists: [TaskGroup] = []
   @State private var isLoading: Bool = false
-  @State private var expandedGroups: [String: Bool] = [:]
   @State private var isAddingTask = false
 
   /// The local provider instance looked up from the registry, if registered.
@@ -29,6 +33,29 @@ struct TasksTabView: View {
   /// `true` when the local provider is registered and currently enabled.
   private var localProviderEnabled: Bool {
     localProvider.map { registry.isEnabled($0.id) } ?? false
+  }
+
+  /// Flat display sections derived from `groupedLists`.
+  ///
+  /// Header labels collapse list and section names following these rules:
+  /// - Multiple lists + has section → "List: Section"
+  /// - Multiple lists + no section → "List"
+  /// - Single list + has section → "Section"
+  /// - Single list + no section → "List"
+  private var flatSections: [FlatSection] {
+    let multipleGroups = groupedLists.count > 1
+    return groupedLists.flatMap { group in
+      group.sections.map { section in
+        let header: String
+        switch (multipleGroups, section.name) {
+        case (true, let name?): header = "\(group.listName): \(name)"
+        case (true, nil): header = group.listName
+        case (false, let name?): header = name
+        case (false, nil): header = group.listName
+        }
+        return FlatSection(id: "\(group.id).\(section.id)", header: header, tasks: section.tasks)
+      }
+    }
   }
 
   var body: some View {
@@ -52,6 +79,8 @@ struct TasksTabView: View {
               : "No tasks match \"\(query)\"."
           )
         )
+      } else if settings.taskPickerLayout == .grid {
+        taskGrid
       } else {
         taskList
       }
@@ -78,33 +107,44 @@ struct TasksTabView: View {
           .help("Add a local task")
         }
       }
+
+      ToolbarItem(placement: .automatic) {
+        Picker("Layout", selection: $settings.taskPickerLayout) {
+          Label("List", systemImage: "list.bullet").tag(TaskPickerLayout.list)
+          Label("Grid", systemImage: "square.grid.2x2").tag(TaskPickerLayout.grid)
+        }
+        .pickerStyle(.segmented)
+        .help("Toggle between list and grid view")
+      }
+
+      ToolbarItem(placement: .automatic) {
+        Button {
+          openSettings()
+        } label: {
+          Label("Settings", systemImage: "gearshape")
+        }
+        .help("Open Settings (⌘,)")
+      }
     }
   }
 
-  // MARK: - Task list
+  // MARK: - List layout
 
   private var taskList: some View {
     List {
-      ForEach(groupedLists) { group in
-        DisclosureGroup(
-          isExpanded: groupExpansion(for: group.id)
-        ) {
-          ForEach(group.sections) { section in
-            if let sectionName = section.name {
-              sectionSeparator(sectionName)
-            }
-            ForEach(section.tasks) { task in
-              TaskRowView(
-                task: task,
-                onComplete: registry.mutableProvider(for: task.id) != nil
-                  ? { handleComplete(task) }
-                  : nil
-              )
-              .onTapGesture { select(task) }
-            }
+      ForEach(flatSections) { section in
+        Section {
+          ForEach(section.tasks) { task in
+            TaskRowView(
+              task: task,
+              onComplete: registry.mutableProvider(for: task.id) != nil
+                ? { handleComplete(task) }
+                : nil
+            )
+            .onTapGesture { select(task) }
           }
-        } label: {
-          Label(group.listName, systemImage: "doc.text")
+        } header: {
+          Text(section.header)
             .font(.subheadline)
             .fontWeight(.semibold)
         }
@@ -112,23 +152,35 @@ struct TasksTabView: View {
     }
   }
 
-  /// A non-interactive visual separator row showing the section heading.
-  @ViewBuilder
-  private func sectionSeparator(_ name: String) -> some View {
-    Text(name)
-      .font(.caption2)
-      .foregroundStyle(.secondary)
-      .textCase(.uppercase)
-      .listRowBackground(Color.clear)
-      .padding(.top, 4)
-  }
+  // MARK: - Grid layout
 
-  /// Returns a stable ``Binding`` for the expanded state of the given group.
-  private func groupExpansion(for id: String) -> Binding<Bool> {
-    Binding(
-      get: { expandedGroups[id] ?? true },
-      set: { expandedGroups[id] = $0 }
-    )
+  private var taskGrid: some View {
+    let columns = [GridItem(.adaptive(minimum: 180), spacing: 10)]
+    return ScrollView {
+      LazyVGrid(columns: columns, spacing: 10) {
+        ForEach(flatSections) { section in
+          Section {
+            ForEach(section.tasks) { task in
+              TaskCardView(
+                task: task,
+                onComplete: registry.mutableProvider(for: task.id) != nil
+                  ? { handleComplete(task) }
+                  : nil
+              )
+              .onTapGesture { select(task) }
+            }
+          } header: {
+            Text(section.header)
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.top, 4)
+              .padding(.bottom, 2)
+          }
+        }
+      }
+      .padding(10)
+    }
   }
 
   // MARK: - Data loading
@@ -211,10 +263,18 @@ private struct TaskSection: Identifiable {
   let tasks: [TaskItem]
 }
 
+/// A flattened display section with a computed header label and its tasks.
+private struct FlatSection: Identifiable {
+  let id: String
+  let header: String
+  let tasks: [TaskItem]
+}
+
 #Preview {
   TasksTabView(
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
-    selectedTab: .constant(1)
+    selectedTab: .constant(1),
+    settings: AppSettings()
   )
 }

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -134,7 +134,7 @@ struct TasksTabView: View {
     List {
       ForEach(flatSections) { section in
         Section {
-          ForEach(section.tasks) { task in
+          SwiftUI.ForEach(section.tasks) { task in
             TaskRowView(
               task: task,
               onComplete: registry.mutableProvider(for: task.id) != nil
@@ -160,7 +160,7 @@ struct TasksTabView: View {
       LazyVGrid(columns: columns, spacing: 10) {
         ForEach(flatSections) { section in
           Section {
-            ForEach(section.tasks) { task in
+            SwiftUI.ForEach(section.tasks) { task in
               TaskCardView(
                 task: task,
                 onComplete: registry.mutableProvider(for: task.id) != nil

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -132,23 +132,28 @@ struct TasksTabView: View {
 
   private var taskList: some View {
     List {
-      ForEach(flatSections) { section in
-        SwiftUI.Section {
-          SwiftUI.ForEach(section.tasks) { task in
-            TaskRowView(
-              task: task,
-              onComplete: registry.mutableProvider(for: task.id) != nil
-                ? { handleComplete(task) }
-                : nil
-            )
-            .onTapGesture { select(task) }
-          }
-        } header: {
-          Text(section.header)
-            .font(.subheadline)
-            .fontWeight(.semibold)
-        }
+      SwiftUI.ForEach(flatSections) { section in
+        listSection(for: section)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func listSection(for section: FlatSection) -> some View {
+    SwiftUI.Section {
+      SwiftUI.ForEach(section.tasks) { task in
+        TaskRowView(
+          task: task,
+          onComplete: registry.mutableProvider(for: task.id) != nil
+            ? { handleComplete(task) }
+            : nil
+        )
+        .onTapGesture { select(task) }
+      }
+    } header: {
+      Text(section.header)
+        .font(.subheadline)
+        .fontWeight(.semibold)
     }
   }
 

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -133,7 +133,7 @@ struct TasksTabView: View {
   private var taskList: some View {
     List {
       ForEach(flatSections) { section in
-        Section {
+        SwiftUI.Section {
           SwiftUI.ForEach(section.tasks) { task in
             TaskRowView(
               task: task,
@@ -157,25 +157,25 @@ struct TasksTabView: View {
   private var taskGrid: some View {
     let columns = [GridItem(.adaptive(minimum: 180), spacing: 10)]
     return ScrollView {
-      LazyVGrid(columns: columns, spacing: 10) {
+      VStack(alignment: .leading, spacing: 16) {
         ForEach(flatSections) { section in
-          Section {
-            SwiftUI.ForEach(section.tasks) { task in
-              TaskCardView(
-                task: task,
-                onComplete: registry.mutableProvider(for: task.id) != nil
-                  ? { handleComplete(task) }
-                  : nil
-              )
-              .onTapGesture { select(task) }
-            }
-          } header: {
+          VStack(alignment: .leading, spacing: 8) {
             Text(section.header)
               .font(.subheadline)
               .fontWeight(.semibold)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .padding(.top, 4)
-              .padding(.bottom, 2)
+              .padding(.horizontal, 2)
+
+            LazyVGrid(columns: columns, spacing: 10) {
+              ForEach(section.tasks) { task in
+                TaskCardView(
+                  task: task,
+                  onComplete: registry.mutableProvider(for: task.id) != nil
+                    ? { handleComplete(task) }
+                    : nil
+                )
+                .onTapGesture { select(task) }
+              }
+            }
           }
         }
       }

--- a/app/Taskmato/MainWindow/TimerTabView.swift
+++ b/app/Taskmato/MainWindow/TimerTabView.swift
@@ -18,6 +18,8 @@ struct TimerTabView: View {
   /// The break type to use when skipping from a focus session.
   var nextBreakPhase: SessionPhase
 
+  @Environment(\.openSettings) private var openSettings
+
   var body: some View {
     VStack(spacing: 0) {
       Spacer()
@@ -62,6 +64,16 @@ struct TimerTabView: View {
       SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
         .padding(.horizontal, 24)
         .padding(.vertical, 12)
+    }
+    .toolbar {
+      ToolbarItem(placement: .automatic) {
+        Button {
+          openSettings()
+        } label: {
+          Label("Settings", systemImage: "gearshape")
+        }
+        .help("Open Settings (⌘,)")
+      }
     }
   }
 

--- a/app/Taskmato/Settings/AppSettings.swift
+++ b/app/Taskmato/Settings/AppSettings.swift
@@ -56,6 +56,13 @@ final class AppSettings {
     didSet { defaults.set(showDockIcon, forKey: Keys.showDockIcon) }
   }
 
+  /// The display mode for the task picker (list rows or card grid).
+  ///
+  /// Defaults to `.grid`.
+  var taskPickerLayout: TaskPickerLayout {
+    didSet { defaults.set(taskPickerLayout.rawValue, forKey: Keys.taskPickerLayout) }
+  }
+
   /// `focusMinutes` expressed as a `TimeInterval` in seconds.
   var focusDuration: TimeInterval { TimeInterval(focusMinutes * 60) }
 
@@ -83,6 +90,8 @@ final class AppSettings {
     notificationsEnabled = defaults.object(forKey: Keys.notificationsEnabled) as? Bool ?? true
     autoStartNextPhase = defaults.object(forKey: Keys.autoStartNextPhase) as? Bool ?? false
     showDockIcon = defaults.object(forKey: Keys.showDockIcon) as? Bool ?? false
+    let rawLayout = defaults.string(forKey: Keys.taskPickerLayout)
+    taskPickerLayout = rawLayout.flatMap(TaskPickerLayout.init) ?? .grid
   }
 
   private enum Keys {
@@ -94,6 +103,7 @@ final class AppSettings {
     static let notificationsEnabled = "notificationsEnabled"
     static let autoStartNextPhase = "autoStartNextPhase"
     static let showDockIcon = "showDockIcon"
+    static let taskPickerLayout = "taskPickerLayout"
   }
 }
 

--- a/app/Taskmato/Settings/TaskPickerLayout.swift
+++ b/app/Taskmato/Settings/TaskPickerLayout.swift
@@ -1,0 +1,14 @@
+//
+//  TaskPickerLayout.swift
+//  Taskmato
+//
+
+/// The display mode for the task picker.
+enum TaskPickerLayout: String, CaseIterable, Sendable {
+
+  /// Tasks displayed as a single-column scrolling list.
+  case list
+
+  /// Tasks displayed as an adaptive multi-column card grid.
+  case grid
+}

--- a/app/Taskmato/Views/TaskCardView.swift
+++ b/app/Taskmato/Views/TaskCardView.swift
@@ -1,0 +1,118 @@
+//
+//  TaskCardView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A card-style representation of a task for the grid layout in the task picker.
+///
+/// Displays a completion circle, priority-prefixed title, due date (red when urgent),
+/// and truncated notes. Pass `onComplete` when the task's provider supports mutation.
+struct TaskCardView: View {
+
+  let task: TaskItem
+  /// Called when the user taps the completion circle. `nil` hides the button entirely.
+  var onComplete: (() -> Void)?
+
+  @State private var isHovering: Bool = false
+
+  init(task: TaskItem, onComplete: (() -> Void)? = nil) {
+    self.task = task
+    self.onComplete = onComplete
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(alignment: .top, spacing: 6) {
+        if let complete = onComplete {
+          Button(action: complete) {
+            Image(systemName: isHovering ? "checkmark.circle" : "circle")
+              .foregroundStyle(Color.accentColor)
+          }
+          .buttonStyle(.plain)
+          .onHover { isHovering = $0 }
+          .help("Mark done")
+        }
+
+        Text(displayTitle)
+          .font(.callout)
+          .lineLimit(3)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+
+      if let due = task.dueDate {
+        Text(due, format: .dateTime.month(.abbreviated).day().year())
+          .font(.caption2)
+          .foregroundStyle(isUrgent(due) ? Color.red : Color.secondary)
+      }
+
+      if let notes = task.notes {
+        TaskNoteView(notes: notes, format: task.format)
+          .lineLimit(2)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(10)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(
+      RoundedRectangle(cornerRadius: 10)
+        .fill(.secondary.opacity(0.1))
+    )
+    .contentShape(RoundedRectangle(cornerRadius: 10))
+  }
+
+  /// Returns `true` when the due date is today or in the past.
+  private func isUrgent(_ date: Date) -> Bool {
+    Calendar.current.isDateInToday(date) || date < Date.now
+  }
+
+  /// Priority mark (colored) prepended inline to the markdown-rendered title.
+  private var displayTitle: AttributedString {
+    guard !priorityMark.isEmpty else { return markdownTitle }
+    var prefix = AttributedString(priorityMark + " ")
+    prefix.swiftUI.foregroundColor = priorityColor
+    return prefix + markdownTitle
+  }
+
+  private var markdownTitle: AttributedString {
+    guard task.format == .markdown else { return AttributedString(task.title) }
+    let options = AttributedString.MarkdownParsingOptions(
+      interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+    return (try? AttributedString(markdown: task.title, options: options))
+      ?? AttributedString(task.title)
+  }
+
+  private var priorityMark: String {
+    switch task.priority {
+    case .highest: return "!!!"
+    case .high: return "!!"
+    case .medium: return "!"
+    case .low, .lowest, .none: return ""
+    }
+  }
+
+  private var priorityColor: Color {
+    switch task.priority {
+    case .highest, .high: return .red
+    case .medium: return .orange
+    case .low, .lowest, .none: return .primary
+    }
+  }
+}
+
+#Preview {
+  let task = TaskItem(
+    id: TaskRef(providerID: "local", nativeID: "1"),
+    title: "Create a support metrics dashboard and wiki",
+    notes: "Build out a dashboard of our support metrics once we have some statistics.",
+    format: .plainText,
+    priority: .high,
+    dueDate: Calendar.current.date(byAdding: .day, value: -3, to: .now)
+  )
+  TaskCardView(task: task, onComplete: {})
+    .padding()
+    .frame(width: 200)
+}

--- a/app/TaskmatoTests/TaskPickerLayoutTests.swift
+++ b/app/TaskmatoTests/TaskPickerLayoutTests.swift
@@ -1,0 +1,36 @@
+//
+//  TaskPickerLayoutTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+struct TaskPickerLayoutTests {
+
+  private func makeSettings() -> AppSettings {
+    AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+  }
+
+  @Test func defaultLayoutIsGrid() {
+    #expect(makeSettings().taskPickerLayout == .grid)
+  }
+
+  @Test func layoutPersistsAcrossInstances() {
+    let suite = UUID().uuidString
+    let defaults = UserDefaults(suiteName: suite)!
+    let writer = AppSettings(defaults: defaults)
+    writer.taskPickerLayout = .list
+
+    let reader = AppSettings(defaults: defaults)
+    #expect(reader.taskPickerLayout == .list)
+  }
+
+  @Test func allRawValuesRoundTrip() {
+    for layout in TaskPickerLayout.allCases {
+      #expect(TaskPickerLayout(rawValue: layout.rawValue) == layout)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a persistent list/grid layout toggle to the Tasks tab. Grid mode renders tasks as adaptive multi-column cards (inspired by the Finder view toggle). Also flattens the two-level list → section grouping into a single section layer with smart header labels, and fixes toolbar button ordering so Settings is always last.

## Linked issue

Closes #299

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**`TaskPickerLayout` enum + `AppSettings` persistence**
- New `TaskPickerLayout: String, CaseIterable` enum with `.list` and `.grid` cases
- Added `taskPickerLayout` to `AppSettings` (UserDefaults, key `taskPickerLayout`, default `.grid`)

**`TaskCardView`**
- Card layout: completion circle, priority mark inline with title (wraps 3 lines), due date (red when overdue or due today), notes truncated to 2 lines
- `Spacer(minLength: 0)` + `maxHeight: .infinity` keeps content top-aligned when cards in the same row have different heights
- Standalone — does not share logic with `TaskRowView` to avoid premature abstraction

**`TasksTabView` changes**
- Accepts `settings: AppSettings` (`@Bindable`) and `@Environment(\.openSettings)`
- Segmented `Picker` toolbar control (list/grid icons, like Finder) replaces the single toggle button
- Grid: `LazyVGrid` with `GridItem(.adaptive(minimum: 180))` and `Section` headers that span full width
- List: `DisclosureGroup` replaced with flat `Section` — same header label logic as grid
- Removed `expandedGroups` state (no longer needed)

**Flat section header logic** (`FlatSection`)
- Multiple lists + has section → `"List: Section"`
- Multiple lists + no section → `"List"`
- Single list + has section → `"Section"`
- Single list + no section → `"List"`

**Toolbar ordering**
- Removed Settings button from `MainWindowView` (parent items were rendering before child items)
- Each tab view now owns its toolbar: Tasks tab = Add Task → Layout Toggle → Settings; Timer and Stats tabs = Settings only

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` — 0 violations)
- [x] Unit tests pass locally (`make test` — all passing, 3 new tests in `TaskPickerLayoutTests`)
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

- Provider ordering in the picker (non-deterministic due to `withTaskGroup` completion order) is tracked in #298 — to be addressed when two-level provider grouping is implemented.
- Obsidian `{year}`/`{week}` date token expansion in file patterns was found broken during this session; tracked as a new TODO and filed as a separate issue against P4.