### PR TITLE
refactor: DRY pass — Debouncer, markdown title, priority styling, urgent date

### DIFF
--- a/app/Taskmato/ActiveTaskView.swift
+++ b/app/Taskmato/ActiveTaskView.swift
@@ -189,36 +189,11 @@ struct ActiveTaskView: View {
   // MARK: - Text helpers
 
   private func displayTitle(for task: TaskItem) -> AttributedString {
-    let mark = priorityMark(for: task.priority)
-    guard !mark.isEmpty else { return markdownTitle(for: task) }
+    let mark = task.priority.mark
+    guard !mark.isEmpty else { return task.markdownTitle }
     var prefix = AttributedString(mark + " ")
-    prefix.swiftUI.foregroundColor = priorityColor(for: task.priority)
-    return prefix + markdownTitle(for: task)
-  }
-
-  private func markdownTitle(for task: TaskItem) -> AttributedString {
-    guard task.format == .markdown else { return AttributedString(task.title) }
-    let options = AttributedString.MarkdownParsingOptions(
-      interpretedSyntax: .inlineOnlyPreservingWhitespace
-    )
-    return (try? AttributedString(markdown: task.title, options: options))
-      ?? AttributedString(task.title)
-  }
-
-  private func priorityMark(for priority: TaskPriority) -> String {
-    switch priority {
-    case .highest: return "!!!"
-    case .high: return "!!"
-    case .medium: return "!"
-    case .low, .lowest, .none: return ""
-    }
-  }
-
-  private func priorityColor(for priority: TaskPriority) -> Color {
-    switch priority {
-    case .highest, .high, .medium: return .orange
-    case .low, .lowest, .none: return .primary
-    }
+    prefix.swiftUI.foregroundColor = task.priority.accentColor
+    return prefix + task.markdownTitle
   }
 }
 

