### PR TITLE
feat(providers): add displayOrder for consistent provider ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,9 +128,12 @@ Code should be presented **file-by-file** and suitable for direct application.
 - Provide build or run instructions when behavior changes
 - Call out when Xcode is required (signing, entitlements, extensions)
 
+**Before building or committing any source code change**, run `make sync-version` first to generate `app/Taskmato/Config/Version.xcconfig` — the build fails without it.
+
 **Before committing any source code change**, agents must run and pass both checks locally:
 
 ```
+make sync-version  # generates Version.xcconfig — required before every build
 make lint          # SwiftLint — must report zero violations
 make format-check  # swift-format — must report zero issues
 ```

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -21,6 +21,7 @@ final class LocalProvider: WritableTaskProvider {
 
   let id: String = LocalProvider.providerID
   let displayName: String = "Local"
+  let displayOrder: Int = 0
   let icon: String = "tray"
   let entitlement: ProviderEntitlement = .free
 

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -17,6 +17,12 @@ protocol TaskProvider: AnyObject, Sendable {
   /// Human-readable name shown in the Providers settings panel.
   var displayName: String { get }
 
+  /// Relative display position when listing providers in the sidebar and add-provider menu.
+  ///
+  /// Lower values appear first. Providers that do not override this property default to
+  /// `Int.max` and are then ordered alphabetically by `displayName` among themselves.
+  var displayOrder: Int { get }
+
   /// SF Symbol name used to represent this provider in the UI.
   var icon: String { get }
 
@@ -50,6 +56,7 @@ protocol TaskProvider: AnyObject, Sendable {
 
 extension TaskProvider {
   var isAuthorized: Bool { true }
+  var displayOrder: Int { Int.max }
 }
 
 /// A `TaskProvider` that supports toggling task completion state in the source system.

--- a/app/Taskmato/Tasks/TaskRegistry.swift
+++ b/app/Taskmato/Tasks/TaskRegistry.swift
@@ -27,7 +27,7 @@ typealias ProviderFetchError = (providerID: String, error: any Error)
 @MainActor
 final class TaskRegistry {
 
-  /// All providers that have been registered, in registration order.
+  /// All providers that have been registered, ordered by `displayOrder` then `displayName`.
   private(set) var providers: [any TaskProvider] = []
 
   /// IDs of providers currently enabled by the user.
@@ -73,10 +73,19 @@ final class TaskRegistry {
   // MARK: - Registration
 
   /// Registers a provider so it appears in the registry. Does not enable it automatically.
+  ///
+  /// The `providers` array is re-sorted after insertion: ascending by `displayOrder`,
+  /// then alphabetically by `displayName` when orders are equal.
   /// - Parameter provider: The provider to register.
   func register(_ provider: any TaskProvider) {
     guard !providers.contains(where: { $0.id == provider.id }) else { return }
     providers.append(provider)
+    providers.sort { lhs, rhs in
+      guard lhs.displayOrder == rhs.displayOrder else {
+        return lhs.displayOrder < rhs.displayOrder
+      }
+      return lhs.displayName.localizedStandardCompare(rhs.displayName) == .orderedAscending
+    }
   }
 
   // MARK: - Enable / Disable

--- a/app/TaskmatoTests/TaskRegistryTests.swift
+++ b/app/TaskmatoTests/TaskRegistryTests.swift
@@ -357,6 +357,42 @@ struct TaskRegistryTests {
     #expect(registry.firstEnabledWritableProvider?.id == "writable")
   }
 
+  // MARK: Provider ordering
+
+  @Test func registerSortsProvidersByDisplayOrder() {
+    let registry = makeRegistry()
+    let high = StubProvider(id: "high")
+    let low = StubProvider(id: "low")
+    // Simulate displayOrder: register high-order provider first.
+    registry.register(high)
+    registry.register(low)
+    // Both stubs use the default displayOrder (Int.max) so they fall back to displayName order.
+    // "high" < "low" alphabetically, so "high" should appear first.
+    #expect(registry.providers[0].id == "high")
+    #expect(registry.providers[1].id == "low")
+  }
+
+  @Test func localProviderDisplayOrderIsLowerThanDefault() {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    let local = LocalProvider(fileURL: url)
+    let readOnly = StubProvider(id: "z-other")
+    let registry = makeRegistry()
+    registry.register(readOnly)
+    registry.register(local)
+    #expect(registry.providers[0].id == LocalProvider.providerID)
+    #expect(registry.providers[1].id == "z-other")
+  }
+
+  @Test func alphaNumericTieBreakOrdersProvidersByDisplayName() {
+    let registry = makeRegistry()
+    registry.register(StubProvider(id: "zebra"))
+    registry.register(StubProvider(id: "apple"))
+    registry.register(StubProvider(id: "mango"))
+    let ids = registry.providers.map(\.id)
+    #expect(ids == ["apple", "mango", "zebra"])
+  }
+
   // MARK: providerAuthorizationStates
 
   @Test func providerAuthorizationStatesEmptyWithNoProviders() {


### PR DESCRIPTION
## Summary

Adds a `displayOrder` property to the `TaskProvider` protocol so providers appear in a deterministic, user-friendly order throughout the app. `LocalProvider` is pinned first (order 0); all other providers default to `Int.max` and are sorted alphabetically by `displayName` among themselves. The current order with three providers becomes: **Local → Apple Reminders → Obsidian**.

`TaskRegistry.register()` re-sorts the `providers` array after each insertion, so the sidebar, add-provider menu, selection-cascade fallback, and task fan-out queries all see a consistent order without any call-site changes.

## Linked issue

Closes #362

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- `TaskProvider` gains `var displayOrder: Int { get }` (between `displayName` and `icon` in declaration order) with a default extension implementation of `Int.max`.
- `LocalProvider` declares `let displayOrder: Int = 0` — the only concrete override needed today.
- `ObsidianProvider` and `RemindersProvider` inherit the default and are naturally ordered "Obsidian" > "Apple Reminders" alphabetically, placing Apple Reminders second and Obsidian third.
- `TaskRegistry.register()` sorts by `(displayOrder ascending, displayName localizedStandard ascending)` after every insertion — a single-location fix that propagates everywhere.
- `AGENTS.md` now documents `make sync-version` as a required step before building (the xcconfig is not checked in).

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` — 0 violations)
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

Three new tests in `TaskRegistryTests`:
- `registerSortsProvidersByDisplayOrder` — default-order alphabetic fallback
- `localProviderDisplayOrderIsLowerThanDefault` — Local pinned before any default-order provider
- `alphaNumericTieBreakOrdersProvidersByDisplayName` — multi-provider alphabetic tie-break

## Reviewer notes

Any new provider added in the future gets correct placement automatically — it lands in alphabetical order among peers without needing to pick a magic integer. Only providers that need a fixed position (like Local) need to override `displayOrder`.