### PR TITLE
feat(main-window): reorder tabs and default sidebar collapsed (#371)

### DIFF
--- a/app/Taskmato/ActiveTaskView.swift
+++ b/app/Taskmato/ActiveTaskView.swift
@@ -70,7 +70,7 @@ struct ActiveTaskView: View {
           if engine.isRunning { engine.pause() }
           NSApp.activate(ignoringOtherApps: true)
           openWindow(id: "main")
-          NotificationCenter.default.post(name: .showTasksTab, object: nil)
+          NotificationCenter.default.post(name: .browseTasksAndPick, object: nil)
         } label: {
           Image(systemName: "arrow.triangle.swap")
             .font(.caption2)

--- a/app/Taskmato/AppNotifications.swift
+++ b/app/Taskmato/AppNotifications.swift
@@ -6,10 +6,17 @@
 import Foundation
 
 extension Notification.Name {
-  /// Posted by the compact popover when the user taps "Browse Tasks…".
+  /// Posted to switch to the Tasks tab without changing sidebar visibility.
   ///
-  /// `MainWindowView` listens for this and switches to the Tasks tab.
+  /// Used for plain tab-switches and auto-navigations after the active task is completed or
+  /// cleared. The sidebar stays in whatever state the user last left it in.
   static let showTasksTab = Notification.Name("Taskmato.showTasksTab")
+
+  /// Posted when the user explicitly wants to browse and pick a task.
+  ///
+  /// `MainWindowView` listens for this, expands the provider sidebar (so list scoping is
+  /// visible), and switches to the Tasks tab.
+  static let browseTasksAndPick = Notification.Name("Taskmato.browseTasksAndPick")
 
   /// Posted by the compact popover when the user taps the session stats row.
   ///

--- a/app/Taskmato/MainWindow/MainWindowView.swift
+++ b/app/Taskmato/MainWindow/MainWindowView.swift
@@ -5,10 +5,20 @@
 
 import SwiftUI
 
+/// Tab ordering for the main window. Raw values are stable selection tags.
+enum MainTab: Int {
+  /// The Tasks tab — the landing tab; hosts the task browser and provider sidebar.
+  case tasks = 0
+  /// The Timer tab — focus/break controls; the popover handles most timer interaction.
+  case timer = 1
+  /// The Stats tab — Today / 7-day / All-time session summaries.
+  case stats = 2
+}
+
 /// The root view for the main application window, hosting three-tab navigation.
 ///
-/// Tabs: Timer (primary), Tasks (P1/P3), Stats (P6).
-/// Settings opens in a separate window via ⌘, or the app menu.
+/// Tabs in order: Tasks (landing), Timer, Stats. Settings opens in a separate window
+/// via ⌘, or the app menu.
 struct MainWindowView: View {
 
   var engine: SessionEngine
@@ -17,11 +27,20 @@ struct MainWindowView: View {
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
 
-  @State private var selectedTab: Int = 0
+  @State private var selectedTab: MainTab = .tasks
 
   var body: some View {
     TabView(selection: $selectedTab) {
-      Tab("Timer", systemImage: "timer", value: 0) {
+      Tab("Tasks", systemImage: "checklist", value: MainTab.tasks) {
+        TasksTabView(
+          selectionStore: selectionStore,
+          registry: registry,
+          selectedTab: $selectedTab,
+          settings: settings
+        )
+      }
+
+      Tab("Timer", systemImage: "timer", value: MainTab.timer) {
         TimerTabView(
           engine: engine,
           settings: settings,
@@ -33,28 +52,23 @@ struct MainWindowView: View {
         )
       }
 
-      Tab("Tasks", systemImage: "checklist", value: 1) {
-        TasksTabView(
-          selectionStore: selectionStore,
-          registry: registry,
-          selectedTab: $selectedTab,
-          settings: settings
-        )
-      }
-
-      Tab("Stats", systemImage: "chart.bar", value: 2) {
+      Tab("Stats", systemImage: "chart.bar", value: MainTab.stats) {
         StatsTabView(store: store)
       }
     }
     .frame(minWidth: 640, minHeight: 400)
     .onReceive(NotificationCenter.default.publisher(for: .showTimerTab)) { _ in
-      selectedTab = 0
+      selectedTab = .timer
     }
     .onReceive(NotificationCenter.default.publisher(for: .showTasksTab)) { _ in
-      selectedTab = 1
+      selectedTab = .tasks
     }
     .onReceive(NotificationCenter.default.publisher(for: .showStatsTab)) { _ in
-      selectedTab = 2
+      selectedTab = .stats
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .browseTasksAndPick)) { _ in
+      settings.sidebarVisible = true
+      selectedTab = .tasks
     }
   }
 }

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -15,7 +15,7 @@ struct TasksTabView: View {
 
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
-  @Binding var selectedTab: Int
+  @Binding var selectedTab: MainTab
   @Bindable var settings: AppSettings
 
   @State private var query: String = ""
@@ -408,7 +408,7 @@ extension TasksTabView {
 
   private func select(_ task: TaskItem) {
     selectionStore.select(task)
-    selectedTab = 0
+    selectedTab = .timer
   }
 
   /// Completes the task via its closable provider, then refreshes the list.
@@ -493,7 +493,7 @@ extension TasksTabView {
   TasksTabView(
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
-    selectedTab: .constant(1),
+    selectedTab: .constant(.tasks),
     settings: AppSettings()
   )
 }

--- a/app/Taskmato/MainWindow/TimerTabView.swift
+++ b/app/Taskmato/MainWindow/TimerTabView.swift
@@ -45,7 +45,7 @@ struct TimerTabView: View {
         .padding(.horizontal, 8)
       } else {
         Button {
-          NotificationCenter.default.post(name: .showTasksTab, object: nil)
+          NotificationCenter.default.post(name: .browseTasksAndPick, object: nil)
         } label: {
           Label("Browse Tasks…", systemImage: "checklist")
             .font(.caption)

--- a/app/Taskmato/Settings/AppSettings.swift
+++ b/app/Taskmato/Settings/AppSettings.swift
@@ -65,7 +65,7 @@ final class AppSettings {
 
   /// Whether the provider/list sidebar column is visible in the Tasks tab.
   ///
-  /// Defaults to `true`.
+  /// Defaults to `false`; pick-flow entries (Browse Tasks…, swap-task) implicitly expand it.
   var sidebarVisible: Bool {
     didSet { defaults.set(sidebarVisible, forKey: Keys.sidebarVisible) }
   }
@@ -109,7 +109,7 @@ final class AppSettings {
     showDockIcon = defaults.object(forKey: Keys.showDockIcon) as? Bool ?? false
     let rawLayout = defaults.string(forKey: Keys.taskPickerLayout)
     taskPickerLayout = rawLayout.flatMap(TaskPickerLayout.init) ?? .grid
-    sidebarVisible = defaults.object(forKey: Keys.sidebarVisible) as? Bool ?? true
+    sidebarVisible = defaults.object(forKey: Keys.sidebarVisible) as? Bool ?? false
     taskSortField =
       defaults.string(forKey: Keys.taskSortField).flatMap(TaskSortField.init) ?? .dueDate
     taskSortDirection =

--- a/app/Taskmato/TimerView.swift
+++ b/app/Taskmato/TimerView.swift
@@ -78,7 +78,7 @@ struct TimerView: View {
           let popover = NSApp.keyWindow
           NSApp.activate(ignoringOtherApps: true)
           openWindow(id: "main")
-          NotificationCenter.default.post(name: .showTasksTab, object: nil)
+          NotificationCenter.default.post(name: .browseTasksAndPick, object: nil)
           DispatchQueue.main.async { popover?.close() }
         } label: {
           Label("Browse Tasks…", systemImage: "checklist")

--- a/docs/architecture/design/0003-main-window-navigation.md
+++ b/docs/architecture/design/0003-main-window-navigation.md
@@ -1,0 +1,55 @@
+# Main window navigation — tab order and sidebar default
+
+## Status
+
+Accepted 2026-06-03. Tracked under [#371](https://github.com/richwklein/taskmato/issues/371); targeted at the 0.6.0 milestone. No ADR is filed — this is a small UX/ordering change with no architecture commitments. [ADR-0003](../decisions/0003-navigation-split-view-sidebar.md) (NavigationSplitView for Tasks) is unaffected.
+
+## Background
+
+The main window hosts three tabs — Timer, Tasks, Stats. Timer and Stats render as plain full-width `VStack` views; Tasks renders inside a `NavigationSplitView` with a sidebar column and a richer toolbar (add, show completed, layout toggle, sort). Traversing the tabs in the current order produces a visible layout shift:
+
+- Timer → Tasks expands the window chrome to add the sidebar column.
+- Tasks → Stats collapses the chrome again.
+
+The shift happens on every traversal because Tasks sits between two structurally simpler tabs.
+
+The current tab order also inverts the actual workflow. The menu bar popover already handles the bulk of timer interaction (start, pause, status, next-task swap). When a user opens the **main window**, they are typically browsing tasks or reviewing stats. Putting Timer first places the least-needed-in-the-main-window view at the landing position.
+
+A second-order question fell out of the redesign: the Tasks sidebar is genuinely useful when the user is **picking** a task (it scopes by provider and list), but it is just visual noise when the user is merely **switching to** Tasks (e.g., after completing the active task, the app auto-navigates back to Tasks). The two intents currently go through the same notification.
+
+## Competitive analysis
+
+Five macOS Pomodoro / time-tracking apps reviewed for prior art on window structure:
+
+- **Flow** — menu bar popover plus a single tabbed main window with a mini-mode, and a floating timer for full-screen work. Closest to Taskmato's model.
+- **Session** — spreads state across menu bar, notifications, Live Activities, and widgets; no strict window-switching model.
+- **Be Focused** — menu bar popover only; preferences panel for settings; no main window for everyday use.
+- **Toggl Track** — explicit dual-mode: a full window plus a mini floating timer (Shift+⌘+M, pinnable always-on-top).
+- **Klokki** — inverted model: automatic background tracking with an optional floating widget; no main window at all.
+
+## Pattern findings
+
+- Every major macOS Pomodoro app uses the menu bar as the primary entry point.
+- Among apps that *have* a main window at all, a **single tabbed main window** is the dominant pattern — none use one window per function.
+- No competitor uses separate windows for Timer / Tasks / Stats.
+- A **floating always-on-top timer** is the most-requested missing feature across the category. (Tracked here as [#260](https://github.com/richwklein/taskmato/issues/260), out of scope for this change.)
+
+## Decisions
+
+1. **Keep the single tabbed main window.** Separating Timer / Tasks / Stats into independent windows has no competitive precedent and no user-facing benefit. The current `TabView` structure stays.
+
+2. **Reorder tabs to Tasks → Timer → Stats.** This mirrors the user workflow (pick task → run session → review stats) and puts the two layout-simple tabs at opposite ends, with Timer in the middle. Tasks becomes the landing tab.
+
+3. **Stats does not get a sidebar at 0.6.0.** Stats today is three time scopes — Today / 7-day / All-time — which is a segmented picker, not a hierarchical filter. Revisit if per-task drill-down lands in 1.1.
+
+4. **Sidebar defaults to collapsed.** `AppSettings.sidebarVisible` flips from `true` to `false` on first launch. Tasks renders as a plain full-width detail column — visually consistent with Timer and Stats — eliminating the layout shift. The sidebar toggle still works; persisted user state is preserved (only first-launch / never-set behavior changes).
+
+5. **Distinguish pick-flow entries from plain tab-switches.** A new `.browseTasksAndPick` notification routes the three explicit task-picking entry points (Browse Tasks… from the Timer tab and the popover, plus the swap-task button on the active task row) through a path that **expands the sidebar before** switching to Tasks. Plain `.showTasksTab` continues to route auto-navigations after the active task is completed or cleared, and leaves sidebar state untouched. Once the sidebar is open via pick-flow, the user can still collapse it; the collapsed state persists until the next pick-flow entry.
+
+6. **Replace raw `Int` tab tags with `enum MainTab: Int`.** The notification handlers in `MainWindowView` previously hardcoded `selectedTab = 0/1/2`; reordering tabs without updating all three sites was a real regression risk. A small enum makes the order explicit and the call sites self-documenting.
+
+## Out of scope
+
+- Floating always-on-top timer panel ([#260](https://github.com/richwklein/taskmato/issues/260)) — separate issue; the most-requested category-wide feature, but independent of this navigation change.
+- Full / minimized mode ([#293](https://github.com/richwklein/taskmato/issues/293)) — separate issue.
+- Stats sidebar — not warranted for 0.6.0 scope; revisit if per-task drill-down lands in 1.1.


### PR DESCRIPTION
## Summary

Calms the main window's tab navigation by (a) reordering tabs to **Tasks → Timer → Stats** so the landing tab matches the user workflow, and (b) defaulting `AppSettings.sidebarVisible` to `false` so the Tasks tab renders as a plain detail column on first launch — eliminating the layout shift that was visible when traversing the three tabs.

Also distinguishes the **task-picking** entry points (Browse Tasks…, swap-task) from plain tab-switches: pick-flow entries now expand the sidebar before navigating to Tasks; post-complete/post-clear auto-navigations leave sidebar state untouched.

## Linked issue

Closes #371

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

- **`MainTab: Int` enum** in `MainWindowView.swift` replaces the previous raw-`Int` tab tags (`0/1/2`), so reordering tabs can no longer silently break notification handlers.
- **Tab order** is now Tasks (landing) → Timer → Stats.
- **`AppSettings.sidebarVisible`** default flips from `true` to `false`. Persisted user state is preserved via `defaults.object(forKey:)` — only first-launch / never-set behavior changes.
- **New `.browseTasksAndPick` notification** wired into `MainWindowView`: it sets `settings.sidebarVisible = true` and selects `.tasks`. Posted by `TimerTabView.swift:48`, `TimerView.swift:81`, and `ActiveTaskView.swift:73`.
- **`.showTasksTab`** kept for plain tab-switches and auto-navigations after the active task is completed (`ActiveTaskView.swift:178`) or cleared (`ActiveTaskView.swift:183`); these leave sidebar state untouched.
- **Design doc** at `docs/architecture/design/0003-main-window-navigation.md` captures the competitive analysis (Flow, Session, Be Focused, Toggl Track, Klokki) and the six decisions. Numbered `0003` because `0002-` was already taken by `0002-provider-sidebar-revisited.md`; the issue's suggested `0002-` filename is therefore inapplicable.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` — 0 violations across 79 files)
- [x] Unit tests pass locally (`make test` — all unit + UI tests passed)
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [x] Documentation updated where appropriate

`make build`, `make format-check`, and the full Swift Testing + UI test suites all green.

## Reviewer notes

- No existing tests assert tab indices, and `MainWindowView` is not unit-testable in isolation (it depends on `TabView` selection), so no new automated tests were added for the reorder itself. The UI tests in `TaskmatoUITests` already exercise launch and basic navigation and continue to pass.
- The acceptance-criterion bullet "Switching between all three tabs produces no visible layout shift when the sidebar is collapsed" requires manual verification at runtime; please confirm during review.
- First launch shows the sidebar collapsed; existing installs keep whatever `sidebarVisible` was last persisted (no migration).
- Related, out of scope: #260 (floating always-on-top timer), #293 (full / minimized mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)