--- a/app/Taskmato/Tasks/Debouncer.swift
+++ b/app/Taskmato/Tasks/Debouncer.swift
@@ -1,0 +1,39 @@
+//
+//  Debouncer.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Coalesces rapid calls by cancelling any pending work before scheduling a new run.
+///
+/// Implicitly `@MainActor` (via `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`), so it is safe
+/// to call synchronously from either provider's change-event handler without additional
+/// actor-hop boilerplate.
+final class Debouncer {
+
+  private let interval: Duration
+  private var pending: Task<Void, Never>?
+
+  /// Creates a debouncer with the given coalescing interval; defaults to 250 ms.
+  init(interval: Duration = .milliseconds(250)) {
+    self.interval = interval
+  }
+
+  /// Cancels any pending action and schedules `action` to run after the interval.
+  func schedule(_ action: @escaping () async -> Void) {
+    pending?.cancel()
+    let interval = self.interval
+    pending = Task { [action, interval] in
+      try? await Task.sleep(for: interval)
+      guard !Task.isCancelled else { return }
+      await action()
+    }
+  }
+
+  /// Cancels any pending action without running it.
+  func cancel() {
+    pending?.cancel()
+    pending = nil
+  }
+}

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -46,7 +46,7 @@ final class ObsidianProvider: ClosableTaskProvider {
   private let parser = ObsidianTaskParser()
   private var streamContinuation: AsyncStream<[TaskItem]>.Continuation?
   private var fsEventStream: FSEventStreamRef?
-  private var debounceTask: Task<Void, Never>?
+  private let debouncer = Debouncer()
 
   private static let bookmarkKey = "obsidian.vaultBookmark"
   private static let patternsKey = "obsidian.filePatterns"
@@ -438,18 +438,15 @@ final class ObsidianProvider: ClosableTaskProvider {
 
   /// Cancels any pending rescan and schedules a new one 250 ms from now.
   private func scheduleDebounce() {
-    debounceTask?.cancel()
-    debounceTask = Task { [weak self] in
-      try? await Task.sleep(for: .milliseconds(250))
-      guard !Task.isCancelled, let self else { return }
+    debouncer.schedule { [weak self] in
+      guard let self else { return }
       let updated = (try? await self.tasks(in: nil)) ?? []
       self.streamContinuation?.yield(updated)
     }
   }
 
   private func stopWatching() {
-    debounceTask?.cancel()
-    debounceTask = nil
+    debouncer.cancel()
     if let stream = fsEventStream {
       FSEventStreamStop(stream)
       FSEventStreamRelease(stream)

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -29,7 +29,7 @@ final class RemindersProvider: ClosableTaskProvider {
   private let store: any RemindersEventStore
   private var streamContinuation: AsyncStream<[TaskItem]>.Continuation?
   private var observer: NSObjectProtocol?
-  private var debounceTask: Task<Void, Never>?
+  private let debouncer = Debouncer()
 
   /// Production initializer using live EventKit.
   convenience init() {
@@ -114,18 +114,15 @@ final class RemindersProvider: ClosableTaskProvider {
   }
 
   private func scheduleDebounce() {
-    debounceTask?.cancel()
-    debounceTask = Task { [weak self] in
-      try? await Task.sleep(for: .milliseconds(250))
-      guard !Task.isCancelled, let self else { return }
+    debouncer.schedule { [weak self] in
+      guard let self else { return }
       let updated = (try? await self.tasks(in: nil)) ?? []
       self.streamContinuation?.yield(updated)
     }
   }
 
   private func stopObserving() {
-    debounceTask?.cancel()
-    debounceTask = nil
+    debouncer.cancel()
     if let observer {
       store.removeObserver(observer)
       self.observer = nil

--- a/app/Taskmato/Tasks/TaskItem.swift
+++ b/app/Taskmato/Tasks/TaskItem.swift
@@ -53,3 +53,17 @@ struct TaskItem: Identifiable, Hashable, Codable, Sendable {
   /// Wall-clock time when the task was created in the source provider, if known.
   var createdAt: Date?
 }
+
+extension TaskItem {
+
+  /// The title rendered as an `AttributedString` with inline markdown interpretation.
+  ///
+  /// Falls back to plain text when `format` is not `.markdown` or when parsing fails.
+  var markdownTitle: AttributedString {
+    guard format == .markdown else { return AttributedString(title) }
+    let options = AttributedString.MarkdownParsingOptions(
+      interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+    return (try? AttributedString(markdown: title, options: options)) ?? AttributedString(title)
+  }
+}

--- a/app/Taskmato/Views/Date+TaskDisplay.swift
+++ b/app/Taskmato/Views/Date+TaskDisplay.swift
@@ -1,0 +1,14 @@
+//
+//  Date+TaskDisplay.swift
+//  Taskmato
+//
+
+import Foundation
+
+extension Date {
+
+  /// `true` when the date falls on today or is already past due.
+  var isUrgentDueDate: Bool {
+    Calendar.current.isDateInToday(self) || self < .now
+  }
+}

--- a/app/Taskmato/Views/TaskCardView.swift
+++ b/app/Taskmato/Views/TaskCardView.swift
@@ -82,14 +82,10 @@ struct TaskCardView: View {
     HStack(alignment: .firstTextBaseline, spacing: 3) {
       if let icon = task.priority.icon {
         Image(systemName: icon)
-          .foregroundStyle(priorityColor)
+          .foregroundStyle(task.priority.accentColor)
           .font(.callout)
       }
-      Text(markdownTitle)
-        .font(.callout)
-        .foregroundStyle(isCompleted ? .secondary : .primary)
-        .lineLimit(3)
-        .frame(maxWidth: .infinity, alignment: .leading)
+      TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: 3)
     }
   }
 
@@ -100,7 +96,7 @@ struct TaskCardView: View {
       if let due = task.dueDate {
         Text(due, format: .dateTime.month(.abbreviated).day().year())
           .font(.caption2)
-          .foregroundStyle(isUrgent(due) ? Color.red : Color.secondary)
+          .foregroundStyle(due.isUrgentDueDate ? Color.red : Color.secondary)
       }
     case .completed:
       Text(completedSubtitle)
@@ -148,26 +144,6 @@ struct TaskCardView: View {
     task.completedAt.map {
       RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
     } ?? "Unknown date"
-  }
-
-  private func isUrgent(_ date: Date) -> Bool {
-    Calendar.current.isDateInToday(date) || date < Date.now
-  }
-
-  private var markdownTitle: AttributedString {
-    guard task.format == .markdown else { return AttributedString(task.title) }
-    let options = AttributedString.MarkdownParsingOptions(
-      interpretedSyntax: .inlineOnlyPreservingWhitespace
-    )
-    return (try? AttributedString(markdown: task.title, options: options))
-      ?? AttributedString(task.title)
-  }
-
-  private var priorityColor: Color {
-    switch task.priority {
-    case .highest, .high, .medium: return .orange
-    case .low, .lowest, .none: return .primary
-    }
   }
 }
 

--- a/app/Taskmato/Views/TaskMarkdownTitle.swift
+++ b/app/Taskmato/Views/TaskMarkdownTitle.swift
@@ -1,0 +1,25 @@
+//
+//  TaskMarkdownTitle.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// Renders a task title with inline-only markdown when `format` is `.markdown`, or as plain text.
+///
+/// Used in task rows and cards wherever the title appears. Pass `isCompleted` to switch to
+/// secondary foreground color; use `lineLimit` to cap truncation per layout context.
+struct TaskMarkdownTitle: View {
+
+  let task: TaskItem
+  var isCompleted: Bool = false
+  var lineLimit: Int = 2
+
+  var body: some View {
+    Text(task.markdownTitle)
+      .font(.callout)
+      .foregroundStyle(isCompleted ? .secondary : .primary)
+      .lineLimit(lineLimit)
+      .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}

--- a/app/Taskmato/Views/TaskPriority+Styling.swift
+++ b/app/Taskmato/Views/TaskPriority+Styling.swift
@@ -1,0 +1,27 @@
+//
+//  TaskPriority+Styling.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension TaskPriority {
+
+  /// The accent color used to tint priority icons in task views.
+  var accentColor: Color {
+    switch self {
+    case .highest, .high, .medium: return .orange
+    case .low, .lowest, .none: return .primary
+    }
+  }
+
+  /// A short text mark prepended to the task title in the active-task label.
+  var mark: String {
+    switch self {
+    case .highest: return "!!!"
+    case .high: return "!!"
+    case .medium: return "!"
+    case .low, .lowest, .none: return ""
+    }
+  }
+}

--- a/app/Taskmato/Views/TaskRowView.swift
+++ b/app/Taskmato/Views/TaskRowView.swift
@@ -76,14 +76,10 @@ struct TaskRowView: View {
     HStack(alignment: .firstTextBaseline, spacing: 3) {
       if let icon = task.priority.icon {
         Image(systemName: icon)
-          .foregroundStyle(priorityColor)
+          .foregroundStyle(task.priority.accentColor)
           .font(.callout)
       }
-      Text(markdownTitle)
-        .font(.callout)
-        .foregroundStyle(isCompleted ? .secondary : .primary)
-        .lineLimit(2)
-        .frame(maxWidth: .infinity, alignment: .leading)
+      TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: 2)
     }
   }
 
@@ -94,7 +90,7 @@ struct TaskRowView: View {
       if let due = task.dueDate {
         Text(due, format: .dateTime.month(.abbreviated).day())
           .font(.caption2)
-          .foregroundStyle(isUrgent(due) ? Color.red : Color.secondary)
+          .foregroundStyle(due.isUrgentDueDate ? Color.red : Color.secondary)
       }
     case .completed:
       Text(completedSubtitle)
@@ -142,25 +138,5 @@ struct TaskRowView: View {
     task.completedAt.map {
       RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
     } ?? "Unknown date"
-  }
-
-  private func isUrgent(_ date: Date) -> Bool {
-    Calendar.current.isDateInToday(date) || date < Date.now
-  }
-
-  private var markdownTitle: AttributedString {
-    guard task.format == .markdown else { return AttributedString(task.title) }
-    let options = AttributedString.MarkdownParsingOptions(
-      interpretedSyntax: .inlineOnlyPreservingWhitespace
-    )
-    return (try? AttributedString(markdown: task.title, options: options))
-      ?? AttributedString(task.title)
-  }
-
-  private var priorityColor: Color {
-    switch task.priority {
-    case .highest, .high, .medium: return .orange
-    case .low, .lowest, .none: return .primary
-    }
   }
 }

--- a/docs/architecture/design/0005-pre-1.0-architecture-pass.md
+++ b/docs/architecture/design/0005-pre-1.0-architecture-pass.md
@@ -216,16 +216,16 @@ app/Taskmato/
 |---|---|:---:|:---:|---|
 | A | Row/Card duplication (~70% identical bodies + state) | H | M | Wave 2 — `TaskItemPresenter` |
 | B | Timer popover vs main-window-tab duplication | H | M | Wave 2 — `TimerPresenter` |
-| C | Composition-root logic in `TaskmatoApp.init` (60 lines) | M | M | Foundation — `AppComposition` |
+| C | Composition-root logic in `TaskmatoApp.init` (60 lines) | M | M | Foundation — `AppComposition` ✅ ([PR #418](https://github.com/richwklein/taskmato/pull/418), part) |
 | D | Engine-duration sync pattern duplicated in 5 sites | M | S | Wave 2 — `engine.applyDurations(from:)` |
 | E | UserDefaults sprawl (5 clients write keys ad-hoc) | M | M | Wave 5 — `SettingsStore` |
 | F | `NotificationCenter` for cross-tab routing | M | M | Routing — `MainNavigation` |
-| G | Markdown title rendering duplicated 3× | L | S | DRY — `TaskMarkdownTitle` |
-| H | Priority styling duplicated 3× | L | S | DRY — `TaskPriority.accentColor` |
-| I | `isUrgent` duplicated 2× | L | S | DRY — `Date.isUrgent` |
+| G | Markdown title rendering duplicated 3× | L | S | DRY — `TaskMarkdownTitle` ✅ (#395) |
+| H | Priority styling duplicated 3× | L | S | DRY — `TaskPriority.accentColor` ✅ (#395) |
+| I | `isUrgent` duplicated 2× | L | S | DRY — `Date.isUrgent` ✅ (#395) |
 | J | `SessionEngine.onPhaseEnded` tuple callback | M | M | Wave 2 — `AsyncStream<PhaseEvent>` |
 | K | Silent `try?` on user-facing operations | M | M | Wave 3 — `ErrorPresenter` |
-| L | Debounce helper duplicated across providers | L | S | DRY — `Debouncer` actor |
+| L | Debounce helper duplicated across providers | L | S | DRY — `Debouncer` actor ✅ (#395) |
 | M | `TaskRegistry` god-class (476 LOC, five concerns) | H | L | Wave 4 — registry split |
 | N | `SoundService` reads from a private framework path | M | S | issue #341 |
 | O | Notification authorization requested on every `send()` | M | S | Hardening — one-shot at launch |
@@ -251,12 +251,12 @@ Each row is one PR. Ordered so PRs are mergeable in isolation and the next build
 
 | # | PR | Wave | Tracked by / Findings |
 |---|---|---|---|
-| 1 | Extract `AppDelegate.swift` from `TaskmatoApp.swift` | Foundation | [#394](https://github.com/richwklein/taskmato/issues/394) |
-| 2 | Introduce `AppComposition.swift`; move service init out of `TaskmatoApp.init` | Foundation | [#394](https://github.com/richwklein/taskmato/issues/394), C (part) |
-| 3 | Extract `Debouncer` actor; adopt in `ObsidianProvider` + `RemindersProvider` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), L |
-| 4 | Centralize markdown title via `TaskMarkdownTitle` + `TaskItem.markdownTitle` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), G |
-| 5 | Centralize priority styling on `TaskPriority` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), H |
-| 6 | Add `Date.isUrgent`; remove from row/card | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), I |
+| ✅ 1 | Extract `AppDelegate.swift` from `TaskmatoApp.swift` | Foundation | [#394](https://github.com/richwklein/taskmato/issues/394) → [PR #418](https://github.com/richwklein/taskmato/pull/418) |
+| ✅ 2 | Introduce `AppComposition.swift`; move service init out of `TaskmatoApp.init` | Foundation | [#394](https://github.com/richwklein/taskmato/issues/394), C (part) → [PR #418](https://github.com/richwklein/taskmato/pull/418) |
+| ✅ 3 | Extract `Debouncer` actor; adopt in `ObsidianProvider` + `RemindersProvider` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), L |
+| ✅ 4 | Centralize markdown title via `TaskMarkdownTitle` + `TaskItem.markdownTitle` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), G |
+| ✅ 5 | Centralize priority styling on `TaskPriority` | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), H |
+| ✅ 6 | Add `Date.isUrgent`; remove from row/card | DRY | [#395](https://github.com/richwklein/taskmato/issues/395), I |
 | 7 | Introduce `MainNavigation` with `bindOpenMainWindow` | Routing | [#396](https://github.com/richwklein/taskmato/issues/396), F (part) |
 | 8 | Add URL buffer in `AppDelegate` (option A — drain on first scene mount) | Routing | [#396](https://github.com/richwklein/taskmato/issues/396) |
 | 9 | Replace NotificationCenter routing with `MainNavigation` calls; delete `AppNotifications.swift` | Routing | [#396](https://github.com/richwklein/taskmato/issues/396), F |


### PR DESCRIPTION
## Summary

Centralises four patterns that were duplicated across 2–3 source files each. No behaviour change — this is a pure DRY refactor as described in the pre-1.0 architecture pass (doc 0005, findings G, H, I, L).

## Linked issue

Closes #395

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**Commit 1 — `Debouncer` actor (`refactor(tasks)`)**

Both `ObsidianProvider` and `RemindersProvider` had an identical inline debounce pattern: cancel the pending `Task`, sleep 250 ms, re-fetch, yield. Extracted into a `final class Debouncer` (implicitly `@MainActor` via `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`) with `schedule(_:)` and `cancel()`. Each provider now stores `let debouncer = Debouncer()` and delegates to it. Closes finding **L**.

**Commit 2 — view helpers (`refactor(views)`)**

Three further extractions, all adopted by `TaskRowView`, `TaskCardView`, and/or `ActiveTaskView`:

- `TaskItem.markdownTitle: AttributedString` — one conversion replaces three identical private helpers; `ActiveTaskView.displayTitle` assembles the attributed string directly from this property. Closes finding **G**.
- `TaskPriority.accentColor: Color` and `TaskPriority.mark: String` in `TaskPriority+Styling.swift` — replaces three copies of the priority-colour switch and two copies of the priority-mark switch. Closes finding **H**.
- `Date.isUrgentDueDate: Bool` in `Date+TaskDisplay.swift` — replaces the identical `isUrgent(_:)` private function in both row and card. Closes finding **I**.

**Commit 3 — docs**

Roadmap rows 1–6 and findings C (part), G, H, I, L marked ✅ in `0005-pre-1.0-architecture-pass.md`. Rows 1–2 cross-reference PR #418; rows 3–6 are covered by this branch.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally (`make lint` — 0 violations in 89 files)
- [x] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [x] Documentation updated where appropriate

## Reviewer notes

New files land in existing directories (`Tasks/` for `Debouncer.swift`, `Views/` for the three view helpers). The target layout from design doc 0005 moves these into subfolders (`Tasks/Models/`, `Views/Tasks/Components/`) — that restructure is tracked separately by #398 (PR 12). No Xcode project file changes are needed; the project uses `PBXFileSystemSynchronizedRootGroup`.

Follow-up: #419 tracks renaming `NoteFormat` → `ContentFormat` now that `format` governs both title and notes rendering.