### PR TITLE
feat(sidebar): add per-provider icons to sidebar, task view, and Add Task picker

### DIFF
--- a/app/Taskmato/MainWindow/ProviderSidebarView.swift
+++ b/app/Taskmato/MainWindow/ProviderSidebarView.swift
@@ -116,20 +116,28 @@ struct ProviderSidebarView: View {
         newListRow(providerID: provider.id)
       }
     } header: {
-      Text(provider.displayName)
-        .contextMenu {
-          if provider is ObsidianProvider {
-            Button("Configure Obsidian…") { isConfiguringObsidian = true }
-            Divider()
-          }
-          if provider is RemindersProvider {
-            Button("Configure Apple Reminders…") { isConfiguringReminders = true }
-            Divider()
-          }
-          Button("Remove \(provider.displayName)", role: .destructive) {
-            registry.disable(providerID: provider.id)
-          }
+      HStack(spacing: 6) {
+        Image(systemName: provider.icon)
+          .imageScale(.small)
+        Text(provider.displayName)
+        Spacer()
+      }
+      .font(.callout)
+      .padding(.vertical, 2)
+      .contentShape(Rectangle())
+      .contextMenu {
+        if provider is ObsidianProvider {
+          Button("Configure Obsidian…") { isConfiguringObsidian = true }
+          Divider()
         }
+        if provider is RemindersProvider {
+          Button("Configure Apple Reminders…") { isConfiguringReminders = true }
+          Divider()
+        }
+        Button("Remove \(provider.displayName)", role: .destructive) {
+          registry.disable(providerID: provider.id)
+        }
+      }
     }
   }
 
