### PR TITLE
docs(architecture): add pre-1.0 architecture pass design doc

### DIFF
--- a/docs/architecture/design/0005-pre-1.0-architecture-pass.md
+++ b/docs/architecture/design/0005-pre-1.0-architecture-pass.md
@@ -1,0 +1,406 @@
+# Pre-1.0 architecture pass
+
+## Status
+
+Proposed 2026-06-05. Tracks architectural work across milestones 0.7.0 (foundation + DRY), 0.8.0 (SwiftData session migration), and 0.9.0 (registry split, Swift 6, polish). Sequenced PRs land independently per AGENTS.md "one logical change per run." No ADR is filed yet; once the registry split lands the existing `TaskRegistry` shape will be obsolete and ADR-0007 should record the new boundary.
+
+## Background
+
+Comprehensive architecture review conducted on the `task/architecture-review` branch against v0.6.x state: 60 Swift files (~6.9k LOC), six accepted ADRs, four prior design docs. The review consulted the README, all ADRs, all design docs, every Swift source file, the Xcode project settings, the issue backlog, and the macOS-development skill modules.
+
+Headline assessment: the architecture is consciously chosen and well-defended at the protocol and engine layers. The weaknesses concentrate in **view-layer plumbing** (row/card and timer duplication), **composition-root size** (60-line `TaskmatoApp.init`), **cross-tab routing via `NotificationCenter`**, **JSON-persistence ceiling** for the session log, **Swift 5 language mode** (no strict concurrency), and **absent accessibility**. None of these is structural — each maps to a contained refactor that fits AGENTS.md's reviewable-increments rule.
+
+This document records the design decisions made during review and the resulting PR roadmap.
+
+## Goals
+
+- Take every architecturally-load-bearing decision deliberately, before 1.0 ships and the user base makes changes expensive.
+- Reduce duplication enough that adding a cloud provider (1.3.0) and writable expansion (1.1.0) become one-folder operations, not cross-cutting edits.
+- Land Swift 6 strict concurrency before 1.0 so the first signed DMG ships clean.
+- Replace JSON persistence for the session log with SwiftData behind a repository abstraction, at the moment aggregation needs grow (0.8.0).
+- Establish view-layer DI patterns matching the codebase's existing constructor-injection style.
+
+## Non-goals
+
+- Major UI redesign. Existing screens stay; their structure improves.
+- macOS 26 (Tahoe) features (Liquid Glass, Foundation Models). Stay on macOS 15 minimum for the pass. Revisit at 2.0.
+- LocalProvider storage migration to SwiftData. Defer to post-1.1 to contain refactor pressure during writable expansion on Obsidian/Reminders.
+- New tests of the existing surface. Wave 4 (registry split) and Wave 2 (TimerPresenter, PhaseOrchestrator) naturally produce smaller and more numerous unit tests; that's enough.
+
+## Decisions
+
+### D1 — Drop the `TaskRegistry` façade
+
+The existing 476-LOC `TaskRegistry` is split into four independent types: `ProviderRegistry`, `SelectionStore`, `TaskQueryService`, `TaskSorter`. No façade is retained. Each caller depends on the smaller types it actually needs. `ProviderSidebarView` binds `SelectionStore`, not the registry — this resolves a long-standing view ↔ service coupling smell.
+
+### D2 — Repository pattern over `@Model`-as-domain for SwiftData
+
+`Session`, `LocalTask`, `LocalList` stay as plain Codable structs. SwiftData entities (`SessionEntity`, eventually `LocalTaskEntity`) live behind `SessionRepository` / `LocalTaskRepository` protocols. Rationale: keeps the domain pure, lets tests use a one-struct fake repository, and makes the migration a single-file flip in composition rather than a cross-codebase rewrite. The entity ⇄ domain mapping uses init-style extensions (`Session.init(entity:)` + `SessionEntity.init(session:)`) — no separate mapper type until the mapping grows.
+
+### D3 — Constructor DI everywhere; scene-bound `openWindow` action
+
+The new `MainNavigation` model is `@Observable` `@MainActor` and constructor-injected through composition into every consumer (`MainWindowView`, `MenuBarPopoverView`, `URLSchemeHandler`, `ActiveTaskView`). The `openWindow` SwiftUI environment action — which can only be captured inside a view — is bound once onto the navigation model via `bindOpenMainWindow(_:)` from the menu-bar scene's first `.onAppear`. This is action injection layered on top of pure constructor DI of the model itself.
+
+URLs that arrive at the `AppDelegate` before any scene mounts (cold launch via `taskmato://`) are **buffered** until the menu-bar scene reports ready, then drained. This is the option-A fix to the cold-launch race that NotificationCenter routing currently masks silently.
+
+### D4 — All view concerns under `Views/` with subfolders
+
+Final layout co-locates each tab with its model, content, toolbar, and inner components. Provider setup sheets and their `+Configuration.swift` adapters move to `Views/Settings/<Provider>/`, freeing the provider source files from `import SwiftUI`. See [§ Target architecture](#target-architecture) for the full tree.
+
+### D5 — Stay on macOS 15 minimum
+
+The codebase uses the macOS-15 `Tab(title:systemImage:value:) { content }` API; dropping to 14 would require rewriting all three tabs for no real user benefit. Going to 26 would unlock Liquid Glass and Foundation Models but cut off Sequoia users at the moment of first install. Hold on 15 for the entire pre-1.0 window; revisit at 2.0.
+
+### D6 — CI runs on `macos-latest` (now macOS 26 / Tahoe)
+
+`macos-latest` migrated to macOS 26 on June 15, 2026 ([changelog](https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/)). The runner provides Xcode 26, which can target macOS 15 from D5 — newest compiler, same deployment target. `macos-15` and `macos-14` remain available; `macos-13` is closing down.
+
+### D7 — Swift 6 lands at 0.9.0 (pre-DMG)
+
+Sequence: enable `SWIFT_STRICT_CONCURRENCY = complete` under Swift 5 first, fix warnings by concern, then flip `SWIFT_VERSION = 6.0`. Pre-DMG is the cheapest moment — the install base is zero. Audit `@unchecked Sendable`: currently none introduced; keep it that way.
+
+### D8 — `SessionEngine` becomes `@MainActor`
+
+The engine is driven by a `Timer.scheduledTimer` on the main runloop and consumed exclusively from `@MainActor` views. Making the actor isolation explicit documents the contract and clears Swift 6 warnings for free. Concurrently, replace the `now: () -> Date` clock-injection closure with `ContinuousClock` for idiomatic test-time control.
+
+### D9 — `SessionEngine.onPhaseEnded` callback becomes `AsyncStream<PhaseEvent>` + `PhaseOrchestrator`
+
+The 27-line side-effect cascade currently inside `TaskmatoApp.init` (append session → play sound → send notification → sync engine durations → auto-start or queue) moves into a `PhaseOrchestrator` that consumes a stream of `PhaseEvent` values from the engine. This makes the cascade unit-testable in isolation and removes the engine's tuple-callback surface.
+
+### D10 — `LocalProvider` matches the `WritableTaskProvider` async-throws shape
+
+Today `LocalProvider.addTask`, `setDefaultList`, `createList`, etc. are declared sync; the protocol declares them `async throws`. Sync-satisfies-async works in Swift but lets callers bypass the protocol — and `URLSchemeHandler` does exactly that today, calling `localProvider.addTask(draft)` directly with a concrete-type reference. Matching the shape closes the bypass and, once `URLSchemeHandler` routes through `ProviderRegistry.firstEnabledWritableProvider`, closes issues #387 and #303 at the same time.
+
+## Target architecture
+
+### Composition
+
+```
+                       ┌──────────────────────────────────────┐
+                       │ TaskmatoApp (@main)                  │
+                       │   only @main + scene composition     │
+                       │                                      │
+                       │ AppDelegate                          │
+                       │   activation policy, URL buffer      │
+                       │                                      │
+                       │ AppComposition                       │
+                       │   constructs every service           │
+                       │   exposes them as let-properties     │
+                       └──────────────────────────────────────┘
+                                         │
+        ┌────────────────────────────────┼────────────────────────────────┐
+        ▼                                ▼                                ▼
+┌──────────────────┐         ┌────────────────────────┐         ┌──────────────────┐
+│ Session/         │         │ Tasks/Registry/        │         │ Services/        │
+│   SessionEngine  │         │   ProviderRegistry     │         │   AppSettings    │
+│   (@MainActor)   │         │   SelectionStore       │         │   TaskSelection  │
+│                  │         │   TaskQueryService     │         │   Notifications  │
+│   AsyncStream    │         │   TaskSorter           │         │   Sound          │
+│   <PhaseEvent>   │         │                        │         │                  │
+└──────────────────┘         └────────────────────────┘         └──────────────────┘
+        │                                │                                │
+        ▼                                ▼                                │
+┌──────────────────┐         ┌────────────────────────┐                  │
+│ PhaseOrchestrator│         │ Tasks/Providers/       │                  │
+│   consumes the   │         │   Local / Obsidian /   │                  │
+│   stream; owns   │         │   Reminders            │                  │
+│   side effects   │         │                        │                  │
+└──────────────────┘         └────────────────────────┘                  │
+        │                                │                                │
+        ▼                                ▼                                ▼
+┌──────────────────┐         ┌────────────────────────┐         ┌──────────────────┐
+│ Session/Storage/ │         │ Tasks/Providers/Local/ │         │ Views/App/       │
+│   SessionRepo    │         │   Storage/             │         │   MainNavigation │
+│   (protocol)     │         │   LocalTaskRepo        │         │   ErrorPresenter │
+│                  │         │   (post-1.1)           │         │                  │
+│   SwiftData impl │         │                        │         │                  │
+└──────────────────┘         └────────────────────────┘         └──────────────────┘
+```
+
+### Provider protocol hierarchy (unchanged from ADR-0001)
+
+```
+TaskProvider                       (read-only: id, lists, tasks, observe, authorize)
+└── ClosableTaskProvider           (+ complete, reopen, completedTasks)
+    └── WritableTaskProvider       (+ addTask, defaultListID, createList, renameList,
+                                     deleteList, deleteTask, setDefaultList)
+
+LocalProvider     conforms WritableTaskProvider
+ObsidianProvider  conforms ClosableTaskProvider     (writable at 1.1 via #328)
+RemindersProvider conforms ClosableTaskProvider     (writable at 1.1 via #329)
+
+ConfigurableTaskProvider (separate axis) — provides a setup-sheet view
+   Obsidian and Reminders conform via Views/Settings/<Provider>/+Configuration.swift adapters.
+```
+
+### Folder layout (target)
+
+```
+app/Taskmato/
+├── TaskmatoApp.swift                  (only @main + scene composition)
+├── AppDelegate.swift                  (extracted; URL buffer + activation policy)
+├── AppComposition.swift               (NEW — the wiring)
+├── Bundle+AppName.swift
+├── Info.plist
+│
+├── Session/
+│   ├── SessionEngine.swift            (@MainActor, ContinuousClock)
+│   ├── PhaseOrchestrator.swift        (NEW)
+│   ├── Session.swift                  (domain struct)
+│   ├── SessionSummary.swift           (domain value)
+│   └── Storage/
+│       ├── SessionRepository.swift    (protocol)
+│       ├── JSONSessionRepository.swift
+│       └── SwiftDataSessionRepository.swift
+│
+├── Tasks/
+│   ├── Models/                        (TaskItem, TaskList, TaskRef, TaskQuery,
+│   │                                   TaskPriority, TaskDraft, TaskSortField,
+│   │                                   TaskSortDirection, SidebarSelection,
+│   │                                   SelectedList, NoteFormat, ProviderEntitlement,
+│   │                                   TaskPickerLayout, ProviderID newtype)
+│   ├── Registry/                      (Wave 4 split)
+│   │   ├── ProviderRegistry.swift
+│   │   ├── SelectionStore.swift
+│   │   ├── TaskQueryService.swift
+│   │   └── TaskSorter.swift
+│   ├── Providers/
+│   │   ├── TaskProvider.swift              (protocol hierarchy)
+│   │   ├── ConfigurableTaskProvider.swift  (protocol only)
+│   │   ├── Local/{LocalProvider, LocalList, LocalTask, Storage/}
+│   │   ├── Obsidian/{ObsidianProvider, ObsidianTaskParser}
+│   │   └── Reminders/{RemindersProvider, *EventStore}
+│   └── URLScheme/URLSchemeHandler.swift
+│
+├── Services/
+│   ├── AppSettings.swift
+│   ├── TaskSelectionStore.swift
+│   ├── NotificationService.swift
+│   └── SoundService.swift
+│
+└── Views/
+    ├── App/{MainWindowView, MainNavigation, ErrorPresenter}
+    ├── MenuBar/MenuBarPopoverView.swift
+    ├── Timer/
+    │   ├── TimerTabView.swift
+    │   ├── TimerPresenter.swift
+    │   ├── ActiveTaskView.swift
+    │   └── Components/{CircularTimerView, ControlButton, SessionStatsView}
+    ├── Tasks/
+    │   ├── TasksTabView.swift
+    │   ├── TasksTabModel.swift            (NEW)
+    │   ├── TasksTabContent.swift          (NEW)
+    │   ├── TasksTabToolbar.swift          (NEW)
+    │   ├── TasksTabSortMenu.swift
+    │   ├── TasksTabSections.swift
+    │   ├── ProviderSidebarView.swift
+    │   ├── AddTaskView.swift
+    │   └── Components/{TaskItemPresenter, TaskRowView, TaskCardView, TaskLineage,
+    │                   TaskNoteView, TaskLabel, TaskItemKind, TaskMarkdownTitle}
+    ├── Stats/
+    │   ├── StatsTabView.swift
+    │   ├── StatsViewModel.swift           (NEW — scope methods move here)
+    │   └── Components/StatCardView.swift
+    └── Settings/
+        ├── SettingsView.swift
+        ├── Components/DurationField.swift
+        ├── Obsidian/{ObsidianSetupSheet, ObsidianSettingsView,
+        │             ObsidianProvider+Configuration}
+        └── Reminders/{RemindersSetupSheet,
+                       RemindersProvider+Configuration}
+```
+
+## Findings inventory
+
+| # | Finding | Severity | Effort | Addressed by |
+|---|---|:---:|:---:|---|
+| A | Row/Card duplication (~70% identical bodies + state) | H | M | Wave 2 — `TaskItemPresenter` |
+| B | Timer popover vs main-window-tab duplication | H | M | Wave 2 — `TimerPresenter` |
+| C | Composition-root logic in `TaskmatoApp.init` (60 lines) | M | M | Foundation — `AppComposition` |
+| D | Engine-duration sync pattern duplicated in 5 sites | M | S | Wave 2 — `engine.applyDurations(from:)` |
+| E | UserDefaults sprawl (5 clients write keys ad-hoc) | M | M | Wave 5 — `SettingsStore` |
+| F | `NotificationCenter` for cross-tab routing | M | M | Routing — `MainNavigation` |
+| G | Markdown title rendering duplicated 3× | L | S | DRY — `TaskMarkdownTitle` |
+| H | Priority styling duplicated 3× | L | S | DRY — `TaskPriority.accentColor` |
+| I | `isUrgent` duplicated 2× | L | S | DRY — `Date.isUrgent` |
+| J | `SessionEngine.onPhaseEnded` tuple callback | M | M | Wave 2 — `AsyncStream<PhaseEvent>` |
+| K | Silent `try?` on user-facing operations | M | M | Wave 3 — `ErrorPresenter` |
+| L | Debounce helper duplicated across providers | L | S | DRY — `Debouncer` actor |
+| M | `TaskRegistry` god-class (476 LOC, five concerns) | H | L | Wave 4 — registry split |
+| N | `SoundService` reads from a private framework path | M | S | issue #341 |
+| O | Notification authorization requested on every `send()` | M | S | Hardening — one-shot at launch |
+| P | `SessionStore` exposes UI-shaped scope methods | L | S | Persistence — `StatsViewModel` |
+| Q | `LocalProvider` dual-API surface | M | M | Surface — protocol match + registry routing |
+| R | Swift 5 language mode; no strict concurrency | H | L | Wave 5 — Swift 6 flip |
+| S | `TaskRef.providerID` is `String` | L | M | Wave 4 — `ProviderID` newtype |
+| T | Project layout inconsistencies | L | S | Structure — Views/ + Services/ moves |
+| U | `displayOrder` default `Int.max` inconsistent across providers | L | S | Hardening — explicit per provider |
+| V | `SessionEngine` not `@MainActor` | L | S | Wave 5 — `@MainActor` annotation |
+| W | `ProviderSidebarView` mutates `TaskRegistry` directly | L | M | Wave 4 — sidebar binds `SelectionStore` |
+| X | Codable session log has no version field | L | S | Persistence — SwiftData migration supersedes |
+| Y | Test coverage gaps in composition, routing, view flows | M | L | Wave 4 + Wave 2 produce naturally smaller tests |
+| Z | No accessibility audit | M | M | Wave 5 — accessibility pass |
+| 6.5 | `Calendar.endOfToday` DST bug | L | S | Hardening |
+| 6.6 | `TasksTabView.refresh()` fires from 8 onChange modifiers | L | S | Wave 2 — `TasksTabModel` |
+
+## Roadmap
+
+Each row is one PR. Ordered so PRs are mergeable in isolation and the next builds on it.
+
+### 0.7.0 — P3 close-out + foundation
+
+| # | PR | Wave | Tracked by / Findings |
+|---|---|---|---|
+| 1 | Extract `AppDelegate.swift` from `TaskmatoApp.swift` | Foundation | [#394](https://github.com/richwklein/taskmato/issues/394) |
+| 2 | Introduce `AppComposition.swift`; move service init out of `TaskmatoApp.init` | Foundation | [#394](https://github.com/richwklein/taskmato/issues/394), C (part) |
+| 3 | Extract `Debouncer` actor; adopt in `ObsidianProvider` + `RemindersProvider` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), L |
+| 4 | Centralize markdown title via `TaskMarkdownTitle` + `TaskItem.markdownTitle` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), G |
+| 5 | Centralize priority styling on `TaskPriority` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), H |
+| 6 | Add `Date.isUrgent`; remove from row/card | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), I |
+| 7 | Introduce `MainNavigation` with `bindOpenMainWindow` | Routing | [#396](https://github.com/richwklein/taskmato/issues/396), F (part) |
+| 8 | Add URL buffer in `AppDelegate` (option A — drain on first scene mount) | Routing | [#396](https://github.com/richwklein/taskmato/issues/396) |
+| 9 | Replace NotificationCenter routing with `MainNavigation` calls; delete `AppNotifications.swift` | Routing | [#396](https://github.com/richwklein/taskmato/issues/396), F |
+| 10 | Match `LocalProvider` method signatures to `WritableTaskProvider` (`async throws`) | Surface | [#397](https://github.com/richwklein/taskmato/issues/397), Q (part) |
+| 11 | Route `URLSchemeHandler.makeAdHocTask` through `ProviderRegistry.firstEnabledWritableProvider`; drop `localProvider:` from URL handler init | Surface | [#397](https://github.com/richwklein/taskmato/issues/397), Q, **#387**, **#303** |
+| 12 | Restructure `Views/` into subfolders (MenuBar, Timer, Tasks, Stats, Settings, App); move provider adapters under `Views/Settings/<Provider>/` | Structure | [#398](https://github.com/richwklein/taskmato/issues/398), T, **#388** |
+| 13 | Create `Services/`; move `AppSettings`, `TaskSelectionStore`, `NotificationService`, `SoundService` into it. Move `TaskPickerLayout` → `Tasks/Models/` | Structure | [#398](https://github.com/richwklein/taskmato/issues/398), T |
+| 14 | Single-shot notification authorization at launch; drop per-`send` auth | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), O |
+| 15 | Fix `Calendar.endOfToday` DST bug | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), 6.5 |
+| 16 | Add `os.Logger` to `SessionStore` and `LocalProvider` save paths | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), T (part) |
+
+Already-planned 0.7.0 issues (#260, #293, #303, #330, #341, #370, #383, #392) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 (closed by PR 11). **#388** closes as part of PR 12.
+
+### 0.8.0 — Stats expansion + SwiftData session migration
+
+| # | PR | Wave | Tracked by / Findings |
+|---|---|---|---|
+| 17 | Introduce `SessionRepository` protocol; extract `JSONSessionRepository` from `SessionStore` | Persistence | [#400](https://github.com/richwklein/taskmato/issues/400), P (prep) |
+| 18 | Introduce `StatsViewModel`; move `todaySummary` / `thisWeekSummary` / `todayFocusCount` / `todayFocusMinutes` out of `SessionStore` | Persistence | [#401](https://github.com/richwklein/taskmato/issues/401), P |
+| 19 | Implement `SessionRepository.focusTotals(over:)`; `StatsViewModel.taskBreakdown` uses it | Persistence | **#268** |
+| 20 | 7-day / all-time charts in `StatsTabView` | Stats | **#270** |
+| 21 | Streak + daily focus total in `MenuBarPopoverView` | Stats | **#271** |
+| 22 | Add `SwiftDataSessionRepository` (`@Model SessionEntity` + init-style mapping) | Persistence | [#402](https://github.com/richwklein/taskmato/issues/402) |
+| 23 | One-shot migration: read JSON on first launch under SwiftData impl, write SwiftData, rename JSON to `.archived` | Persistence | [#402](https://github.com/richwklein/taskmato/issues/402) |
+| 24 | Flip `AppComposition` default to `SwiftDataSessionRepository`; keep JSON impl for one release | Persistence | [#402](https://github.com/richwklein/taskmato/issues/402) |
+| 25 | New design doc amending ADR-0002 (`0006-session-repository-swiftdata.md`) | Docs | [#402](https://github.com/richwklein/taskmato/issues/402) |
+
+### 0.9.0 — Polish, Swift 6, registry split
+
+| # | PR | Wave | Tracked by / Findings |
+|---|---|---|---|
+| 26 | Introduce `ProviderID` newtype; migrate `TaskRef`, `TaskList`, provider `id` | Wave 4 | [#403](https://github.com/richwklein/taskmato/issues/403), S |
+| 27 | Extract `TaskSorter` from `TaskRegistry`; move sort tests | Wave 4 | [#404](https://github.com/richwklein/taskmato/issues/404), M |
+| 28 | Extract `TaskQueryService(registry:, sorter:)`; registry delegates | Wave 4 | [#404](https://github.com/richwklein/taskmato/issues/404), M |
+| 29 | Extract `SelectionStore`; `ProviderSidebarView` binds `selectionStore` | Wave 4 | [#404](https://github.com/richwklein/taskmato/issues/404), M, W |
+| 30 | Rename remaining `TaskRegistry` → `ProviderRegistry`; drop pass-through methods; update all callers | Wave 4 | [#404](https://github.com/richwklein/taskmato/issues/404), M |
+| 30a | Establish design token vocabulary (`Typography`, `Color`, `Spacing`, `Shape`, `Opacity`) + `docs/reference/styling.md` | Style | [#415](https://github.com/richwklein/taskmato/issues/415) |
+| 30b | Apply design tokens across existing views; resolve audit-surfaced inconsistencies | Style | [#416](https://github.com/richwklein/taskmato/issues/416) |
+| 31 | Add `engine.applyDurations(from:)`; replace the 5-site sync pattern | Wave 2 | [#405](https://github.com/richwklein/taskmato/issues/405), D |
+| 32 | Introduce `TimerPresenter`; refactor popover + tab views; extract `CircularTimerView` / `ControlButton` / `SessionStatsView` to `Views/Timer/Components/` | Wave 2 | [#405](https://github.com/richwklein/taskmato/issues/405), B |
+| 33 | Introduce `TaskItemPresenter`; refactor `TaskRowView` and `TaskCardView` to layout-only views | Wave 2 | [#406](https://github.com/richwklein/taskmato/issues/406), A |
+| 34 | Replace `SessionEngine.onPhaseEnded` with `AsyncStream<PhaseEvent>`; add `PhaseOrchestrator`; `AppComposition` runs it | Wave 2 | [#407](https://github.com/richwklein/taskmato/issues/407), J, C (rest) |
+| 35 | Mark `SessionEngine` `@MainActor`; replace `now: () -> Date` with `ContinuousClock` | Wave 5 | [#407](https://github.com/richwklein/taskmato/issues/407), V |
+| 36 | Set `SWIFT_STRICT_CONCURRENCY = complete` under Swift 5; fix warnings by concern | Wave 5 | [#408](https://github.com/richwklein/taskmato/issues/408), R (part) |
+| 37 | Flip `SWIFT_VERSION = 6.0` | Wave 5 | [#408](https://github.com/richwklein/taskmato/issues/408), R |
+| 38 | Introduce `SettingsStore` (single-writer wrapping `UserDefaults`); migrate clients | Wave 5 | [#409](https://github.com/richwklein/taskmato/issues/409), E |
+| 39 | Introduce `ErrorPresenter`; surface provider errors in `TasksTabView`; replace `try?` in handlers + `AddTaskView.submit` | Wave 3 | [#410](https://github.com/richwklein/taskmato/issues/410), K |
+| 40 | Accessibility pass: `accessibilityLabel/Value` on `CircularTimerView`, labels on plain icon buttons, Dynamic Type on timer label, color-contrast audit | Wave 5 | [#411](https://github.com/richwklein/taskmato/issues/411), Z |
+
+Already-planned 0.9.0 issues: #374, #379. Note **#387** moves to 0.7.0; **#388** closes via PR 12.
+
+### 1.0.0 — DMG (no architectural change)
+
+Stabilise. Fix **#280** (LCOV pipeline). Ship the signed DMG. The architecture pass is complete by the cut date.
+
+### 1.4.0 — Persistence pass (LocalProvider repository)
+
+Filed against milestone **1.4.0** ("Persistence pass — LocalProvider repository protocol extraction + SwiftData migration"). Deferred until after writable expansion at 1.1.0 closes so refactor pressure stays contained.
+
+| # | PR | Tracked by |
+|---|---|---|
+| 41 | Introduce `LocalTaskRepository` protocol + `JSONLocalTaskRepository`; `LocalProvider` injects it | [#412](https://github.com/richwklein/taskmato/issues/412) |
+| 42 | Add `SwiftDataLocalTaskRepository` + migration; flip default | [#413](https://github.com/richwklein/taskmato/issues/413) |
+| 43 | Delete `JSONSessionRepository` and `JSONLocalTaskRepository` (one release after each flip) | [#414](https://github.com/richwklein/taskmato/issues/414) |
+
+## Definition of done
+
+The architecture pass is complete when:
+
+- [ ] `TaskmatoApp.init` is fewer than 10 lines.
+- [ ] `TaskRegistry` no longer exists; `ProviderRegistry`, `SelectionStore`, `TaskQueryService`, `TaskSorter` are its replacement.
+- [ ] No `NotificationCenter.default.post(name:)` for cross-view routing in the codebase.
+- [ ] No file references `/System/Library/PrivateFrameworks/`.
+- [ ] Every user-initiated provider operation propagates errors to `ErrorPresenter`.
+- [ ] `SessionStore` no longer exists; `SessionRepository` (SwiftData impl) is the source of truth; scope methods live on `StatsViewModel`.
+- [ ] `Views/` contains only view types; `Services/` contains only services; `Tasks/`, `Session/` contain only domain + storage; `App/` contains only composition.
+- [ ] `SWIFT_VERSION = 6.0` and the build is clean.
+- [ ] `SessionEngine` is `@MainActor` and uses `ContinuousClock`.
+- [ ] Every interactive control has an accessibility label; the circular timer announces remaining time + phase to VoiceOver.
+
+## Open items
+
+1. **ADR-0007 (Pluggable task providers, revised)** should land when the registry split closes (after PR 30). It supersedes the boundary description in ADR-0001 with the new `ProviderRegistry + SelectionStore + TaskQueryService + TaskSorter` shape. ADR-0001 stays as the record of the protocol hierarchy itself, which is unchanged.
+2. **ADR-0002 amendment** for SwiftData lands alongside PR 25.
+3. **Issue triage**: done — tracking issues filed (see [Tracking issues](#tracking-issues) below). **#387** moved from 0.9.0 → 0.7.0.
+4. **Migration safety**: PRs 22–24 should land behind a debug build flag for the first 0.8.x release so a quick rollback to JSON is possible if the SwiftData migration surfaces problems in the wild (small audience at 0.8 makes this low-risk, but cheap insurance).
+5. **macOS 26 reconsideration**: at 2.0, revisit D5 — by then Sequoia drops further down the install base and Liquid Glass + Foundation Models become worth the bump.
+
+## Tracking issues
+
+The GitHub issues filed to track this design doc, in chronological / milestone order. Each issue covers one or more roadmap PRs.
+
+### 0.7.0
+
+- [#394](https://github.com/richwklein/taskmato/issues/394) — Extract `AppDelegate` and introduce `AppComposition` (PRs 1–2).
+- [#395](https://github.com/richwklein/taskmato/issues/395) — DRY pass: `Debouncer`, markdown title, priority styling, urgent date (PRs 3–6).
+- [#396](https://github.com/richwklein/taskmato/issues/396) — Replace `NotificationCenter` cross-tab routing with `MainNavigation` + URL buffer (PRs 7–9).
+- [#397](https://github.com/richwklein/taskmato/issues/397) — Match `LocalProvider` to `WritableTaskProvider` async-throws shape; route URL handler through registry (PRs 10–11; closes #387, aligns with #303).
+- [#398](https://github.com/richwklein/taskmato/issues/398) — Restructure source tree into `Views/` subfolders, `Services/`, `Tasks/Models/` (PRs 12–13; closes #388 by construction).
+- [#399](https://github.com/richwklein/taskmato/issues/399) — Hardening pass: single-shot notification auth, `endOfToday` DST fix, write-failure logging (PRs 14–16).
+
+### 0.8.0
+
+- [#400](https://github.com/richwklein/taskmato/issues/400) — Extract `SessionRepository` protocol and `JSONSessionRepository` (PR 17).
+- [#401](https://github.com/richwklein/taskmato/issues/401) — Introduce `StatsViewModel`; move scope methods out of `SessionStore` (PR 18).
+- [#402](https://github.com/richwklein/taskmato/issues/402) — `SwiftDataSessionRepository` with one-shot JSON migration; amends ADR-0002 (PRs 22–25).
+
+### 0.9.0
+
+- [#403](https://github.com/richwklein/taskmato/issues/403) — Introduce `ProviderID` newtype (PR 26).
+- [#404](https://github.com/richwklein/taskmato/issues/404) — Split `TaskRegistry` into `ProviderRegistry` + `SelectionStore` + `TaskQueryService` + `TaskSorter` (PRs 27–30).
+- [#415](https://github.com/richwklein/taskmato/issues/415) — Establish design token vocabulary + `docs/reference/styling.md` (PR 30a).
+- [#416](https://github.com/richwklein/taskmato/issues/416) — Apply design tokens across existing views (PR 30b).
+- [#405](https://github.com/richwklein/taskmato/issues/405) — `TimerPresenter` and `engine.applyDurations(from:)` (PRs 31–32).
+- [#406](https://github.com/richwklein/taskmato/issues/406) — `TaskItemPresenter`: deduplicate `TaskRowView` and `TaskCardView` (PR 33).
+- [#407](https://github.com/richwklein/taskmato/issues/407) — `PhaseOrchestrator` with `AsyncStream` phase events; `SessionEngine` `@MainActor` + `ContinuousClock` (PRs 34–35).
+- [#408](https://github.com/richwklein/taskmato/issues/408) — Enable Swift 6 strict concurrency; flip `SWIFT_VERSION = 6.0` (PRs 36–37).
+- [#409](https://github.com/richwklein/taskmato/issues/409) — `SettingsStore`: consolidate `UserDefaults` clients (PR 38).
+- [#410](https://github.com/richwklein/taskmato/issues/410) — `ErrorPresenter`: surface provider errors in `TasksTabView` (PR 39).
+- [#411](https://github.com/richwklein/taskmato/issues/411) — Accessibility pass: timer announcements, control labels, Dynamic Type, contrast (PR 40).
+
+### 1.4.0
+
+- [#412](https://github.com/richwklein/taskmato/issues/412) — Extract `LocalTaskRepository` protocol and `JSONLocalTaskRepository` (PR 41).
+- [#413](https://github.com/richwklein/taskmato/issues/413) — `SwiftDataLocalTaskRepository` with one-shot JSON migration (PR 42).
+- [#414](https://github.com/richwklein/taskmato/issues/414) — Delete JSON repository implementations after one-release SwiftData soak (PR 43).
+
+## Related ADRs and design docs
+
+- [ADR-0001 — Pluggable task providers via protocol hierarchy](../decisions/0001-pluggable-task-providers.md) — unchanged; the protocols stay as-is.
+- [ADR-0002 — JSON file persistence for MVP](../decisions/0002-json-persistence-mvp.md) — amended by PR 25 design doc; SwiftData lands at 0.8.0.
+- [ADR-0003 — NavigationSplitView sidebar](../decisions/0003-navigation-split-view-sidebar.md) — unchanged.
+- [ADR-0006 — Developer ID distribution first](../decisions/0006-developer-id-distribution.md) — unchanged; the DMG cut at 1.0.0 lands after the architecture pass.
+- [Design doc 0002 — Provider sidebar revisited](0002-provider-sidebar-revisited.md) — load-bearing for the `SelectionStore` extraction at PR 29.
+- [Design doc 0004 — Specialized task views](0004-specialized-task-views.md) — load-bearing for the `TaskItemPresenter` design at PR 33.
+
+## Related issues
+
+Existing issues this design doc resolves or aligns with:
+
+- **#268** — `SessionStore.focusTotals(by: TaskRef)` aggregation — implemented at PR 19.
+- **#270** — 7-day / all-time charts — implemented at PR 20.
+- **#271** — Streak + daily focus total in popover header — implemented at PR 21.
+- **#303** — URL scheme creates ad-hoc tasks in any `WritableTaskProvider` — closes at PR 11.
+- **#341** — System notification sound — addresses Finding N.
+- **#387** — Remove concrete `LocalProvider` reference from `URLSchemeHandler` — closes at PR 11 (move milestone from 0.9.0 → 0.7.0).
+- **#388** — Remove stale `import SwiftUI` from `ObsidianProvider` — closes at PR 12 by construction.


### PR DESCRIPTION
## Summary

Adds [design doc 0005](docs/architecture/design/0005-pre-1.0-architecture-pass.md) — a planning artifact for the pre-1.0 architecture pass running across milestones 0.7.0 → 1.4.0. Captures the load-bearing decisions taken during the architecture review and breaks the work down into a PR-level roadmap. No code changes; implementation lands across 23 GitHub tracking issues filed against the listed milestones.

## Linked issue

Closes #

_This PR opens, rather than closes, the 23 follow-up issues — see Details._

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

Records the outcome of an end-to-end architecture review against the v0.6.x state (60 Swift files, ~6.9k LOC, six ADRs, four prior design docs).

**Ten load-bearing decisions (D1–D10):**

- **D1** — Drop the `TaskRegistry` façade; split into `ProviderRegistry` + `SelectionStore` + `TaskQueryService` + `TaskSorter`.
- **D2** — Repository pattern over `@Model`-as-domain for SwiftData migrations.
- **D3** — Constructor DI everywhere; scene-bound `openWindow` action; URL buffer for the cold-launch race.
- **D4** — All view concerns under `Views/` with subfolders; provider configuration adapters co-located under `Views/Settings/<Provider>/`.
- **D5** — Stay on macOS 15 minimum for the pass.
- **D6** — CI runs on `macos-latest` (now macOS 26).
- **D7** — Swift 6 lands at 0.9.0 (pre-DMG).
- **D8** — `SessionEngine` becomes `@MainActor`.
- **D9** — Replace the `onPhaseEnded` tuple callback with `AsyncStream<PhaseEvent>` + `PhaseOrchestrator`.
- **D10** — `LocalProvider` matches the `WritableTaskProvider` `async throws` shape.

**Other content:**

- Target folder layout for every file after the pass.
- 28 prioritised findings (A–Z plus 6.5, 6.6) with severity, effort, and addressed-by mapping.
- Milestone-mapped PR roadmap with 40+ PR rows.
- Definition of done checklist.
- Open items (ADR-0007 follow-up, ADR-0002 amendment, migration-safety notes).

**Tracking issues filed (23 across 4 milestones):**

- **0.7.0** — #394, #395, #396, #397, #398, #399
- **0.8.0** — #400, #401, #402
- **0.9.0** — #403, #404, #405, #406, #407, #408, #409, #410, #411, #415, #416
- **1.4.0** — #412, #413, #414 _(new milestone created for the post-1.1 LocalProvider repository pass)_

**Milestone change:** #387 moved from 0.9.0 → 0.7.0 (closed by #397).

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

Docs-only. release-please's transitional `always-bump-patch` policy ([ADR-0005](docs/architecture/decisions/0005-release-please-versioning.md)) will still cut a patch release on merge, but the change is not behaviorally version-worthy.

## Validation

- [x] Lint passes locally _(N/A — markdown only; pre-existing cspell/markdownlint warnings on this file intentionally not addressed here)_
- [x] Unit tests pass locally _(N/A — no source code changed)_
- [ ] Added or updated tests where appropriate _(N/A)_
- [x] Manually verified changes
- [x] Documentation updated where appropriate _(this IS the documentation)_

## Reviewer notes

This is a planning artifact, not implementation. The doc captures the load-bearing decisions so each follow-up PR (40+ planned, tracked across 23 issues) can be a one-logical-change increment per `AGENTS.md`.

Worth focusing review on:

- **Decisions D1–D10** — if any need revisiting, the corresponding follow-up issues will need to be adjusted before work starts.
- **Roadmap milestone alignment** — each PR row in the roadmap maps to a tracking issue. The first issue scheduled is #394 (Extract `AppDelegate` + `AppComposition`).
- **Open item 1** — ADR-0007 (Pluggable task providers, revised) should land after PR 30 (#404) closes; it supersedes the registry-boundary description in [ADR-0001](docs/architecture/decisions/0001-pluggable-task-providers.md). Not blocking this PR.
- **Open item 4** — migration safety for the SwiftData session migration is gated behind a debug build flag (per #402's plan). Worth confirming the flag naming convention and rollback steps before #402 work begins.

Three minor pre-existing markdownlint warnings (`Debouncer`, `subfolders`, `newtype` cSpell + one MD060 table-pipe spacing) are present in the file and intentionally not fixed here — to be handled separately if a project-level `cspell.json` lands.
