### PR TITLE
refactor(app): extract AppDelegate and introduce AppComposition

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -1,0 +1,90 @@
+//
+//  AppComposition.swift
+//  Taskmato
+//
+//  Created by Richard Klein on 5/2/26.
+//
+
+import Foundation
+
+/// The composition root for Taskmato — constructs every service and exposes
+/// them as immutable properties for injection into the scene hierarchy.
+///
+/// `TaskmatoApp` holds one `@State` instance and passes slices to each scene.
+/// The `engine.onPhaseEnded` side-effect cascade is wired here; it will move
+/// to `PhaseOrchestrator` at 0.9.0.
+@MainActor
+struct AppComposition {
+
+  let engine: SessionEngine
+  let settings: AppSettings
+  let store: SessionStore
+  let selectionStore: TaskSelectionStore
+  let registry: TaskRegistry
+  let notifications: NotificationService
+  let sounds: SoundService
+  let obsidianProvider: ObsidianProvider
+  let localProvider: LocalProvider
+  let remindersProvider: RemindersProvider
+  let urlHandler: URLSchemeHandler
+
+  /// Constructs every service, registers providers, and wires the phase-ended callback.
+  init() {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    let store = SessionStore()
+    let selectionStore = TaskSelectionStore()
+    let registry = TaskRegistry()
+    let notifications = NotificationService()
+    let sounds = SoundService()
+    let obsidianProvider = ObsidianProvider()
+    let localProvider = LocalProvider()
+    let remindersProvider = RemindersProvider()
+    registry.register(obsidianProvider)
+    registry.register(localProvider)
+    registry.register(remindersProvider)
+    // Auto-enable on first launch before any provider state is persisted.
+    if registry.enabledIDs.isEmpty { registry.enable(localProvider) }
+    let urlHandler = URLSchemeHandler(
+      registry: registry, selectionStore: selectionStore,
+      engine: engine, settings: settings, localProvider: localProvider
+    )
+    engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in
+      store.append(
+        Session(
+          id: UUID(), phase: phase, startedAt: startedAt,
+          endedAt: endedAt, wasCompleted: wasCompleted,
+          taskRef: selectionStore.activeTask?.id,
+          taskTitle: selectionStore.activeTask?.title
+        ))
+      guard wasCompleted else { return }
+      if settings.soundEnabled { sounds.play() }
+      if settings.notificationsEnabled { notifications.send(phase: phase) }
+      engine.focusDuration = settings.focusDuration
+      engine.shortBreakDuration = settings.shortBreakDuration
+      engine.longBreakDuration = settings.longBreakDuration
+      let next: SessionPhase
+      switch phase {
+      case .focus:
+        next = engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+      case .shortBreak, .longBreak: next = .focus
+      }
+      if settings.autoStartNextPhase {
+        engine.start(phase: next)
+      } else {
+        engine.enqueuePhase(next)
+      }
+    }
+    self.engine = engine
+    self.settings = settings
+    self.store = store
+    self.selectionStore = selectionStore
+    self.registry = registry
+    self.notifications = notifications
+    self.sounds = sounds
+    self.obsidianProvider = obsidianProvider
+    self.localProvider = localProvider
+    self.remindersProvider = remindersProvider
+    self.urlHandler = urlHandler
+  }
+}

