### PR TITLE
feat(tasks): edit task sheet and markdown format for local provider

### DIFF
--- a/app/Taskmato/MainWindow/ProviderSidebarView.swift
+++ b/app/Taskmato/MainWindow/ProviderSidebarView.swift
@@ -16,6 +16,8 @@ import SwiftUI
 struct ProviderSidebarView: View {
 
   @Bindable var registry: TaskRegistry
+  /// Called after a task is successfully added from the list context-menu "Add Task…" item.
+  var onTaskAdded: (() -> Void)?
 
   /// Inline new-list name buffer keyed by provider ID.
   @State private var newListName: [String: String] = [:]
@@ -31,6 +33,12 @@ struct ProviderSidebarView: View {
 
   /// The provider whose configuration sheet is currently presented, or `nil`.
   @State private var configuringProvider: (any ConfigurableTaskProvider)?
+
+  /// Provider and list targeted by the "Add Task…" context-menu action, or `nil`.
+  @State private var addTaskTarget: AddTaskTarget?
+
+  /// Drives the "Add Task…" sheet opened from the list context menu.
+  @State private var isAddingTask = false
 
   // MARK: - Computed helpers
 
@@ -69,6 +77,9 @@ struct ProviderSidebarView: View {
       }
     }
     .task { await loadAllLists() }
+    .onChange(of: isAddingTask) { _, adding in
+      if !adding { onTaskAdded?() }
+    }
     .sheet(
       isPresented: Binding(
         get: { configuringProvider != nil },
@@ -81,6 +92,15 @@ struct ProviderSidebarView: View {
         }
       }
     )
+    .sheet(isPresented: $isAddingTask) {
+      if let target = addTaskTarget {
+        AddTaskView(
+          provider: target.provider,
+          isPresented: $isAddingTask,
+          initialListID: target.listID
+        )
+      }
+    }
   }
 
   // MARK: - Provider section
