### PR TITLE
fix(vscode): make sweetpad work in git worktrees

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
   "[swift]": {
     "editor.defaultFormatter": "sweetpad.sweetpad"
   },
-  "cSpell.words": ["pomodoro", "swiftlint", "taskmato"]
+  "cSpell.words": ["pomodoro", "swiftlint", "taskmato"],
+  "sweetpad.build.xcodeWorkspacePath": "app/Taskmato.xcodeproj/project.xcworkspace"
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,7 +1,14 @@
 {
   "version": "2.0.0",
   "tasks": [
-        {
+    {
+      "label": "Sync Version",
+      "type": "shell",
+      "command": "make sync-version",
+      "presentation": { "reveal": "silent", "panel": "shared" },
+      "problemMatcher": []
+    },
+    {
       "type": "sweetpad",
       "action": "launch",
       "problemMatcher": [
@@ -12,7 +19,8 @@
       ],
       "label": "Build and Launch",
       "detail": "Build and Launch the app",
-      "isBackground": true // ! Required for debugging
+      "isBackground": true, // ! Required for debugging
+      "dependsOn": ["Sync Version"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Two VS Code config fixes that make the sweetpad extension work correctly when opening the project from any git worktree.

1. **Pin the Xcode workspace path** — adds `sweetpad.build.xcodeWorkspacePath` to `.vscode/settings.json` so sweetpad doesn't need per-workspace VS Code state to locate the project. Without this, clicking "Select Workspace" threw `The "path" argument must be of type string. Received undefined`, and builds failed because no scheme could be resolved.

2. **Generate `Version.xcconfig` before every build** — adds a `Sync Version` shell task that runs `make sync-version` and wires it as a `dependsOn` prerequisite of the `Build and Launch` sweetpad task. `Version.xcconfig` is gitignored and must be generated from `version.txt`; fresh worktrees don't have it, causing an immediate `Unable to open base configuration reference file` error. This mirrors exactly what `code-build.yaml` already does in CI.

## Linked issue

Closes #

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- `sweetpad.build.xcodeWorkspacePath` must point to the `.xcworkspace` bundle (`app/Taskmato.xcodeproj/project.xcworkspace`), not the `.xcodeproj` — xcodebuild rejects the latter with "is not a workspace file."
- The relative path works across all worktrees since every worktree shares the same directory structure.
- The `Sync Version` task uses `reveal: silent` so it doesn't interrupt the build output panel.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

Verified in the `fix/sweetpad` worktree: sweetpad finds the workspace, `Version.xcconfig` is generated automatically, and the `Build and Launch` / LLDB attach flow completes successfully.

## Reviewer notes

No Swift source changes — `.vscode/` only. Safe to squash.