--- a/app/Taskmato/AppDelegate.swift
+++ b/app/Taskmato/AppDelegate.swift
@@ -1,0 +1,53 @@
+//
+//  AppDelegate.swift
+//  Taskmato
+//
+//  Created by Richard Klein on 5/2/26.
+//
+
+import AppKit
+
+/// Applies the dock icon activation policy once the application has fully launched,
+/// and forwards URL scheme events directly to ``URLSchemeHandler``.
+///
+/// `NSApp.setActivationPolicy` must not be called during `App.init()` — the launch
+/// sequence is incomplete at that point and the call traps on restart. Deferring to
+/// `applicationDidFinishLaunching` is the documented safe window.
+///
+/// URL events are handled here rather than via `.onOpenURL` on SwiftUI views because
+/// `MenuBarExtra` content is not in the main window responder chain and misses URL events
+/// when the popover is collapsed.
+final class AppDelegate: NSObject, NSApplicationDelegate {
+
+  /// Injected by `TaskmatoApp.init()`. Called from `applicationWillFinishLaunching`,
+  /// which fires before the system delivers any queued `taskmato://` Apple events —
+  /// guaranteeing the handler is wired before the first URL arrives.
+  var bootstrap: (() -> Void)?
+
+  /// The URL handler wired by ``wire(urlHandler:)`` after composition completes.
+  private(set) var urlHandler: URLSchemeHandler?
+
+  func applicationWillFinishLaunching(_ notification: Notification) {
+    bootstrap?()
+  }
+
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    if UserDefaults.standard.bool(forKey: "showDockIcon") {
+      NSApp.setActivationPolicy(.regular)
+    }
+  }
+
+  func application(_ application: NSApplication, open urls: [URL]) {
+    guard let urlHandler else { return }
+    for url in urls {
+      Task { @MainActor in
+        await urlHandler.handle(url)
+      }
+    }
+  }
+
+  /// Completes dependency injection by wiring the URL handler after composition.
+  func wire(urlHandler: URLSchemeHandler) {
+    self.urlHandler = urlHandler
+  }
+}

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -8,168 +8,58 @@
 import AppKit
 import SwiftUI
 
