### PR TITLE
fix(release): always bump patch to keep alpha counter incrementing

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,7 @@
       "draft": false,
       "prerelease": true,
       "prerelease-type": "alpha",
+      "versioning-strategy": "always-bump-patch",
       "extra-files": ["version.txt"]
     }
   }


### PR DESCRIPTION
## Summary

Adds `"versioning-strategy": "always-bump-patch"` to `release-please-config.json`.

## Why

`prerelease-type: alpha` alone doesn't freeze the base version — `feat:` commits still bump the minor, producing `1.1.0-alpha.14` instead of `1.0.0-alpha.15`. Setting `versioning-strategy: always-bump-patch` forces every commit to be treated as a patch-level bump so the alpha counter increments predictably regardless of commit type.

When the project leaves alpha, the strategy should be removed so conventional commits drive semver normally. Tracked in #320.