### PR TITLE
feat(tasks): view completed tasks inline with list rename

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -41,9 +41,9 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 
 - [x] Main window with Timer, Tasks, and Stats tabs (TabView navigation skeleton) ([#294](https://github.com/richwklein/taskmato/issues/294))
 - [x] Task picker view in main window Tasks tab (search across providers, grouped by list) ([#257](https://github.com/richwklein/taskmato/issues/257) partial — provider section headers and priority badges remain)
-- [ ] Collapsible provider sidebar with per-provider list scoping: `NavigationSplitView` layout; sidebar owns provider enable/disable, list visibility (checkmark), default list (star), and list CRUD for `WritableTaskProvider` conformers; detail column scoped to visible lists; removes Providers section from Settings ([#298](https://github.com/richwklein/taskmato/issues/298), fulfills [#276](https://github.com/richwklein/taskmato/issues/276))
+- [x] Collapsible provider sidebar with per-provider list scoping: `NavigationSplitView` layout; sidebar owns provider enable/disable, list visibility (checkmark), default list (star), and list CRUD for `WritableTaskProvider` conformers; detail column scoped to visible lists; removes Providers section from Settings ([#298](https://github.com/richwklein/taskmato/issues/298), fulfills [#276](https://github.com/richwklein/taskmato/issues/276))
 - [x] List and grid view toggle for the task picker (list = current row layout, grid = card layout) ([#299](https://github.com/richwklein/taskmato/issues/299))
-- [ ] "View Completed" sheet in picker for any enabled `MutableTaskProvider`; calls `completedTasks()` with restore (`reopen`) and permanent-delete affordances ([#300](https://github.com/richwklein/taskmato/issues/300))
+- [x] "View Completed" inline section in picker for any enabled `ClosableTaskProvider`; Show/Hide toolbar toggle; completed tasks appear at the bottom of their originating list section with restore (`reopen`) and permanent-delete affordances for `WritableTaskProvider` tasks ([#300](https://github.com/richwklein/taskmato/issues/300))
 - [x] Active task label in popover and main window timer tab: provider-conditional complete (checkmark) button, always-visible clear button, hidden when no task active ([#258](https://github.com/richwklein/taskmato/issues/258))
 - [x] Mid-session task swap (does not stop the timer) ([#296](https://github.com/richwklein/taskmato/issues/296))
 - [ ] Edit task sheet for `WritableTaskProvider` items: title, notes, priority, due date, list; `LocalProvider.updateTask` already implemented; accessible via right-click context menu or double-click in picker ([#330](https://github.com/richwklein/taskmato/issues/330))
@@ -141,6 +141,10 @@ The numbered tracks below (P0–P8) become the **Provider Pivot (1.0)** GitHub m
 - [ ] Add a documentation deploy action (if needed) ([#290](https://github.com/richwklein/taskmato/issues/290))
 - [ ] Make deploys dependent on build and require build checks ([#291](https://github.com/richwklein/taskmato/issues/291))
 - [ ] Re-enable the GitHub ruleset when rules are finalized ([#292](https://github.com/richwklein/taskmato/issues/292))
+
+## Notifications & sound (exploration)
+
+- [ ] Explore skipping `SoundService.play()` when notification banners are enabled to avoid the double audio cue on phase completion ([#341](https://github.com/richwklein/taskmato/issues/341))
 
 ## General foundations (pre-pivot, already shipped)
 

--- a/app/Taskmato/ActiveTaskView.swift
+++ b/app/Taskmato/ActiveTaskView.swift
@@ -103,7 +103,7 @@ struct ActiveTaskView: View {
       ) {
         Button("Stop & Complete", role: .destructive) {
           guard let task = selectionStore.activeTask,
-            let provider = registry.mutableProvider(for: task.id)
+            let provider = registry.closableProvider(for: task.id)
           else { return }
           let ref = task.id
           engine.stop()
@@ -156,7 +156,7 @@ struct ActiveTaskView: View {
   /// Returns a complete button when the provider supports mutation, or a static dot indicator otherwise.
   @ViewBuilder
   private func leadingIndicator(for task: TaskItem) -> some View {
-    if let provider = registry.mutableProvider(for: task.id) {
+    if let provider = registry.closableProvider(for: task.id) {
       Button {
         if sessionIsActive {
           confirmComplete = true

--- a/app/Taskmato/MainWindow/ProviderSidebarView.swift
+++ b/app/Taskmato/MainWindow/ProviderSidebarView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 /// each group, list rows carry a checkbox to control visibility and, for writable
 /// providers, a star button to promote the default list. Writable provider groups
 /// also expose an inline "New list" row at the bottom. A context menu on each list
-/// row provides set-default and delete actions. The "Add Provider" menu at the
-/// bottom enables any registered but currently disabled provider.
+/// row provides set-default, rename, and delete actions. The "Add Provider" menu at
+/// the bottom enables any registered but currently disabled provider.
 struct ProviderSidebarView: View {
 
   var registry: TaskRegistry
@@ -25,6 +25,15 @@ struct ProviderSidebarView: View {
 
   /// Inline new-list name buffer keyed by provider ID.
   @State private var newListName: [String: String] = [:]
+
+  /// The list ID currently being renamed inline, or `nil` when no rename is in progress.
+  @State private var renamingListID: String?
+
+  /// Editable buffer for the in-progress rename.
+  @State private var renameBuffer: String = ""
+
+  /// Drives focus into the rename `TextField` when a rename begins.
+  @FocusState private var renameFocused: String?
 
   /// Controls the Obsidian configuration sheet shown when Obsidian is first enabled.
   @State private var isConfiguringObsidian = false
@@ -160,8 +169,7 @@ struct ProviderSidebarView: View {
       .toggleStyle(.checkbox)
       .disabled(isDefaultList)
 
-      Text(list.name)
-        .lineLimit(1)
+      listNameField(list: list, provider: provider)
 
       Spacer()
 
@@ -186,6 +194,12 @@ struct ProviderSidebarView: View {
         }
         .disabled(isDefaultList)
 
+        Button("Rename") {
+          renamingListID = list.id
+          renameBuffer = list.name
+          renameFocused = list.id
+        }
+
         Divider()
 
         Button("Delete", role: .destructive) {
@@ -198,6 +212,21 @@ struct ProviderSidebarView: View {
         }
         .disabled(isDefaultList)
       }
+    }
+  }
+
+  /// Inline name display that switches to an editable `TextField` during a rename.
+  @ViewBuilder
+  private func listNameField(list: TaskList, provider: any TaskProvider) -> some View {
+    if renamingListID == list.id {
+      TextField("", text: $renameBuffer)
+        .textFieldStyle(.plain)
+        .focused($renameFocused, equals: list.id)
+        .onSubmit { commitRename(list: list, provider: provider) }
+        .onExitCommand { cancelRename() }
+    } else {
+      Text(list.name)
+        .lineLimit(1)
     }
   }
 
@@ -302,6 +331,26 @@ struct ProviderSidebarView: View {
       return local.defaultListID == listID
     }
     return (provider as? (any WritableTaskProvider))?.defaultListID == listID
+  }
+
+  // MARK: - Rename helpers
+
+  private func commitRename(list: TaskList, provider: any TaskProvider) {
+    let trimmed = renameBuffer.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty, let writable = provider as? (any WritableTaskProvider) else {
+      cancelRename()
+      return
+    }
+    renamingListID = nil
+    Task {
+      try? await writable.renameList(list.id, name: trimmed)
+      await loadLists(for: provider)
+    }
+  }
+
+  private func cancelRename() {
+    renamingListID = nil
+    renameBuffer = ""
   }
 
   // MARK: - Async list loading

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -133,7 +133,7 @@ struct TasksTabView: View {
               } label: {
                 Label(
                   showCompleted ? "Hide Completed" : "Show Completed",
-                  systemImage: "checkmark.circle.fill"
+                  systemImage: showCompleted ? "eye.slash" : "eye"
                 )
               }
               .help(showCompleted ? "Hide completed tasks" : "Show completed tasks")
@@ -262,6 +262,17 @@ struct TasksTabView: View {
     )
   }
 
+  /// A ``CompletedTaskCardView`` wired to this view's restore and delete handlers.
+  @ViewBuilder
+  private func completedCard(_ task: TaskItem) -> some View {
+    CompletedTaskCardView(
+      task: task,
+      onRestore: { handleRestore(task) },
+      onDelete: registry.provider(for: task.id) is (any WritableTaskProvider)
+        ? { handleDelete(task) } : nil
+    )
+  }
+
   // MARK: - Grid layout
 
   private var taskGrid: some View {
@@ -305,7 +316,9 @@ struct TasksTabView: View {
             }
 
             if showCompleted && !completed.isEmpty {
-              ForEach(completed) { task in completedRow(task) }
+              LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(completed) { task in completedCard(task) }
+              }
             }
           }
         }
@@ -316,7 +329,9 @@ struct TasksTabView: View {
               .font(.subheadline)
               .fontWeight(.semibold)
               .padding(.horizontal, 2)
-            ForEach(completedOrphans) { task in completedRow(task) }
+            LazyVGrid(columns: columns, spacing: 10) {
+              ForEach(completedOrphans) { task in completedCard(task) }
+            }
           }
         }
       }
@@ -456,31 +471,6 @@ extension TasksTabView {
       )
     }
   }
-}
-
-// MARK: - Supporting types
-
-/// A grouped collection of tasks sharing a ``TaskList``.
-private struct TaskGroup: Identifiable {
-  let id: String
-  let listName: String
-  let sections: [TaskSection]
-}
-
-/// A collection of tasks under a single section heading within a list.
-private struct TaskSection: Identifiable {
-  let id: String
-  let name: String?
-  let tasks: [TaskItem]
-}
-
-/// A flattened display section with a computed header label and its tasks.
-private struct FlatSection: Identifiable {
-  let id: String
-  /// The ``TaskList`` identifier this section belongs to — used to bucket completed tasks.
-  let listID: String
-  let header: String
-  let tasks: [TaskItem]
 }
 
 #Preview {

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -217,14 +217,7 @@ struct TasksTabView: View {
 
       if showCompleted && !completedOrphans.isEmpty {
         SwiftUI.Section {
-          SwiftUI.ForEach(completedOrphans) { task in
-            CompletedTaskRowView(
-              task: task,
-              onRestore: { handleRestore(task) },
-              onDelete: registry.provider(for: task.id) is (any WritableTaskProvider)
-                ? { handleDelete(task) } : nil
-            )
-          }
+          SwiftUI.ForEach(completedOrphans) { task in completedRow(task) }
         } header: {
           Text("Other Completed")
             .font(.subheadline)
@@ -249,14 +242,7 @@ struct TasksTabView: View {
         .onTapGesture { select(task) }
       }
       if showCompleted && !completed.isEmpty {
-        SwiftUI.ForEach(completed) { task in
-          CompletedTaskRowView(
-            task: task,
-            onRestore: { handleRestore(task) },
-            onDelete: registry.provider(for: task.id) is (any WritableTaskProvider)
-              ? { handleDelete(task) } : nil
-          )
-        }
+        SwiftUI.ForEach(completed) { task in completedRow(task) }
       }
     } header: {
       Text(section.header)
@@ -265,13 +251,41 @@ struct TasksTabView: View {
     }
   }
 
+  /// A ``CompletedTaskRowView`` wired to this view's restore and delete handlers.
+  @ViewBuilder
+  private func completedRow(_ task: TaskItem) -> some View {
+    CompletedTaskRowView(
+      task: task,
+      onRestore: { handleRestore(task) },
+      onDelete: registry.provider(for: task.id) is (any WritableTaskProvider)
+        ? { handleDelete(task) } : nil
+    )
+  }
+
   // MARK: - Grid layout
 
   private var taskGrid: some View {
     let columns = [GridItem(.adaptive(minimum: 180), spacing: 10)]
     return ScrollView {
       VStack(alignment: .leading, spacing: 16) {
+        if showCompleted {
+          HStack {
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundStyle(Color.accentColor)
+            Text("\(totalCompletedCount) Completed")
+              .foregroundStyle(.secondary)
+            Spacer()
+            Button("Hide") { showCompleted = false }
+              .buttonStyle(.plain)
+              .foregroundStyle(Color.accentColor)
+          }
+          .padding(.horizontal, 2)
+        }
+
         ForEach(flatSections) { section in
+          let isLastForList =
+            flatSections.last(where: { $0.listID == section.listID })?.id == section.id
+          let completed = isLastForList ? (completedByListID[section.listID] ?? []) : []
           VStack(alignment: .leading, spacing: 8) {
             Text(section.header)
               .font(.subheadline)
@@ -289,6 +303,20 @@ struct TasksTabView: View {
                 .onTapGesture { select(task) }
               }
             }
+
+            if showCompleted && !completed.isEmpty {
+              ForEach(completed) { task in completedRow(task) }
+            }
+          }
+        }
+
+        if showCompleted && !completedOrphans.isEmpty {
+          VStack(alignment: .leading, spacing: 8) {
+            Text("Other Completed")
+              .font(.subheadline)
+              .fontWeight(.semibold)
+              .padding(.horizontal, 2)
+            ForEach(completedOrphans) { task in completedRow(task) }
           }
         }
       }
@@ -296,7 +324,11 @@ struct TasksTabView: View {
     }
   }
 
-  // MARK: - Data loading
+}
+
+// MARK: - Data loading
+
+extension TasksTabView {
 
   /// Subscribes to live-update streams from all enabled providers and reloads tasks on each event.
   private func subscribeToProviderUpdates() async {
@@ -383,7 +415,11 @@ struct TasksTabView: View {
     }
   }
 
-  // MARK: - Grouping
+}
+
+// MARK: - Grouping
+
+extension TasksTabView {
 
   private func buildGroups(from tasks: [TaskItem]) -> [TaskGroup] {
     var ordered: [String] = []

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -172,7 +172,7 @@ struct TasksTabView: View {
       SwiftUI.ForEach(section.tasks) { task in
         TaskRowView(
           task: task,
-          onComplete: registry.mutableProvider(for: task.id) != nil
+          onComplete: registry.closableProvider(for: task.id) != nil
             ? { handleComplete(task) }
             : nil
         )
@@ -202,7 +202,7 @@ struct TasksTabView: View {
               ForEach(section.tasks) { task in
                 TaskCardView(
                   task: task,
-                  onComplete: registry.mutableProvider(for: task.id) != nil
+                  onComplete: registry.closableProvider(for: task.id) != nil
                     ? { handleComplete(task) }
                     : nil
                 )
@@ -248,7 +248,7 @@ struct TasksTabView: View {
   private func handleComplete(_ task: TaskItem) {
     let ref = task.id
     Task {
-      if let provider = registry.mutableProvider(for: ref) {
+      if let provider = registry.closableProvider(for: ref) {
         try? await provider.complete(ref)
       }
       await loadTasks()

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -13,6 +13,10 @@ import SwiftUI
 /// formatted as "List: Section" when multiple lists are active, or just "Section"
 /// when only one list is active. Supports toggling between a list and an adaptive
 /// card grid layout.
+///
+/// When at least one enabled provider conforms to ``ClosableTaskProvider``, a
+/// "Show Completed" toolbar button becomes available. Toggling it on fetches
+/// completed tasks and appends them inline at the bottom of each matching section.
 struct TasksTabView: View {
 
   var selectionStore: TaskSelectionStore
@@ -26,6 +30,10 @@ struct TasksTabView: View {
   @State private var groupedLists: [TaskGroup] = []
   @State private var isLoading: Bool = false
   @State private var isAddingTask = false
+  @State private var showCompleted = false
+  @State private var completedByListID: [String: [TaskItem]] = [:]
+  @State private var completedOrphans: [TaskItem] = []
+  @State private var isLoadingCompleted = false
 
   /// The local provider instance looked up from the registry, if registered.
   private var localProvider: LocalProvider? {
@@ -39,6 +47,16 @@ struct TasksTabView: View {
   /// `true` when the local provider is registered and currently enabled.
   private var localProviderEnabled: Bool {
     localProvider.map { registry.isEnabled($0.id) } ?? false
+  }
+
+  /// `true` when at least one enabled provider conforms to ``ClosableTaskProvider``.
+  private var hasClosableProvider: Bool {
+    registry.providers.contains { registry.isEnabled($0.id) && $0 is (any ClosableTaskProvider) }
+  }
+
+  /// Total number of completed tasks currently loaded across all sections and orphans.
+  private var totalCompletedCount: Int {
+    completedByListID.values.reduce(0) { $0 + $1.count } + completedOrphans.count
   }
 
   /// Flat display sections derived from `groupedLists`.
@@ -59,7 +77,9 @@ struct TasksTabView: View {
         case (false, let name?): header = name
         case (false, nil): header = group.listName
         }
-        return FlatSection(id: "\(group.id).\(section.id)", header: header, tasks: section.tasks)
+        return FlatSection(
+          id: "\(group.id).\(section.id)", listID: group.id, header: header, tasks: section.tasks
+        )
       }
     }
   }
@@ -102,6 +122,21 @@ struct TasksTabView: View {
                 Label("Add Task", systemImage: "plus")
               }
               .help("Add a local task")
+            }
+          }
+
+          if hasClosableProvider {
+            ToolbarItem(placement: .automatic) {
+              Button {
+                showCompleted.toggle()
+                if showCompleted { Task { await loadCompleted() } }
+              } label: {
+                Label(
+                  showCompleted ? "Hide Completed" : "Show Completed",
+                  systemImage: "checkmark.circle.fill"
+                )
+              }
+              .help(showCompleted ? "Hide completed tasks" : "Show completed tasks")
             }
           }
 
@@ -160,14 +195,49 @@ struct TasksTabView: View {
 
   private var taskList: some View {
     List {
+      if showCompleted {
+        SwiftUI.Section {
+          HStack {
+            Image(systemName: "checkmark.circle.fill")
+              .foregroundStyle(Color.accentColor)
+            Text("\(totalCompletedCount) Completed")
+              .foregroundStyle(.secondary)
+            Spacer()
+            Button("Hide") { showCompleted = false }
+              .buttonStyle(.plain)
+              .foregroundStyle(Color.accentColor)
+          }
+          .padding(.vertical, 2)
+        }
+      }
+
       SwiftUI.ForEach(flatSections) { section in
         listSection(for: section)
+      }
+
+      if showCompleted && !completedOrphans.isEmpty {
+        SwiftUI.Section {
+          SwiftUI.ForEach(completedOrphans) { task in
+            CompletedTaskRowView(
+              task: task,
+              onRestore: { handleRestore(task) },
+              onDelete: registry.provider(for: task.id) is (any WritableTaskProvider)
+                ? { handleDelete(task) } : nil
+            )
+          }
+        } header: {
+          Text("Other Completed")
+            .font(.subheadline)
+            .fontWeight(.semibold)
+        }
       }
     }
   }
 
   @ViewBuilder
   private func listSection(for section: FlatSection) -> some View {
+    let isLastForList = flatSections.last(where: { $0.listID == section.listID })?.id == section.id
+    let completed = isLastForList ? (completedByListID[section.listID] ?? []) : []
     SwiftUI.Section {
       SwiftUI.ForEach(section.tasks) { task in
         TaskRowView(
@@ -177,6 +247,16 @@ struct TasksTabView: View {
             : nil
         )
         .onTapGesture { select(task) }
+      }
+      if showCompleted && !completed.isEmpty {
+        SwiftUI.ForEach(completed) { task in
+          CompletedTaskRowView(
+            task: task,
+            onRestore: { handleRestore(task) },
+            onDelete: registry.provider(for: task.id) is (any WritableTaskProvider)
+              ? { handleDelete(task) } : nil
+          )
+        }
       }
     } header: {
       Text(section.header)
@@ -239,12 +319,36 @@ struct TasksTabView: View {
     isLoading = false
   }
 
+  private func loadCompleted() async {
+    isLoadingCompleted = true
+    var byList: [String: [TaskItem]] = [:]
+    var orphans: [TaskItem] = []
+    let activeListIDs = Set(flatSections.map(\.listID))
+    for provider in registry.providers where registry.isEnabled(provider.id) {
+      guard let closable = provider as? (any ClosableTaskProvider) else { continue }
+      let items = (try? await closable.completedTasks()) ?? []
+      for item in items {
+        let key = item.list?.id ?? ""
+        if !key.isEmpty && activeListIDs.contains(key) {
+          byList[key, default: []].append(item)
+        } else {
+          orphans.append(item)
+        }
+      }
+    }
+    completedByListID = byList
+    completedOrphans = orphans.sorted {
+      ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast)
+    }
+    isLoadingCompleted = false
+  }
+
   private func select(_ task: TaskItem) {
     selectionStore.select(task)
     selectedTab = 0
   }
 
-  /// Completes the task via its mutable provider, then refreshes the list.
+  /// Completes the task via its closable provider, then refreshes the list.
   private func handleComplete(_ task: TaskItem) {
     let ref = task.id
     Task {
@@ -252,6 +356,30 @@ struct TasksTabView: View {
         try? await provider.complete(ref)
       }
       await loadTasks()
+      if showCompleted { await loadCompleted() }
+    }
+  }
+
+  /// Reopens a completed task via its closable provider, then refreshes both lists.
+  private func handleRestore(_ task: TaskItem) {
+    let ref = task.id
+    Task {
+      if let provider = registry.closableProvider(for: ref) {
+        try? await provider.reopen(ref)
+      }
+      await loadTasks()
+      await loadCompleted()
+    }
+  }
+
+  /// Permanently deletes a completed task via its writable provider, then refreshes completed.
+  private func handleDelete(_ task: TaskItem) {
+    let ref = task.id
+    Task {
+      if let provider = registry.provider(for: ref) as? (any WritableTaskProvider) {
+        try? await provider.deleteTask(ref)
+      }
+      await loadCompleted()
     }
   }
 
@@ -313,6 +441,8 @@ private struct TaskSection: Identifiable {
 /// A flattened display section with a computed header label and its tasks.
 private struct FlatSection: Identifiable {
   let id: String
+  /// The ``TaskList`` identifier this section belongs to — used to bucket completed tasks.
+  let listID: String
   let header: String
   let tasks: [TaskItem]
 }

--- a/app/Taskmato/MainWindow/TasksTabViewTypes.swift
+++ b/app/Taskmato/MainWindow/TasksTabViewTypes.swift
@@ -1,0 +1,27 @@
+//
+//  TasksTabViewTypes.swift
+//  Taskmato
+//
+
+/// A grouped collection of tasks sharing a ``TaskList``.
+struct TaskGroup: Identifiable {
+  let id: String
+  let listName: String
+  let sections: [TaskSection]
+}
+
+/// A collection of tasks under a single section heading within a list.
+struct TaskSection: Identifiable {
+  let id: String
+  let name: String?
+  let tasks: [TaskItem]
+}
+
+/// A flattened display section with a computed header label and its tasks.
+struct FlatSection: Identifiable {
+  let id: String
+  /// The ``TaskList`` identifier this section belongs to — used to bucket completed tasks.
+  let listID: String
+  let header: String
+  let tasks: [TaskItem]
+}

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -84,7 +84,7 @@ final class LocalProvider: WritableTaskProvider {
   /// Returns `nil` — mutations are in-process and `@Observable` propagates changes directly.
   func observe() -> AsyncStream<[TaskItem]>? { nil }
 
-  // MARK: - MutableTaskProvider
+  // MARK: - ClosableTaskProvider
 
   /// Soft-deletes the task by setting `isCompleted = true` and recording `completedAt`.
   func complete(_ ref: TaskRef) async throws {

--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -62,7 +62,8 @@ struct LocalTask: Codable, Identifiable {
       dueDate: dueDate,
       scheduledDate: scheduledDate,
       startDate: startDate,
-      list: taskList
+      list: taskList,
+      completedAt: completedAt
     )
   }
 

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -19,7 +19,7 @@ import SwiftUI
 ///   change notifications are coalesced by a 250 ms debounce before a rescan is triggered.
 @Observable
 @MainActor
-final class ObsidianProvider: MutableTaskProvider {
+final class ObsidianProvider: ClosableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
   static let providerID = "obsidian"
@@ -148,7 +148,7 @@ final class ObsidianProvider: MutableTaskProvider {
     return stream
   }
 
-  // MARK: - MutableTaskProvider
+  // MARK: - ClosableTaskProvider
 
   /// Rewrites the task checkbox from `[ ]` to `[x]` in the vault file, supporting both
   /// unordered (`- [ ] `) and ordered (`1. [ ] `) list formats.

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -169,7 +169,7 @@ final class ObsidianProvider: ClosableTaskProvider {
   func completedTasks() async throws -> [TaskItem] {
     guard let vaultURL else { return [] }
     let patterns = filePatterns
-    let entries: [(item: TaskItem, completedAt: Date?)] = try await Task.detached(
+    let entries: [TaskItem] = try await Task.detached(
       priority: .userInitiated
     ) { [weak self] in
       guard let self else { return [] }
@@ -192,10 +192,7 @@ final class ObsidianProvider: ClosableTaskProvider {
         }
       }
     }.value
-    return
-      entries
-      .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
-      .map(\.item)
+    return entries.sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
   }
 
   // MARK: - Vault bookmark management

--- a/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
@@ -23,8 +23,8 @@ struct ObsidianTaskParser {
 
   /// The result of parsing a single markdown file for completed tasks.
   struct CompletedParseResult {
-    /// Completed tasks paired with their `✅` completion dates (nil when the date is absent).
-    let entries: [(item: TaskItem, completedAt: Date?)]
+    /// Completed tasks, each with `completedAt` set from the `✅ YYYY-MM-DD` emoji when present.
+    let entries: [TaskItem]
     /// Text of the first H1 heading in the file, if any — used to name the ``TaskList``.
     let listName: String?
   }
@@ -68,8 +68,8 @@ struct ObsidianTaskParser {
 
   /// Parses all completed (`- [x]` / `- [X]`) tasks from `content`.
   ///
-  /// Each entry includes the parsed ``TaskItem`` and the `✅ YYYY-MM-DD` completion date
-  /// (nil when the emoji is absent), allowing callers to sort by recency.
+  /// Each ``TaskItem`` in the result has `completedAt` set from the `✅ YYYY-MM-DD` emoji
+  /// when present, or `nil` when the date is absent.
   func parseCompleted(
     content: String,
     providerID: String,
@@ -275,14 +275,14 @@ struct ObsidianTaskParser {
     )
   }
 
-  /// Builds a ``TaskItem`` from a completed task line and extracts the `✅` completion date.
+  /// Builds a ``TaskItem`` from a completed task line, setting `completedAt` from the `✅` emoji.
   private func buildCompletedEntry(
     rawLine: String,
     lineNumber: Int,
     section: String?,
     notes: String?,
     context: FileContext
-  ) -> (item: TaskItem, completedAt: Date?) {
+  ) -> TaskItem {
     var text = stripTaskMarker(from: rawLine)
 
     let completedAt = extractDate(emoji: "✅", from: &text)
@@ -292,7 +292,7 @@ struct ObsidianTaskParser {
     let startDate = extractDate(emoji: "🛫", from: &text)
     let title = text.trimmingCharacters(in: .whitespaces)
 
-    let item = TaskItem(
+    return TaskItem(
       id: TaskRef(
         providerID: context.providerID,
         nativeID: "\(context.fileRelativePath):\(lineNumber)"
@@ -306,9 +306,9 @@ struct ObsidianTaskParser {
       startDate: startDate,
       list: context.list,
       section: section,
-      sourceURL: obsidianURL(vaultName: context.vaultName, filePath: context.fileRelativePath)
+      sourceURL: obsidianURL(vaultName: context.vaultName, filePath: context.fileRelativePath),
+      completedAt: completedAt
     )
-    return (item, completedAt)
   }
 
   // MARK: - Field extraction

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -9,11 +9,11 @@ import Foundation
 /// A task provider backed by Apple Reminders via EventKit.
 ///
 /// Authorization is lazy: ``lists()`` and ``tasks(in:)`` return empty arrays until
-/// ``authorize()`` succeeds. The provider conforms to ``MutableTaskProvider`` so
+/// ``authorize()`` succeeds. The provider conforms to ``ClosableTaskProvider`` so
 /// completing a Pomodoro can mark the reminder done in the source system.
 @Observable
 @MainActor
-final class RemindersProvider: MutableTaskProvider {
+final class RemindersProvider: ClosableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
   static let providerID = "reminders"
@@ -133,7 +133,7 @@ final class RemindersProvider: MutableTaskProvider {
     streamContinuation = nil
   }
 
-  // MARK: - MutableTaskProvider
+  // MARK: - ClosableTaskProvider
 
   func completedTasks() async throws -> [TaskItem] {
     guard isAuthorized else { return [] }

--- a/app/Taskmato/Tasks/TaskItem.swift
+++ b/app/Taskmato/Tasks/TaskItem.swift
@@ -44,4 +44,9 @@ struct TaskItem: Identifiable, Hashable, Codable, Sendable {
 
   /// A deep link back to the task in the source provider app, if available.
   var sourceURL: URL?
+
+  /// Wall-clock time the task was completed, or `nil` for active tasks.
+  ///
+  /// Populated by ``ClosableTaskProvider/completedTasks()``; always `nil` for live tasks.
+  var completedAt: Date?
 }

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// A read-only source of tasks that can be listed, searched, and observed for live updates.
 ///
-/// Conform to `MutableTaskProvider` in addition when the provider supports
+/// Conform to `ClosableTaskProvider` in addition when the provider supports
 /// completing or reopening tasks in the source system.
 protocol TaskProvider: AnyObject, Sendable {
 
@@ -39,8 +39,8 @@ protocol TaskProvider: AnyObject, Sendable {
   func observe() -> AsyncStream<[TaskItem]>?
 }
 
-/// A `TaskProvider` that can also write completion state back to the source system.
-protocol MutableTaskProvider: TaskProvider {
+/// A `TaskProvider` that supports toggling task completion state in the source system.
+protocol ClosableTaskProvider: TaskProvider {
 
   /// Marks the task identified by `ref` as complete in the source system.
   /// - Parameter ref: The stable reference to the task to close.
@@ -50,24 +50,24 @@ protocol MutableTaskProvider: TaskProvider {
   /// - Parameter ref: The stable reference to the task to reopen.
   func reopen(_ ref: TaskRef) async throws
 
-  /// Returns tasks that have been marked complete, for display in a "View Completed" sheet.
+  /// Returns tasks that have been marked complete, for display in the "View Completed" section.
   ///
   /// The default implementation returns an empty array. Override when the provider
   /// supports surfacing completed tasks (e.g. a local JSON store or an Obsidian vault).
   func completedTasks() async throws -> [TaskItem]
 }
 
-extension MutableTaskProvider {
+extension ClosableTaskProvider {
   func completedTasks() async throws -> [TaskItem] { [] }
 }
 
-/// A `MutableTaskProvider` that also supports creating tasks and managing lists.
+/// A `ClosableTaskProvider` that also supports creating tasks and managing lists.
 ///
 /// Providers conforming to this protocol expose the full write surface: task creation,
-/// list lifecycle (create, rename, delete), and a persistent default-list preference.
-/// `LocalProvider` conforms immediately; `ObsidianProvider` and `RemindersProvider`
-/// will conform in follow-on milestones.
-protocol WritableTaskProvider: MutableTaskProvider {
+/// list lifecycle (create, rename, delete), task deletion, and a persistent default-list
+/// preference. `LocalProvider` conforms immediately; `ObsidianProvider` and
+/// `RemindersProvider` will conform in follow-on milestones.
+protocol WritableTaskProvider: ClosableTaskProvider {
 
   /// The ID of the list new tasks target by default, or `nil` if none is set.
   var defaultListID: String? { get }
@@ -96,4 +96,8 @@ protocol WritableTaskProvider: MutableTaskProvider {
   /// another list before deleting the current default.
   /// - Throws: if `listID` is the default list or does not identify a known list.
   func deleteList(_ listID: String) async throws
+
+  /// Permanently removes the task identified by `ref` from the provider's store.
+  /// - Throws: if the task cannot be found or removal fails.
+  func deleteTask(_ ref: TaskRef) async throws
 }

--- a/app/Taskmato/Tasks/TaskRegistry.swift
+++ b/app/Taskmato/Tasks/TaskRegistry.swift
@@ -145,10 +145,10 @@ final class TaskRegistry {
     providers.first { $0.id == ref.providerID }
   }
 
-  /// Returns the provider for a task reference if it conforms to `MutableTaskProvider`, or `nil`.
-  /// - Parameter ref: The task reference whose mutable provider to look up.
-  func mutableProvider(for ref: TaskRef) -> (any MutableTaskProvider)? {
-    provider(for: ref) as? any MutableTaskProvider
+  /// Returns the provider for a task reference if it conforms to `ClosableTaskProvider`, or `nil`.
+  /// - Parameter ref: The task reference whose closable provider to look up.
+  func closableProvider(for ref: TaskRef) -> (any ClosableTaskProvider)? {
+    provider(for: ref) as? any ClosableTaskProvider
   }
 
   // MARK: - List scoping

--- a/app/Taskmato/Views/CompletedTaskCardView.swift
+++ b/app/Taskmato/Views/CompletedTaskCardView.swift
@@ -1,0 +1,92 @@
+//
+//  CompletedTaskCardView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A card-style representation of a completed task for the grid layout.
+///
+/// Mirrors the shape of ``TaskCardView``: filled `checkmark.circle.fill` restore button,
+/// muted title, and a completion subtitle (list · relative date) where the due date
+/// normally appears. On hover, an optional trash button appears in the top-right corner.
+struct CompletedTaskCardView: View {
+
+  let task: TaskItem
+  /// Called when the user clicks the filled circle to restore the task.
+  var onRestore: () -> Void
+  /// Called when the user confirms permanent deletion. `nil` hides the trash button.
+  var onDelete: (() -> Void)?
+
+  @State private var isHovering: Bool = false
+  @State private var showDeleteConfirmation: Bool = false
+
+  var body: some View {
+    ZStack(alignment: .topTrailing) {
+      HStack(alignment: .top, spacing: 6) {
+        Button(action: onRestore) {
+          Image(systemName: "checkmark.circle.fill")
+            .foregroundStyle(Color.accentColor)
+        }
+        .buttonStyle(.plain)
+        .help("Restore task")
+
+        VStack(alignment: .leading, spacing: 4) {
+          Text(task.title)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .lineLimit(3)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+          Text(subtitle)
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+
+          if let notes = task.notes {
+            TaskNoteView(notes: notes, format: task.format)
+              .lineLimit(2)
+          }
+
+          Spacer(minLength: 0)
+        }
+      }
+      .padding(10)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+      if isHovering, let delete = onDelete {
+        Button {
+          showDeleteConfirmation = true
+        } label: {
+          Image(systemName: "trash")
+            .foregroundStyle(.secondary)
+            .padding(8)
+        }
+        .buttonStyle(.plain)
+        .help("Delete permanently")
+        .confirmationDialog("Delete this task permanently?", isPresented: $showDeleteConfirmation) {
+          Button("Delete", role: .destructive) { delete() }
+          Button("Cancel", role: .cancel) {}
+        }
+      }
+    }
+    .background(
+      RoundedRectangle(cornerRadius: 10)
+        .fill(.secondary.opacity(0.1))
+    )
+    .contentShape(RoundedRectangle(cornerRadius: 10))
+    .onHover { isHovering = $0 }
+  }
+
+  private var subtitle: String {
+    let listPart = task.list?.name
+    let datePart = task.completedAt.map {
+      RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
+    }
+    switch (listPart, datePart) {
+    case (let list?, let date?): return "\(list) · \(date)"
+    case (let list?, nil): return list
+    case (nil, let date?): return date
+    case (nil, nil): return "Unknown date"
+    }
+  }
+}

--- a/app/Taskmato/Views/CompletedTaskRowView.swift
+++ b/app/Taskmato/Views/CompletedTaskRowView.swift
@@ -1,0 +1,77 @@
+//
+//  CompletedTaskRowView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A single row for a completed task in the inline completed section.
+///
+/// Shows a filled `checkmark.circle.fill` restore button, a muted title, and a subtitle
+/// with the list name and relative completion time. On hover, an optional trash button
+/// appears for providers that support permanent deletion.
+struct CompletedTaskRowView: View {
+
+  let task: TaskItem
+  /// Called when the user clicks the filled circle to restore the task.
+  var onRestore: () -> Void
+  /// Called when the user confirms permanent deletion. `nil` hides the trash button.
+  var onDelete: (() -> Void)?
+
+  @State private var isHovering: Bool = false
+  @State private var showDeleteConfirmation: Bool = false
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 8) {
+      Button(action: onRestore) {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(Color.accentColor)
+      }
+      .buttonStyle(.plain)
+      .help("Restore task")
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(task.title)
+          .font(.callout)
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+          .frame(maxWidth: .infinity, alignment: .leading)
+
+        Text(subtitle)
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+      }
+
+      if isHovering, let delete = onDelete {
+        Button {
+          showDeleteConfirmation = true
+        } label: {
+          Image(systemName: "trash")
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Delete permanently")
+        .confirmationDialog("Delete this task permanently?", isPresented: $showDeleteConfirmation) {
+          Button("Delete", role: .destructive) { delete() }
+          Button("Cancel", role: .cancel) {}
+        }
+      }
+    }
+    .padding(.vertical, 4)
+    .contentShape(Rectangle())
+    .onHover { isHovering = $0 }
+  }
+
+  private var subtitle: String {
+    let listPart = task.list?.name
+    let datePart = task.completedAt.map {
+      RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
+    }
+    switch (listPart, datePart) {
+    case (let list?, let date?): return "\(list) · \(date)"
+    case (let list?, nil): return list
+    case (nil, let date?): return date
+    case (nil, nil): return "Unknown date"
+    }
+  }
+}

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -183,6 +183,22 @@ struct LocalProviderTests {
     #expect(completed[0].title == "Done")
   }
 
+  @Test func completedTasksItemsCarryCompletedAt() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "With Date"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    let before = Date()
+    try await provider.complete(ref)
+    let after = Date()
+    let completed = try await provider.completedTasks()
+    #expect(completed.count == 1)
+    let stamp = try #require(completed[0].completedAt)
+    #expect(stamp >= before)
+    #expect(stamp <= after)
+  }
+
   @Test func reopenRestoresTaskToActive() async throws {
     let provider = makeProvider()
     var draft = TaskDraft()

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -241,6 +241,18 @@ struct LocalProviderTests {
     #expect(try await provider.completedTasks().isEmpty)
   }
 
+  @Test func writableProviderDeleteTaskRemovesCompletedItem() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Completed and deleted"
+    provider.addTask(draft)
+    let ref = try await provider.tasks(in: nil)[0].id
+    try await provider.complete(ref)
+    let writable: any WritableTaskProvider = provider
+    try await writable.deleteTask(ref)
+    #expect(try await provider.completedTasks().isEmpty)
+  }
+
   @Test func updateTaskAppliesNewTitle() async throws {
     let provider = makeProvider()
     var draft = TaskDraft()

--- a/app/TaskmatoTests/ObsidianProviderTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderTests.swift
@@ -62,6 +62,22 @@ struct ObsidianProviderCompletedTasksTests {
     #expect(tasks[0].title == "Done")
   }
 
+  @Test func completedTasksItemsCarryCompletedAt() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [x] Done ✅ 2026-05-10\n- [ ] Pending", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let tasks = try await provider.completedTasks()
+    #expect(tasks.count == 1)
+    let stamp = try #require(tasks[0].completedAt)
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC")!
+    let comps = cal.dateComponents([.year, .month, .day], from: stamp)
+    #expect(comps.year == 2026)
+    #expect(comps.month == 5)
+    #expect(comps.day == 10)
+  }
+
   @Test func excludesIncompleteTasks() async throws {
     let vault = try makeVault()
     defer { try? FileManager.default.removeItem(at: vault) }

--- a/app/TaskmatoTests/ObsidianTaskParserTests.swift
+++ b/app/TaskmatoTests/ObsidianTaskParserTests.swift
@@ -362,7 +362,7 @@ struct ObsidianTaskParserCompletedTests {
   private func parseCompleted(
     _ content: String,
     relativePath: String = "tasks.md"
-  ) -> [(item: TaskItem, completedAt: Date?)] {
+  ) -> [TaskItem] {
     parser.parseCompleted(
       content: content,
       providerID: providerID,
@@ -375,13 +375,13 @@ struct ObsidianTaskParserCompletedTests {
   @Test func parsesCompletedTaskLowercaseX() {
     let entries = parseCompleted("- [x] Finished task")
     #expect(entries.count == 1)
-    #expect(entries[0].item.title == "Finished task")
+    #expect(entries[0].title == "Finished task")
   }
 
   @Test func parsesCompletedTaskUppercaseX() {
     let entries = parseCompleted("- [X] Also finished")
     #expect(entries.count == 1)
-    #expect(entries[0].item.title == "Also finished")
+    #expect(entries[0].title == "Also finished")
   }
 
   @Test func skipsIncompleteTaskInCompletedScan() {
@@ -405,8 +405,8 @@ struct ObsidianTaskParserCompletedTests {
 
   @Test func completionEmojiRemovedFromTitle() {
     let entries = parseCompleted("- [x] Done task ✅ 2025-12-31")
-    #expect(entries[0].item.title == "Done task")
-    #expect(!entries[0].item.title.contains("✅"))
+    #expect(entries[0].title == "Done task")
+    #expect(!entries[0].title.contains("✅"))
   }
 
   @Test func completedWithNoDateHasNilCompletedAt() {
@@ -415,26 +415,26 @@ struct ObsidianTaskParserCompletedTests {
 
   @Test func completedTaskExtractsPriority() {
     let entries = parseCompleted("- [x] High priority task ⏫")
-    #expect(entries[0].item.priority == .high)
-    #expect(entries[0].item.title == "High priority task")
+    #expect(entries[0].priority == .high)
+    #expect(entries[0].title == "High priority task")
   }
 
   @Test func completedTaskExtractsDueDate() {
     let entries = parseCompleted("- [x] Task 📅 2025-06-01")
-    #expect(entries[0].item.dueDate != nil)
-    #expect(entries[0].item.title == "Task")
+    #expect(entries[0].dueDate != nil)
+    #expect(entries[0].title == "Task")
   }
 
   @Test func completedTaskPreservesNativeID() {
     let entries = parseCompleted("- [x] Task", relativePath: "Projects/done.md")
-    #expect(entries[0].item.id.nativeID == "Projects/done.md:1")
-    #expect(entries[0].item.id.providerID == "obsidian")
+    #expect(entries[0].id.nativeID == "Projects/done.md:1")
+    #expect(entries[0].id.providerID == "obsidian")
   }
 
   @Test func completedTaskPreservesNotes() {
     let content = "- [x] Done\n    Some follow-up notes"
     let entries = parseCompleted(content)
-    #expect(entries[0].item.notes?.contains("Some follow-up notes") == true)
+    #expect(entries[0].notes?.contains("Some follow-up notes") == true)
   }
 
   @Test func mixedContentReturnsOnlyCompleted() {
@@ -445,19 +445,19 @@ struct ObsidianTaskParserCompletedTests {
       """
     let entries = parseCompleted(content)
     #expect(entries.count == 2)
-    #expect(entries[0].item.title == "Done one")
-    #expect(entries[1].item.title == "Done two")
+    #expect(entries[0].title == "Done one")
+    #expect(entries[1].title == "Done two")
   }
 
   @Test func parsesOrderedListCompletedTask() {
     let entries = parseCompleted("1. [x] Done ordered")
     #expect(entries.count == 1)
-    #expect(entries[0].item.title == "Done ordered")
+    #expect(entries[0].title == "Done ordered")
   }
 
   @Test func parsesOrderedListCompletedWithDate() {
     let entries = parseCompleted("2. [x] Done ✅ 2025-06-01")
-    #expect(entries[0].item.title == "Done")
+    #expect(entries[0].title == "Done")
     #expect(entries[0].completedAt != nil)
   }
 }

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -21,6 +21,7 @@ private final class FakeWritableProvider: WritableTaskProvider {
   private(set) var createListCalls: [String] = []
   private(set) var renameListCalls: [(String, String)] = []
   private(set) var deleteListCalls: [String] = []
+  private(set) var deleteTaskCalls: [TaskRef] = []
 
   func authorize() async throws {}
   func lists() async throws -> [TaskList] {
@@ -60,6 +61,10 @@ private final class FakeWritableProvider: WritableTaskProvider {
   func deleteList(_ listID: String) {
     deleteListCalls.append(listID)
   }
+
+  func deleteTask(_ ref: TaskRef) {
+    deleteTaskCalls.append(ref)
+  }
 }
 
 private final class FakeReadOnlyProvider: TaskProvider {
@@ -73,9 +78,9 @@ private final class FakeReadOnlyProvider: TaskProvider {
   func observe() -> AsyncStream<[TaskItem]>? { nil }
 }
 
-private final class FakeMutableProvider: MutableTaskProvider {
-  let id = "fake-mutable"
-  let displayName = "Fake Mutable"
+private final class FakeClosableProvider: ClosableTaskProvider {
+  let id = "fake-closable"
+  let displayName = "Fake Closable"
   let entitlement: ProviderEntitlement = .paid(productID: "com.taskmato.provider.fake")
 
   private(set) var completedRefs: [TaskRef] = []
@@ -95,8 +100,8 @@ private final class FakeMutableProvider: MutableTaskProvider {
 @Suite("WritableTaskProvider")
 struct WritableTaskProviderTests {
 
-  @Test func writableProviderSatisfiesMutableProvider() {
-    let provider: any MutableTaskProvider = FakeWritableProvider()
+  @Test func writableProviderSatisfiesClosableProvider() {
+    let provider: any ClosableTaskProvider = FakeWritableProvider()
     #expect(provider.id == "fake-writable")
   }
 
@@ -198,29 +203,29 @@ struct TaskProviderTests {
     #expect(try await provider.tasks(in: nil).isEmpty)
   }
 
-  @Test func mutableProviderIsPaid() {
-    let provider = FakeMutableProvider()
+  @Test func closableProviderIsPaid() {
+    let provider = FakeClosableProvider()
     #expect(provider.entitlement == .paid(productID: "com.taskmato.provider.fake"))
   }
 
-  @Test func mutableProviderTracksComplete() async throws {
-    let provider = FakeMutableProvider()
-    let ref = TaskRef(providerID: "fake-mutable", nativeID: "1")
+  @Test func closableProviderTracksComplete() async throws {
+    let provider = FakeClosableProvider()
+    let ref = TaskRef(providerID: "fake-closable", nativeID: "1")
     try await provider.complete(ref)
     #expect(provider.completedRefs == [ref])
     #expect(provider.reopenedRefs.isEmpty)
   }
 
-  @Test func mutableProviderTracksReopen() async throws {
-    let provider = FakeMutableProvider()
-    let ref = TaskRef(providerID: "fake-mutable", nativeID: "1")
+  @Test func closableProviderTracksReopen() async throws {
+    let provider = FakeClosableProvider()
+    let ref = TaskRef(providerID: "fake-closable", nativeID: "1")
     try await provider.reopen(ref)
     #expect(provider.reopenedRefs == [ref])
     #expect(provider.completedRefs.isEmpty)
   }
 
-  @Test func mutableProviderSatisfiesTaskProvider() {
-    let provider: any TaskProvider = FakeMutableProvider()
-    #expect(provider.id == "fake-mutable")
+  @Test func closableProviderSatisfiesTaskProvider() {
+    let provider: any TaskProvider = FakeClosableProvider()
+    #expect(provider.id == "fake-closable")
   }
 }

--- a/app/TaskmatoTests/TaskRegistryTests.swift
+++ b/app/TaskmatoTests/TaskRegistryTests.swift
@@ -58,7 +58,7 @@ private final class StubScopedProvider: TaskProvider {
   func observe() -> AsyncStream<[TaskItem]>? { nil }
 }
 
-private final class StubMutableProvider: MutableTaskProvider {
+private final class StubClosableProvider: ClosableTaskProvider {
   let id: String
   let displayName: String
   let entitlement: ProviderEntitlement = .free
@@ -272,22 +272,22 @@ struct TaskRegistryTests {
     #expect(registry.provider(for: ref) == nil)
   }
 
-  @Test func mutableProviderForMutableConformer() {
+  @Test func closableProviderForClosableConformer() {
     let registry = makeRegistry()
-    let provider = StubMutableProvider(id: "mutable")
+    let provider = StubClosableProvider(id: "closable")
     registry.register(provider)
 
-    let ref = TaskRef(providerID: "mutable", nativeID: "x")
-    #expect(registry.mutableProvider(for: ref) != nil)
+    let ref = TaskRef(providerID: "closable", nativeID: "x")
+    #expect(registry.closableProvider(for: ref) != nil)
   }
 
-  @Test func mutableProviderForReadOnlyReturnsNil() {
+  @Test func closableProviderForReadOnlyReturnsNil() {
     let registry = makeRegistry()
     let provider = StubProvider(id: "readonly")
     registry.register(provider)
 
     let ref = TaskRef(providerID: "readonly", nativeID: "x")
-    #expect(registry.mutableProvider(for: ref) == nil)
+    #expect(registry.closableProvider(for: ref) == nil)
   }
 
   // MARK: - List scoping


### PR DESCRIPTION
## Summary

Implements the \"View Completed\" inline section in the task picker (#300) and list rename in the provider sidebar. Completed tasks are revealed via a Show/Hide toolbar toggle (Reminders-style) and appear at the bottom of their originating list section with restore and permanent-delete affordances. Also renames `MutableTaskProvider` → `ClosableTaskProvider` to better reflect the protocol's intent.

## Linked issue

Closes #300

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**Step 0 — `MutableTaskProvider` → `ClosableTaskProvider` rename**
Pure rename across all conformances, tests, and cast sites. No functional change.

**Step 1 — `TaskItem.completedAt: Date?`**
Additive field (defaults `nil`). Wired through `LocalTask.asTaskItem`, `ObsidianTaskParser.buildCompletedEntry` (parses `✅ YYYY-MM-DD`), and `ObsidianProvider.completedTasks()` (sorts by `completedAt` directly on `TaskItem`; eliminates the old `(item, completedAt)` tuple).

**Step 2 — `deleteTask` on `WritableTaskProvider`**
Added `func deleteTask(_ ref: TaskRef) async throws` to the protocol. `LocalProvider` already satisfied the requirement; no body change needed.

**Step 3 — `CompletedTaskRowView` + `CompletedTaskCardView`**
- Row (list mode): filled `checkmark.circle.fill` restore button, muted title, `list · N ago` subtitle, hover trash with `confirmationDialog` guard.
- Card (grid mode): same data, card layout matching `TaskCardView`, trash button overlaid in `ZStack(alignment: .topTrailing)` on hover.

**Step 4 — Inline completed section in `TasksTabView`**
- `hasClosableProvider` computed property gates the toolbar button.
- Toolbar toggle uses `eye` / `eye.slash` icons.
- Banner row shows total count + Hide shortcut.
- `loadCompleted()` buckets items by `list.id` into `completedByListID`; unmatched items go to `completedOrphans`.
- Completed rows append at the bottom of the **last** `FlatSection` for each list (avoids duplicating across multi-section lists).
- Orphan catch-all section appears after all active sections.
- `handleRestore` / `handleDelete` refresh both active and completed lists.
- `TaskGroup`, `TaskSection`, `FlatSection` extracted to `TasksTabViewTypes.swift` to keep `TasksTabView.swift` within the 500-line SwiftLint limit.

**Step 5 — Inline list rename in `ProviderSidebarView`**
Right-clicking a list row for a `WritableTaskProvider` shows a **Rename** item. Selecting it replaces the row label with an inline `TextField` pre-filled with the current name. Return commits; Escape cancels. `@FocusState` drives focus into the field automatically. `listNameField(list:provider:)` extracted to stay within function body length limit.

**Step 6 — TODO housekeeping**
Ticked sidebar (#298) and View Completed (#300) checkboxes. Added `## Notifications & sound (exploration)` section with issue #341 (double audio cue on phase completion).

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` — zero violations)
- [x] Unit tests pass locally (`make test`)
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

- Obsidian `completedTasks()` is included in the bucket but shows **no trash button** (Obsidian is `ClosableTaskProvider` only, not `WritableTaskProvider`). Clicking the filled circle calls `reopen`, which rewrites `- [x]` back to `- [ ]` in the vault file.
- The `MutableTaskProvider` rename is a breaking change for any external conformers, but there are none — all providers are internal.
- `completedByListID` keys on `list.id`, not `FlatSection.id` (which is a composite key). `FlatSection.listID` was added to expose the raw list ID for correct bucketing.