### PR TITLE
chore(audit): remove stale BRANCH_PROTECTION.md link from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ docs: clarify deployment steps
 
 ## Branching and PRs
 
-- `main` is protected by a ruleset (see [`docs/BRANCH_PROTECTION.md`](docs/BRANCH_PROTECTION.md)).
+- `main` is protected by a ruleset.
 - Work happens on feature branches. PRs only — no direct pushes to `main`.
 - Merges must be squash or rebase. No merge commits.
 - Branch must be up to date with `main` before merging (strict status checks).


### PR DESCRIPTION
## Summary

- Remove stale `docs/BRANCH_PROTECTION.md` link from `CONTRIBUTING.md` — the link was added in an earlier template revision but has since been removed from the template

## Test plan

- [ ] `CONTRIBUTING.md` line 22 reads `` - `main` is protected by a ruleset. `` without the docs link

🤖 Generated with [Claude Code](https://claude.com/claude-code)