-/// Applies the dock icon activation policy once the application has fully launched,
-/// and forwards URL scheme events directly to ``URLSchemeHandler``.
-///
-/// `NSApp.setActivationPolicy` must not be called during `App.init()` — the launch
-/// sequence is incomplete at that point and the call traps on restart. Deferring to
-/// `applicationDidFinishLaunching` is the documented safe window.
-///
-/// URL events are handled here rather than via `.onOpenURL` on SwiftUI views because
-/// `MenuBarExtra` content is not in the main window responder chain and misses URL events
-/// when the popover is collapsed.
-final class AppDelegate: NSObject, NSApplicationDelegate {
-
-  /// Injected by `TaskmatoApp.init()`. Called from `applicationWillFinishLaunching`,
-  /// which fires before the system delivers any queued `taskmato://` Apple events —
-  /// guaranteeing the handler is wired before the first URL arrives.
-  var bootstrap: (() -> Void)?
-
-  private(set) var urlHandler: URLSchemeHandler?
-
-  func applicationWillFinishLaunching(_ notification: Notification) {
-    bootstrap?()
-  }
-
-  func applicationDidFinishLaunching(_ notification: Notification) {
-    if UserDefaults.standard.bool(forKey: "showDockIcon") {
-      NSApp.setActivationPolicy(.regular)
-    }
-  }
-
-  func application(_ application: NSApplication, open urls: [URL]) {
-    guard let urlHandler else { return }
-    for url in urls {
-      Task { @MainActor in
-        await urlHandler.handle(url)
-      }
-    }
-  }
-
-  /// Called by the bootstrap closure to complete dependency injection.
-  fileprivate func wire(urlHandler: URLSchemeHandler) {
-    self.urlHandler = urlHandler
-  }
-}
-
 @main
 struct TaskmatoApp: App {
 
   @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-
-  @State private var engine: SessionEngine
-  @State private var settings: AppSettings
-  @State private var store: SessionStore
-  @State private var selectionStore: TaskSelectionStore
-  @State private var registry: TaskRegistry
-  @State private var notifications: NotificationService
-  @State private var sounds: SoundService
-  @State private var obsidianProvider: ObsidianProvider
-  @State private var localProvider: LocalProvider
-  @State private var remindersProvider: RemindersProvider
-  @State private var urlHandler: URLSchemeHandler
+  @State private var composition: AppComposition
 
   init() {
-    let engine = SessionEngine()
-    let settings = AppSettings()
-    let store = SessionStore()
-    let selectionStore = TaskSelectionStore()
-    let registry = TaskRegistry()
-    let notifications = NotificationService()
-    let sounds = SoundService()
-    let obsidianProvider = ObsidianProvider()
-    let localProvider = LocalProvider()
-    let remindersProvider = RemindersProvider()
-    registry.register(obsidianProvider)
-    registry.register(localProvider)
-    registry.register(remindersProvider)
-    // Auto-enable on first launch before any provider state is persisted.
-    if registry.enabledIDs.isEmpty { registry.enable(localProvider) }
-    let urlHandler = URLSchemeHandler(
-      registry: registry, selectionStore: selectionStore,
-      engine: engine, settings: settings, localProvider: localProvider
-    )
-    engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in
-      store.append(
-        Session(
-          id: UUID(), phase: phase, startedAt: startedAt,
-          endedAt: endedAt, wasCompleted: wasCompleted,
-          taskRef: selectionStore.activeTask?.id,
-          taskTitle: selectionStore.activeTask?.title
-        ))
-      guard wasCompleted else { return }
-      if settings.soundEnabled { sounds.play() }
-      if settings.notificationsEnabled { notifications.send(phase: phase) }
-      engine.focusDuration = settings.focusDuration
-      engine.shortBreakDuration = settings.shortBreakDuration
-      engine.longBreakDuration = settings.longBreakDuration
-      let next: SessionPhase
-      switch phase {
-      case .focus:
-        next = engine.nextBreakPhase(
-          longBreakAfter: settings.longBreakAfterSessions
-        )
-      case .shortBreak, .longBreak: next = .focus
-      }
-      if settings.autoStartNextPhase {
-        engine.start(phase: next)
-      } else {
-        engine.enqueuePhase(next)
-      }
-    }
-    _engine = State(initialValue: engine)
-    _settings = State(initialValue: settings)
-    _store = State(initialValue: store)
-    _selectionStore = State(initialValue: selectionStore)
-    _registry = State(initialValue: registry)
-    _notifications = State(initialValue: notifications)
-    _sounds = State(initialValue: sounds)
-    _obsidianProvider = State(initialValue: obsidianProvider)
-    _localProvider = State(initialValue: localProvider)
-    _remindersProvider = State(initialValue: remindersProvider)
-    _urlHandler = State(initialValue: urlHandler)
+    let composition = AppComposition()
+    _composition = State(initialValue: composition)
     let appDel = _appDelegate.wrappedValue
-    appDel.bootstrap = { appDel.wire(urlHandler: urlHandler) }
+    appDel.bootstrap = { appDel.wire(urlHandler: composition.urlHandler) }
   }
 
   var body: some Scene {
     MenuBarExtra {
       TimerView(
-        engine: engine,
-        settings: settings,
-        store: store,
-        selectionStore: selectionStore,
-        registry: registry,
-        nextStartPhase: engine.queuedPhase ?? .focus,
-        nextBreakPhase: engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+        engine: composition.engine,
+        settings: composition.settings,
+        store: composition.store,
+        selectionStore: composition.selectionStore,
+        registry: composition.registry,
+        nextStartPhase: composition.engine.queuedPhase ?? .focus,
+        nextBreakPhase: composition.engine.nextBreakPhase(
+          longBreakAfter: composition.settings.longBreakAfterSessions)
       )
       .confirmationDialog(
         "Multiple tasks match — which one?",
         isPresented: Binding(
-          get: { urlHandler.pendingDisambiguation != nil },
-          set: { if !$0 { urlHandler.pendingDisambiguation = nil } }
+          get: { composition.urlHandler.pendingDisambiguation != nil },
+          set: { if !$0 { composition.urlHandler.pendingDisambiguation = nil } }
         ),
         titleVisibility: .visible,
-        presenting: urlHandler.pendingDisambiguation
+        presenting: composition.urlHandler.pendingDisambiguation
       ) { matches in
         ForEach(matches.prefix(4)) { task in
           Button(task.title) {
-            selectionStore.select(task)
-            urlHandler.pendingDisambiguation = nil
+            composition.selectionStore.select(task)
+            composition.urlHandler.pendingDisambiguation = nil
             NotificationCenter.default.post(name: .showTimerTab, object: nil)
           }
         }
-        if let params = urlHandler.pendingAdHocParams {
+        if let params = composition.urlHandler.pendingAdHocParams {
           Button("Create new \"\(params.title)\"") {
-            let task = urlHandler.makeAdHocTask(from: params)
-            selectionStore.select(task)
-            urlHandler.pendingDisambiguation = nil
+            let task = composition.urlHandler.makeAdHocTask(from: params)
+            composition.selectionStore.select(task)
+            composition.urlHandler.pendingDisambiguation = nil
             NotificationCenter.default.post(name: .showTimerTab, object: nil)
           }
         }
         Button("Cancel", role: .cancel) {
-          urlHandler.pendingDisambiguation = nil
-          urlHandler.pendingAdHocParams = nil
+          composition.urlHandler.pendingDisambiguation = nil
+          composition.urlHandler.pendingAdHocParams = nil
         }
       }
     } label: {
@@ -182,11 +72,11 @@ struct TaskmatoApp: App {
 
     Window(Bundle.main.appName, id: "main") {
       MainWindowView(
-        engine: engine,
-        settings: settings,
-        store: store,
-        selectionStore: selectionStore,
-        registry: registry
+        engine: composition.engine,
+        settings: composition.settings,
+        store: composition.store,
+        selectionStore: composition.selectionStore,
+        registry: composition.registry
       )
     }
     .defaultSize(width: 480, height: 520)
@@ -194,9 +84,9 @@ struct TaskmatoApp: App {
 
     Settings {
       SettingsView(
-        settings: settings,
-        selectionStore: selectionStore,
-        registry: registry
+        settings: composition.settings,
+        selectionStore: composition.selectionStore,
+        registry: composition.registry
       )
     }
     .windowResizability(.contentSize)
@@ -205,15 +95,15 @@ struct TaskmatoApp: App {
   /// Formats the active or idle time as `"MM:SS"` for display in the menu bar.
   private var menuBarLabel: String {
     let seconds: Int
-    if case .idle = engine.state {
-      let phase = engine.queuedPhase ?? SessionPhase.focus
+    if case .idle = composition.engine.state {
+      let phase = composition.engine.queuedPhase ?? SessionPhase.focus
       switch phase {
-      case .focus: seconds = Int(settings.focusDuration)
-      case .shortBreak: seconds = Int(settings.shortBreakDuration)
-      case .longBreak: seconds = Int(settings.longBreakDuration)
+      case .focus: seconds = Int(composition.settings.focusDuration)
+      case .shortBreak: seconds = Int(composition.settings.shortBreakDuration)
+      case .longBreak: seconds = Int(composition.settings.longBreakDuration)
       }
     } else {
-      seconds = Int(engine.timeRemaining)
+      seconds = Int(composition.engine.timeRemaining)
     }
     return String(format: "%02d:%02d", seconds / 60, seconds % 60)
   }


### PR DESCRIPTION
## Summary

Extract `AppDelegate` from `TaskmatoApp.swift` into its own file and introduce `AppComposition` as the sole composition root. `TaskmatoApp.init` shrinks from 60 lines to 4; all service construction and the `engine.onPhaseEnded` cascade move into `AppComposition`. No behavior change is visible to users.

## Linked issue

Closes #394

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

Three files changed:

- **`AppDelegate.swift`** (new) — `AppDelegate` extracted verbatim from `TaskmatoApp.swift`. `wire(urlHandler:)` changes from `fileprivate` to `internal` so `TaskmatoApp` can call it across files.
- **`AppComposition.swift`** (new) — `@MainActor struct AppComposition` holds all 11 services as `let` properties. `init()` contains all construction, provider registration, auto-enable logic, and the `onPhaseEnded` cascade. The cascade will move to `PhaseOrchestrator` at 0.9.0 (issue #407).
- **`TaskmatoApp.swift`** (modified) — `AppDelegate` class removed; 11 individual `@State` properties replaced with `@State private var composition: AppComposition`. `init()` is now 4 lines.

No project file changes are required — the project uses `PBXFileSystemSynchronizedRootGroup`, which picks up new `.swift` files in `app/Taskmato/` automatically.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` → 0 violations across 87 files)
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [ ] Manually verified changes
- [x] Documentation updated where appropriate

## Reviewer notes

This is the foundation PR from the pre-1.0 architecture pass (design doc `docs/architecture/design/0005-pre-1.0-architecture-pass.md`, PRs 1–2). Subsequent PRs in the 0.7.0 milestone build on `AppComposition` as the stable DI root.