@@ -107,13 +127,17 @@ struct ProviderSidebarView: View {
       .contentShape(Rectangle())
       .contextMenu {
         if let configurable = provider as? (any ConfigurableTaskProvider) {
-          Button("Configure \(provider.displayName)…") {
+          Button {
             configuringProvider = configurable
+          } label: {
+            Label("Configure \(provider.displayName)…", systemImage: "gear")
           }
           Divider()
         }
-        Button("Remove \(provider.displayName)", role: .destructive) {
+        Button(role: .destructive) {
           registry.disable(providerID: provider.id)
+        } label: {
+          Label("Remove \(provider.displayName)", systemImage: "trash")
         }
       }
     }
@@ -153,8 +177,8 @@ struct ProviderSidebarView: View {
   /// Builds the contextual menu for a control-clicked sidebar selection.
   ///
   /// Activated via `contextMenu(forSelectionType:)` on the List, this looks up the
-  /// writable list referenced by the clicked row and renders the standard set/rename/delete
-  /// actions. Returns no items for `.today` or unknown rows.
+  /// writable list referenced by the clicked row and renders "Add Task…" plus the standard
+  /// set/rename/delete management actions. Returns no items for `.today` or read-only rows.
   @ViewBuilder
   private func listContextMenu(for selections: Set<SidebarSelection>) -> some View {
     if let resolved = resolveListAction(from: selections) {
@@ -163,25 +187,40 @@ struct ProviderSidebarView: View {
       let writable = resolved.writable
       let isDefaultList = isDefault(list.id, for: provider)
 
-      Button("Set as Default") {
-        let id = list.id
-        Task { try? await writable.setDefaultList(id) }
-      }
-      .disabled(isDefaultList)
-
-      Button("Rename") {
-        renamingListID = list.id
-        renameBuffer = list.name
-        renameFocused = list.id
+      Button {
+        addTaskTarget = AddTaskTarget(provider: writable, listID: list.id)
+        isAddingTask = true
+      } label: {
+        Label("Add Task…", systemImage: "plus.circle")
       }
 
       Divider()
 
-      Button("Delete", role: .destructive) {
+      Button {
+        let id = list.id
+        Task { try? await writable.setDefaultList(id) }
+      } label: {
+        Label("Set as Default", systemImage: "star")
+      }
+      .disabled(isDefaultList)
+
+      Button {
+        renamingListID = list.id
+        renameBuffer = list.name
+        renameFocused = list.id
+      } label: {
+        Label("Rename", systemImage: "pencil")
+      }
+
+      Divider()
+
+      Button(role: .destructive) {
         Task {
           try? await writable.deleteList(list.id)
           await loadLists(for: provider)
         }
+      } label: {
+        Label("Delete", systemImage: "trash")
       }
       .disabled(isDefaultList)
     }
@@ -204,6 +243,12 @@ struct ProviderSidebarView: View {
     let list: TaskList
     let provider: any TaskProvider
     let writable: any WritableTaskProvider
+  }
+
+  /// Provider and list ID targeted by the "Add Task…" context-menu sheet.
+  private struct AddTaskTarget {
+    let provider: any WritableTaskProvider
+    let listID: String
   }
 
   /// Inline name display that switches to an editable `TextField` during a rename.

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -22,6 +22,8 @@ struct TasksTabView: View {
   @State private var sections: [TaskSection] = []
   @State private var isLoading: Bool = false
   @State private var isAddingTask = false
+  @State private var isEditingTask = false
+  @State private var taskToEdit: TaskItem?
   @State private var showCompleted = false
   @State private var completedTasks: [TaskItem] = []
   @State private var isLoadingCompleted = false
@@ -67,7 +69,7 @@ struct TasksTabView: View {
         set: { settings.sidebarVisible = $0 != .detailOnly }
       )
     ) {
-      ProviderSidebarView(registry: registry)
+      ProviderSidebarView(registry: registry, onTaskAdded: { Task { await refresh() } })
         .navigationSplitViewColumnWidth(min: 160, ideal: 200, max: 280)
     } detail: {
       detailColumn
@@ -78,6 +80,9 @@ struct TasksTabView: View {
     .onAppear { Task { await refresh() } }
     .onChange(of: isAddingTask) { _, adding in
       if !adding { Task { await refresh() } }
+    }
+    .onChange(of: isEditingTask) { _, editing in
+      if !editing { Task { await refresh() } }
     }
     .onChange(of: registry.enabledIDs) { _, _ in Task { await refresh() } }
     .onChange(of: registry.selection) { _, _ in
@@ -93,6 +98,11 @@ struct TasksTabView: View {
     .sheet(isPresented: $isAddingTask) {
       if let provider = writableProvider {
         AddTaskView(provider: provider, isPresented: $isAddingTask)
+      }
+    }
+    .sheet(isPresented: $isEditingTask) {
+      if let task = taskToEdit, let provider = registry.writableProvider(for: task.id) {
+        AddTaskView(provider: provider, isPresented: $isEditingTask, taskToEdit: task)
       }
     }
     .toolbar {
@@ -248,6 +258,14 @@ struct TasksTabView: View {
       select(task)
     } label: {
       Label(TaskLabel.Menu.trackTask, systemImage: "timer")
+    }
+    if registry.writableProvider(for: task.id) != nil {
+      Button {
+        taskToEdit = task
+        isEditingTask = true
+      } label: {
+        Label("Edit…", systemImage: "pencil")
+      }
     }
     Divider()
     if registry.closableProvider(for: task.id) != nil {

--- a/app/Taskmato/Tasks/Local/AddTaskView.swift
+++ b/app/Taskmato/Tasks/Local/AddTaskView.swift
@@ -5,14 +5,21 @@
 
 import SwiftUI
 
-/// A sheet for creating a new task via any writable task provider.
+/// A sheet for creating or editing a task via any writable task provider.
 ///
-/// Displayed as a modal sheet from the Tasks tab. The title field is auto-focused on appear.
-/// Submitting with an empty title is disabled. Lists are loaded asynchronously on appear.
+/// Pass a `taskToEdit` to open in edit mode; the form pre-fills with the task's existing
+/// values and the submit button calls ``WritableTaskProvider/updateTask(_:draft:)`` instead
+/// of ``WritableTaskProvider/addTask(_:)``. Pass `initialListID` to pre-select a specific
+/// list in add mode (e.g. when triggered from a sidebar list context menu). When both are
+/// `nil`, the sheet defaults to the provider's default list. The title field is auto-focused
+/// on appear.
 struct AddTaskView: View {
 
   var provider: any WritableTaskProvider
   @Binding var isPresented: Bool
+  var taskToEdit: TaskItem?
+  /// List to pre-select in add mode. Ignored when `taskToEdit` is non-nil.
+  var initialListID: String?
 
   @State private var title = ""
   @State private var notes = ""
@@ -25,13 +32,17 @@ struct AddTaskView: View {
 
   @FocusState private var isTitleFocused: Bool
 
+  private var isEditing: Bool { taskToEdit != nil }
+  private var sheetTitle: String { isEditing ? "Edit Task" : "New Task" }
+  private var submitLabel: String { isEditing ? "Save" : "Add Task" }
+
   private var canSubmit: Bool {
     !title.trimmingCharacters(in: .whitespaces).isEmpty
   }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
-      Text("New Task")
+      Text(sheetTitle)
         .font(.headline)
 
       TextField("Task title", text: $title)
@@ -93,17 +104,30 @@ struct AddTaskView: View {
         Spacer()
         Button("Cancel") { isPresented = false }
           .keyboardShortcut(.cancelAction)
-        Button("Add Task") { submit() }
+        Button(submitLabel) { submit() }
           .keyboardShortcut(.defaultAction)
           .disabled(!canSubmit)
       }
     }
     .padding()
     .frame(width: 360)
-    .onAppear { isTitleFocused = true }
+    .onAppear {
+      isTitleFocused = true
+      if let task = taskToEdit {
+        title = task.title
+        notes = task.notes ?? ""
+        priority = task.priority
+        hasDueDate = task.dueDate != nil
+        if let due = task.dueDate { dueDate = due }
+        showNotes = !(task.notes ?? "").isEmpty
+        selectedListID = task.list?.id ?? ""
+      } else if let listID = initialListID {
+        selectedListID = listID
+      }
+    }
     .task {
       taskLists = (try? await provider.lists()) ?? []
-      if selectedListID.isEmpty, let first = taskLists.first {
+      if taskToEdit == nil, selectedListID.isEmpty, let first = taskLists.first {
         selectedListID = provider.defaultListID ?? first.id
       }
     }
@@ -119,7 +143,11 @@ struct AddTaskView: View {
     draft.dueDate = hasDueDate ? dueDate : nil
     draft.listID = selectedListID.isEmpty ? nil : selectedListID
     isPresented = false
-    Task { try? await provider.addTask(draft) }
+    if let task = taskToEdit {
+      Task { try? await provider.updateTask(task.id, draft: draft) }
+    } else {
+      Task { try? await provider.addTask(draft) }
+    }
   }
 }
 

--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -20,6 +20,12 @@ struct LocalTask: Codable, Identifiable {
   /// Optional supplementary notes or description.
   var notes: String?
 
+  /// How the task's `notes` string should be interpreted for display.
+  ///
+  /// Defaults to `.markdown` for all new tasks. Existing JSON records without this
+  /// field also decode as `.markdown` via ``init(from:)``.
+  var format: NoteFormat
+
   /// Priority level, used for sorting and badging in the picker.
   var priority: TaskPriority
 
@@ -44,6 +50,11 @@ struct LocalTask: Codable, Identifiable {
   /// Wall-clock time when the task was first created.
   let createdAt: Date
 
+  private enum CodingKeys: String, CodingKey {
+    case id, title, notes, format, priority, dueDate, scheduledDate, startDate
+    case listID, isCompleted, completedAt, createdAt
+  }
+
   /// Converts this task to the provider-agnostic ``TaskItem`` used by the picker and registry.
   ///
   /// - Parameter lists: The full list of ``LocalList`` values managed by the provider,
@@ -57,7 +68,7 @@ struct LocalTask: Codable, Identifiable {
       id: TaskRef(providerID: LocalProvider.providerID, nativeID: id.uuidString),
       title: title,
       notes: notes,
-      format: .plainText,
+      format: format,
       priority: priority,
       dueDate: dueDate,
       scheduledDate: scheduledDate,
@@ -80,11 +91,32 @@ struct LocalTask: Codable, Identifiable {
 
 extension LocalTask {
 
+  /// Decodes a ``LocalTask`` from `decoder`, defaulting `format` to `.markdown` when absent.
+  ///
+  /// The default preserves backward compatibility with JSON records written before the
+  /// `format` field was introduced.
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(UUID.self, forKey: .id)
+    title = try container.decode(String.self, forKey: .title)
+    notes = try container.decodeIfPresent(String.self, forKey: .notes)
+    format = try container.decodeIfPresent(NoteFormat.self, forKey: .format) ?? .markdown
+    priority = try container.decode(TaskPriority.self, forKey: .priority)
+    dueDate = try container.decodeIfPresent(Date.self, forKey: .dueDate)
+    scheduledDate = try container.decodeIfPresent(Date.self, forKey: .scheduledDate)
+    startDate = try container.decodeIfPresent(Date.self, forKey: .startDate)
+    listID = try container.decodeIfPresent(UUID.self, forKey: .listID)
+    isCompleted = try container.decode(Bool.self, forKey: .isCompleted)
+    completedAt = try container.decodeIfPresent(Date.self, forKey: .completedAt)
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+  }
+
   /// Creates a new incomplete task from a ``TaskDraft``.
   init(from draft: TaskDraft) {
     id = UUID()
     title = draft.title
     notes = draft.notes.isEmpty ? nil : draft.notes
+    format = .markdown
     priority = draft.priority
     dueDate = draft.dueDate
     scheduledDate = nil

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -117,6 +117,10 @@ protocol WritableTaskProvider: ClosableTaskProvider {
   /// - Throws: if `listID` is the default list or does not identify a known list.
   func deleteList(_ listID: String) async throws
 
+  /// Updates the task identified by `ref` with values from `draft`.
+  /// - Throws: if the task cannot be found or the update fails.
+  func updateTask(_ ref: TaskRef, draft: TaskDraft) async throws
+
   /// Permanently removes the task identified by `ref` from the provider's store.
   /// - Throws: if the task cannot be found or removal fails.
   func deleteTask(_ ref: TaskRef) async throws

--- a/app/Taskmato/Tasks/TaskRegistry.swift
+++ b/app/Taskmato/Tasks/TaskRegistry.swift
@@ -313,6 +313,12 @@ final class TaskRegistry {
     provider(for: ref) as? any ClosableTaskProvider
   }
 
+  /// Returns the provider for a task reference if it conforms to `WritableTaskProvider`, or `nil`.
+  /// - Parameter ref: The task reference whose writable provider to look up.
+  func writableProvider(for ref: TaskRef) -> (any WritableTaskProvider)? {
+    provider(for: ref) as? any WritableTaskProvider
+  }
+
   /// Returns the first enabled provider conforming to `WritableTaskProvider`, or `nil`.
   var firstEnabledWritableProvider: (any WritableTaskProvider)? {
     providers.first { isEnabled($0.id) && $0 is (any WritableTaskProvider) }

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -279,6 +279,41 @@ struct LocalProviderTests {
     #expect(tasks[0].title == "Updated")
   }
 
+  @Test func addTaskHasMarkdownFormat() async throws {
+    let provider = makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Markdown task"
+    provider.addTask(draft)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks[0].format == .markdown)
+  }
+
+  @Test func existingTaskWithoutFormatFieldDecodesAsMarkdown() async throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+
+    let rawList = RawLocalStore.RawList(id: UUID(), name: "Default")
+    let rawTask = RawLocalStore.RawTask(
+      id: UUID(),
+      title: "Legacy task",
+      priority: .none,
+      isCompleted: false,
+      createdAt: Date()
+    )
+    let raw = RawLocalStore(lists: [rawList], tasks: [rawTask])
+    let data = try encoder.encode(raw)
+    try data.write(to: url, options: [])
+
+    let provider = LocalProvider(fileURL: url)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks.count == 1)
+    #expect(tasks[0].format == .markdown)
+  }
+
   @Test func activeTaskCountExcludesCompleted() async throws {
     let provider = makeProvider()
     var draft = TaskDraft()

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -64,6 +64,7 @@ private final class FakeWritableProvider: WritableTaskProvider {
     deleteListCalls.append(listID)
   }
 
+  func updateTask(_: TaskRef, draft _: TaskDraft) {}
   func deleteTask(_ ref: TaskRef) {
     deleteTaskCalls.append(ref)
   }

--- a/app/TaskmatoTests/TaskRegistrySelectionTests.swift
+++ b/app/TaskmatoTests/TaskRegistrySelectionTests.swift
@@ -82,6 +82,7 @@ private final class SelectionWritableProvider: WritableTaskProvider {
   func createList(name _: String) async throws -> TaskList { fatalError("unused") }
   func renameList(_: String, name _: String) async throws {}
   func deleteList(_: String) async throws {}
+  func updateTask(_: TaskRef, draft _: TaskDraft) async throws {}
   func deleteTask(_: TaskRef) async throws {}
 }
 

--- a/app/TaskmatoTests/TaskRegistryTests.swift
+++ b/app/TaskmatoTests/TaskRegistryTests.swift
@@ -71,6 +71,7 @@ private final class StubWritableProvider: WritableTaskProvider {
 
   func renameList(_: String, name _: String) async throws {}
   func deleteList(_: String) async throws {}
+  func updateTask(_: TaskRef, draft _: TaskDraft) async throws {}
   func deleteTask(_: TaskRef) async throws {}
 }
 

--- a/docs/architecture/design/0005-pre-1.0-architecture-pass.md
+++ b/docs/architecture/design/0005-pre-1.0-architecture-pass.md
@@ -268,7 +268,7 @@ Each row is one PR. Ordered so PRs are mergeable in isolation and the next build
 | 15 | Fix `Calendar.endOfToday` DST bug | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), 6.5 |
 | 16 | Add `os.Logger` to `SessionStore` and `LocalProvider` save paths | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), T (part) |
 
-Already-planned 0.7.0 issues (#260, #293, #303, #330, #341, #370, #383, #392) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 (closed by PR 11). **#388** closes as part of PR 12.
+Already-planned 0.7.0 issues (#260, #293, #303, ~~#330~~, #341, #370, ~~#383~~, #392) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 (closed by PR 11). **#388** closes as part of PR 12.
 
 ### 0.8.0 — Stats expansion + SwiftData session migration
 


### PR DESCRIPTION
## Summary

Implements two 0.7.0 items: writable providers can now edit existing tasks via a shared add/edit sheet, and `LocalTask` stores and renders notes in Markdown format. Also improves the sidebar list context menu with SF Symbol icons and a contextual "Add Task…" action.

## Linked issue

Closes #330
Closes #383

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**`WritableTaskProvider.updateTask` (commit fb97dfa)**
- Added `updateTask(_ ref: TaskRef, draft: TaskDraft) async throws` to `WritableTaskProvider`.
- `LocalProvider` implements it synchronously (same pattern as `addTask`).
- `LocalTask` gains a `format: NoteFormat` field that defaults to `.markdown` for both new tasks and existing JSON that predates the field (custom `init(from:)` with `decodeIfPresent`).
- Two new tests in `LocalProviderTests`: `addTaskHasMarkdownFormat` and `existingTaskWithoutFormatFieldDecodesAsMarkdown`.

**Edit task sheet (commit 55c4208)**
- `AddTaskView` is now dual-mode: pass `taskToEdit: TaskItem?` to open in edit mode. The sheet pre-fills title, notes, priority, due date, and list picker from the existing task and calls `updateTask` on submit instead of `addTask`.
- `initialListID: String?` lets the sidebar context menu pre-select the right list when adding.
- `TasksTabView` gains `isEditingTask`/`taskToEdit` state and an "Edit…" context-menu item gated on `registry.writableProvider(for: task.id) != nil`.
- `TaskRegistry` gains `writableProvider(for:)` convenience lookup.
- `ProviderSidebarView` owns its own add-task sheet state and calls `onTaskAdded?()` on dismiss so `TasksTabView` can refresh.

**Sidebar context menu icons + Add Task (commit 9fc8390)**
- All list context-menu items now carry SF Symbol icons per macOS HIG (`plus.circle`, `star`, `pencil`, `trash`).
- "Add Task…" is the first item in the list context menu, available only for lists belonging to writable providers; it pre-selects the clicked list via `initialListID`.
- Provider header context menu: Configure gains a `gear` icon; Remove gains a `trash` icon.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

## Reviewer notes

- `LocalTask.encode(to:)` remains synthesized — the custom `init(from:)` lives in an extension so Swift still generates the encoder automatically.
- Test mocks (`SelectionWritableProvider`, `StubWritableProvider`, `FakeWritableProvider`) each received a stub `updateTask` to satisfy the new protocol requirement.
- Cut/copy/paste for task items was scoped out to a separate issue (#422) targeting 0.9.0.