@@ -273,7 +281,7 @@ struct ProviderSidebarView: View {
   private var addProviderMenu: some View {
     Menu {
       ForEach(disabledProviders, id: \.id) { provider in
-        Button(provider.displayName) {
+        Button {
           registry.enable(provider)
           if provider is ObsidianProvider {
             isConfiguringObsidian = true
@@ -282,6 +290,8 @@ struct ProviderSidebarView: View {
             isConfiguringReminders = true
           }
           Task { await loadLists(for: provider) }
+        } label: {
+          Label(provider.displayName, systemImage: provider.icon)
         }
       }
     } label: {

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -59,8 +59,9 @@ struct TasksTabView: View {
       return ("magnifyingglass", label)
     }
     if registry.selection == .today { return ("calendar", "Today") }
-    guard case .list = registry.selection, let grp = groupedLists.first else { return nil }
-    return ("list.bullet", grp.listName)
+    guard case .list(let sel) = registry.selection, let grp = groupedLists.first else { return nil }
+    let icon = registry.providers.first(where: { $0.id == sel.providerID })?.icon ?? "list.bullet"
+    return (icon, grp.listName)
   }
 
   var body: some View {

--- a/app/Taskmato/Tasks/Local/AddTaskView.swift
+++ b/app/Taskmato/Tasks/Local/AddTaskView.swift
@@ -44,7 +44,7 @@ struct AddTaskView: View {
             .foregroundStyle(.secondary)
           Picker("List", selection: $selectedListID) {
             ForEach(provider.taskLists) { list in
-              Text(list.name).tag(list.id.uuidString)
+              Label(list.name, systemImage: "list.bullet").tag(list.id.uuidString)
             }
           }
           .labelsHidden()
@@ -129,4 +129,5 @@ extension TaskPriority {
     case .highest: return "Highest"
     }
   }
+
 }

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -21,6 +21,7 @@ final class LocalProvider: WritableTaskProvider {
 
   let id: String = LocalProvider.providerID
   let displayName: String = "Local"
+  let icon: String = "tray"
   let entitlement: ProviderEntitlement = .free
 
   /// Lists managed by this provider, in creation order.

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -26,6 +26,7 @@ final class ObsidianProvider: ClosableTaskProvider {
 
   let id: String = ObsidianProvider.providerID
   let displayName: String = "Obsidian"
+  let icon: String = "book.closed"
   let entitlement: ProviderEntitlement = .free
 
   /// The user-selected vault directory, resolved from the stored security-scoped bookmark.

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -20,6 +20,7 @@ final class RemindersProvider: ClosableTaskProvider {
 
   let id: String = RemindersProvider.providerID
   let displayName: String = "Apple Reminders"
+  let icon: String = "checklist"
   let entitlement: ProviderEntitlement = .free
 
   /// Whether the user has granted full Reminders access.

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -17,6 +17,9 @@ protocol TaskProvider: AnyObject, Sendable {
   /// Human-readable name shown in the Providers settings panel.
   var displayName: String { get }
 
+  /// SF Symbol name used to represent this provider in the UI.
+  var icon: String { get }
+
   /// Whether this provider is free or requires a StoreKit purchase.
   var entitlement: ProviderEntitlement { get }
 

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -13,6 +13,7 @@ import Testing
 private final class FakeWritableProvider: WritableTaskProvider {
   let id = "fake-writable"
   let displayName = "Fake Writable"
+  let icon = "square"
   let entitlement: ProviderEntitlement = .free
 
   private(set) var defaultListID: String?
@@ -70,6 +71,7 @@ private final class FakeWritableProvider: WritableTaskProvider {
 private final class FakeReadOnlyProvider: TaskProvider {
   let id = "fake-readonly"
   let displayName = "Fake Read-Only"
+  let icon = "square"
   let entitlement: ProviderEntitlement = .free
 
   func authorize() async throws {}
@@ -81,6 +83,7 @@ private final class FakeReadOnlyProvider: TaskProvider {
 private final class FakeClosableProvider: ClosableTaskProvider {
   let id = "fake-closable"
   let displayName = "Fake Closable"
+  let icon = "square"
   let entitlement: ProviderEntitlement = .paid(productID: "com.taskmato.provider.fake")
 
   private(set) var completedRefs: [TaskRef] = []

--- a/app/TaskmatoTests/TaskRegistrySelectionTests.swift
+++ b/app/TaskmatoTests/TaskRegistrySelectionTests.swift
@@ -13,6 +13,7 @@ import Testing
 private final class SelectionStubProvider: TaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private let stubbedTasks: [TaskItem]
   private let stubbedLists: [TaskList]
@@ -33,6 +34,7 @@ private final class SelectionStubProvider: TaskProvider {
 private final class SelectionScopedProvider: TaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private let stubbedLists: [TaskList]
   private let tasksByListID: [String: [TaskItem]]
@@ -56,6 +58,7 @@ private final class SelectionScopedProvider: TaskProvider {
 private final class SelectionWritableProvider: WritableTaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let defaultListID: String?
 

--- a/app/TaskmatoTests/TaskRegistrySortTests.swift
+++ b/app/TaskmatoTests/TaskRegistrySortTests.swift
@@ -13,6 +13,7 @@ import Testing
 private final class SortStubProvider: TaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   var stubbedItems: [TaskItem]
 

--- a/app/TaskmatoTests/TaskRegistryTests.swift
+++ b/app/TaskmatoTests/TaskRegistryTests.swift
@@ -15,6 +15,7 @@ private struct StubError: Error, Equatable {}
 private final class StubProvider: TaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let stubbedTasks: [TaskItem]
   let shouldThrow: Bool
@@ -38,6 +39,7 @@ private final class StubProvider: TaskProvider {
 private final class StubClosableProvider: ClosableTaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let stubbedTasks: [TaskItem]
   private(set) var completedRefs: [TaskRef] = []

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -22,6 +22,7 @@ private struct HandlerContext {
 private final class StubTaskProvider: TaskProvider {
   let id: String
   let displayName: String
+  let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private let stubbedTasks: [TaskItem]
 


### PR DESCRIPTION
## Summary

Adds a distinct SF Symbol icon to each task provider and surfaces it consistently across the sidebar, task view affordance, and Add Task dialog. Providers had no visual identity — section headers were plain text, the Add Provider menu showed only names, and the task list affordance always used the generic `list.bullet` icon regardless of which provider's list was selected.

## Linked issue

Closes #372
Closes #359 

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**Protocol layer (`TaskProvider.swift`)**
Added `var icon: String { get }` to the protocol. Concrete mappings:

| Provider | SF Symbol |
|---|---|
| Local | `tray` |
| Reminders | `checklist` |
| Obsidian | `book.closed` |

**Sidebar (`ProviderSidebarView.swift`)**
- Section headers replaced `Text(provider.displayName)` with an `HStack` carrying `Image(systemName: provider.icon).imageScale(.small)` + `Text`, matching the existing list-row icon style.
- Added `Spacer()` + `.contentShape(Rectangle())` so right-clicking anywhere across the full header row opens the context menu, not just over the icon/text.
- Applied `.font(.callout)` and `.padding(.vertical, 2)` for improved readability.
- Add Provider menu items now render as `Label(provider.displayName, systemImage: provider.icon)`.

**Task view affordance (`TasksTabView.swift`)**
The list affordance header resolves the selected list's provider from `registry.selection` and uses `provider.icon` instead of the hard-coded `"list.bullet"`. Falls back to `"list.bullet"` if the provider can't be resolved.

**Add Task picker (`AddTaskView.swift`)**
List options in the picker now use `Label(list.name, systemImage: "list.bullet")`, consistent with the sidebar list row style.

Today/Search affordance icons (`calendar`, `magnifyingglass`) are unchanged — those are view-type indicators, not provider-specific. Provider icons in those contexts are tracked separately in #361.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` — 0 violations)
- [ ] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

- Priority icon changes in the Add Task dialog were considered and deferred to #378 (mapping decided: lowest/low → `!`, medium → `!!`, high/highest → `!!!`).
- Menu bar right-click context menu deferred to #379.
- Today/Search provider icon placement deferred to #361.
