### PR TITLE
feat(commands): add app menus and keyboard shortcuts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,23 @@
   "permissions": {
     "allow": [
       "Bash(codesign -d *)",
-      "mcp__github__pull_request_read"
+      "Bash(make lint)",
+      "Bash(make lint *)",
+      "Bash(make format-check)",
+      "Bash(make format-check *)",
+      "Bash(make test)",
+      "Bash(make test *)",
+      "Bash(xcodebuild test *)",
+      "Bash(xcodebuild build-for-testing *)",
+      "Bash(xcodebuild -project *)",
+      "Bash(gh label list *)",
+      "mcp__github__get_file_contents",
+      "mcp__github__pull_request_read",
+      "mcp__github__issue_read",
+      "mcp__github__search_issues",
+      "mcp__github__list_issues",
+      "mcp__xcode__XcodeListWindows",
+      "mcp__xcode__DocumentationSearch"
     ]
   }
 }

--- a/app/Taskmato/ActiveTaskView.swift
+++ b/app/Taskmato/ActiveTaskView.swift
@@ -75,7 +75,7 @@ struct ActiveTaskView: View {
             .foregroundStyle(.secondary)
         }
         .buttonStyle(.plain)
-        .help("Swap task — pauses the session and opens the task list")
+        .help(AppLabels.Tooltip.swapTask)
       }
 
       Button {
@@ -90,7 +90,7 @@ struct ActiveTaskView: View {
           .foregroundStyle(.secondary)
       }
       .buttonStyle(.plain)
-      .help("Clear task")
+      .help(AppLabels.Tooltip.clearTask)
     }
   }
 
@@ -156,7 +156,7 @@ struct ActiveTaskView: View {
       .onHover { isCompletionHovered = $0 }
       .help(
         sessionIsActive
-          ? TaskLabel.Tooltip.markAsCompletedActive : TaskLabel.Tooltip.markAsCompleted)
+          ? AppLabels.Tooltip.markAsCompletedActive : AppLabels.Tooltip.markAsCompleted)
     } else {
       Image(systemName: "circle.fill")
         .font(.caption2)

--- a/app/Taskmato/MainWindow/AppFocusedValues.swift
+++ b/app/Taskmato/MainWindow/AppFocusedValues.swift
@@ -1,0 +1,113 @@
+//
+//  AppFocusedValues.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+// MARK: - Key types
+
+private struct FocusSearchKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct AddTaskKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct ToggleCompletedKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct ToggleCompletedTitleKey: FocusedValueKey {
+  typealias Value = String
+}
+
+private struct ToggleCompletedIconKey: FocusedValueKey {
+  typealias Value = String
+}
+
+private struct TimerToggleKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct TimerToggleTitleKey: FocusedValueKey {
+  typealias Value = String
+}
+
+private struct TimerSkipKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct TimerStopKey: FocusedValueKey {
+  typealias Value = () -> Void
+}
+
+private struct SelectedTabKey: FocusedValueKey {
+  typealias Value = MainTab
+}
+
+// MARK: - FocusedValues extensions
+
+extension FocusedValues {
+
+  /// Moves keyboard focus into the Tasks tab search field. Published by ``TasksTabView``.
+  var focusSearch: (() -> Void)? {
+    get { self[FocusSearchKey.self] }
+    set { self[FocusSearchKey.self] = newValue }
+  }
+
+  /// Opens the Add Task sheet. Published by ``TasksTabView`` when a writable provider is active.
+  var addTask: (() -> Void)? {
+    get { self[AddTaskKey.self] }
+    set { self[AddTaskKey.self] = newValue }
+  }
+
+  /// Toggles the completed tasks section. Published by ``TasksTabView`` when a closable provider is enabled.
+  var toggleCompleted: (() -> Void)? {
+    get { self[ToggleCompletedKey.self] }
+    set { self[ToggleCompletedKey.self] = newValue }
+  }
+
+  /// The current label for the completed toggle — "Show Completed" or "Hide Completed".
+  var toggleCompletedTitle: String? {
+    get { self[ToggleCompletedTitleKey.self] }
+    set { self[ToggleCompletedTitleKey.self] = newValue }
+  }
+
+  /// The SF Symbol name for the completed toggle icon — matches the corresponding toolbar button.
+  var toggleCompletedIcon: String? {
+    get { self[ToggleCompletedIconKey.self] }
+    set { self[ToggleCompletedIconKey.self] = newValue }
+  }
+
+  /// Starts, pauses, or resumes the timer based on current engine state. Published by ``TimerTabView``.
+  var timerToggle: (() -> Void)? {
+    get { self[TimerToggleKey.self] }
+    set { self[TimerToggleKey.self] = newValue }
+  }
+
+  /// The current label for the timer toggle action: "Start", "Pause", or "Resume".
+  var timerToggleTitle: String? {
+    get { self[TimerToggleTitleKey.self] }
+    set { self[TimerToggleTitleKey.self] = newValue }
+  }
+
+  /// Skips the current phase and advances to the next. Published by ``TimerTabView``.
+  var timerSkip: (() -> Void)? {
+    get { self[TimerSkipKey.self] }
+    set { self[TimerSkipKey.self] = newValue }
+  }
+
+  /// Stops the current timer session. Published by ``TimerTabView`` when the engine is not idle.
+  var timerStop: (() -> Void)? {
+    get { self[TimerStopKey.self] }
+    set { self[TimerStopKey.self] = newValue }
+  }
+
+  /// The currently selected tab in the main window. Published by ``MainWindowView``.
+  var selectedTab: MainTab? {
+    get { self[SelectedTabKey.self] }
+    set { self[SelectedTabKey.self] = newValue }
+  }
+}

--- a/app/Taskmato/MainWindow/MainWindowView.swift
+++ b/app/Taskmato/MainWindow/MainWindowView.swift
@@ -31,7 +31,10 @@ struct MainWindowView: View {
 
   var body: some View {
     TabView(selection: $nav.selectedTab) {
-      Tab("Tasks", systemImage: "checklist", value: MainTab.tasks) {
+      Tab(
+        AppLabels.Tab.tasks.title, systemImage: AppLabels.Tab.tasks.systemImage,
+        value: MainTab.tasks
+      ) {
         TasksTabView(
           selectionStore: selectionStore,
           registry: registry,
@@ -40,7 +43,10 @@ struct MainWindowView: View {
         )
       }
 
-      Tab("Timer", systemImage: "timer", value: MainTab.timer) {
+      Tab(
+        AppLabels.Tab.timer.title, systemImage: AppLabels.Tab.timer.systemImage,
+        value: MainTab.timer
+      ) {
         TimerTabView(
           engine: engine,
           settings: settings,
@@ -53,11 +59,48 @@ struct MainWindowView: View {
         )
       }
 
-      Tab("Stats", systemImage: "chart.bar", value: MainTab.stats) {
+      Tab(
+        AppLabels.Tab.stats.title, systemImage: AppLabels.Tab.stats.systemImage,
+        value: MainTab.stats
+      ) {
         StatsTabView(store: store)
       }
     }
     .frame(minWidth: 640, minHeight: 400)
+    .focusedSceneValue(\.selectedTab, nav.selectedTab)
+    .focusedSceneValue(\.timerToggle, timerToggleAction)
+    .focusedSceneValue(\.timerToggleTitle, timerToggleTitleValue)
+    .focusedSceneValue(\.timerSkip, { skipPhase() })
+    .focusedSceneValue(\.timerStop, engine.state != .idle ? { engine.stop() } : nil)
+  }
+
+  // MARK: - Timer command helpers
+
+  private var timerToggleAction: (() -> Void)? {
+    if engine.isRunning { return { engine.pause() } }
+    if case .paused = engine.state { return { engine.resume() } }
+    guard selectionStore.activeTask != nil else { return nil }
+    return { startSession() }
+  }
+
+  private var timerToggleTitleValue: String {
+    if engine.isRunning { return AppLabels.Timer.pause.title }
+    if case .paused = engine.state { return AppLabels.Timer.resume.title }
+    return AppLabels.Timer.start.title
+  }
+
+  private func startSession() {
+    engine.focusDuration = settings.focusDuration
+    engine.shortBreakDuration = settings.shortBreakDuration
+    engine.longBreakDuration = settings.longBreakDuration
+    engine.start(phase: engine.queuedPhase ?? .focus)
+  }
+
+  private func skipPhase() {
+    engine.focusDuration = settings.focusDuration
+    engine.shortBreakDuration = settings.shortBreakDuration
+    engine.longBreakDuration = settings.longBreakDuration
+    engine.skip(nextBreak: engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions))
   }
 }
 

--- a/app/Taskmato/MainWindow/ProviderSidebarView.swift
+++ b/app/Taskmato/MainWindow/ProviderSidebarView.swift
@@ -130,14 +130,16 @@ struct ProviderSidebarView: View {
           Button {
             configuringProvider = configurable
           } label: {
-            Label("Configure \(provider.displayName)…", systemImage: "gear")
+            Label(
+              "Configure \(provider.displayName)…",
+              systemImage: AppLabels.Sidebar.configure.systemImage)
           }
           Divider()
         }
         Button(role: .destructive) {
           registry.disable(providerID: provider.id)
         } label: {
-          Label("Remove \(provider.displayName)", systemImage: "trash")
+          Label("Remove \(provider.displayName)", systemImage: AppLabels.Sidebar.remove.systemImage)
         }
       }
     }
@@ -191,7 +193,7 @@ struct ProviderSidebarView: View {
         addTaskTarget = AddTaskTarget(provider: writable, listID: list.id)
         isAddingTask = true
       } label: {
-        Label("Add Task…", systemImage: "plus.circle")
+        Label(AppLabels.Sidebar.addTask.title, systemImage: AppLabels.Sidebar.addTask.systemImage)
       }
 
       Divider()
@@ -200,7 +202,8 @@ struct ProviderSidebarView: View {
         let id = list.id
         Task { try? await writable.setDefaultList(id) }
       } label: {
-        Label("Set as Default", systemImage: "star")
+        Label(
+          AppLabels.Sidebar.setDefault.title, systemImage: AppLabels.Sidebar.setDefault.systemImage)
       }
       .disabled(isDefaultList)
 
@@ -209,7 +212,7 @@ struct ProviderSidebarView: View {
         renameBuffer = list.name
         renameFocused = list.id
       } label: {
-        Label("Rename", systemImage: "pencil")
+        Label(AppLabels.Sidebar.rename.title, systemImage: AppLabels.Sidebar.rename.systemImage)
       }
 
       Divider()
@@ -220,7 +223,8 @@ struct ProviderSidebarView: View {
           await loadLists(for: provider)
         }
       } label: {
-        Label("Delete", systemImage: "trash")
+        Label(
+          AppLabels.Sidebar.deleteList.title, systemImage: AppLabels.Sidebar.deleteList.systemImage)
       }
       .disabled(isDefaultList)
     }
@@ -315,8 +319,10 @@ struct ProviderSidebarView: View {
         }
       }
     } label: {
-      Label("Add Provider", systemImage: "plus.circle")
-        .frame(maxWidth: .infinity, alignment: .leading)
+      Label(
+        AppLabels.Sidebar.addProvider.title, systemImage: AppLabels.Sidebar.addProvider.systemImage
+      )
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
     .menuStyle(.borderlessButton)
   }

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -27,6 +27,7 @@ struct TasksTabView: View {
   @State private var showCompleted = false
   @State private var completedTasks: [TaskItem] = []
   @State private var isLoadingCompleted = false
+  @FocusState private var isSearchFocused: Bool
 
   /// Returns the writable provider for the current sidebar selection, or the first
   /// enabled writable provider when the selection is `.today` or unresolved.
@@ -42,6 +43,11 @@ struct TasksTabView: View {
 
   private var hasClosableProvider: Bool {
     registry.providers.contains { registry.isEnabled($0.id) && $0 is (any ClosableTaskProvider) }
+  }
+
+  /// The label spec matching the current show/hide completed toolbar state.
+  private var completedToggleSpec: AppLabel {
+    showCompleted ? AppLabels.View.hideCompleted : AppLabels.View.showCompleted
   }
 
   private var totalCompletedCount: Int { completedTasks.count }
@@ -63,6 +69,108 @@ struct TasksTabView: View {
   }
 
   var body: some View {
+    splitView
+      .sheet(isPresented: $isAddingTask) {
+        if let provider = writableProvider {
+          AddTaskView(provider: provider, isPresented: $isAddingTask)
+        }
+      }
+      .sheet(isPresented: $isEditingTask) {
+        if let task = taskToEdit, let provider = registry.writableProvider(for: task.id) {
+          AddTaskView(provider: provider, isPresented: $isEditingTask, taskToEdit: task)
+        }
+      }
+      .toolbar {
+        if writableProvider != nil {
+          ToolbarItem(placement: .automatic) {
+            Button {
+              isAddingTask = true
+            } label: {
+              Label(AppLabels.Task.add.title, systemImage: AppLabels.Task.add.systemImage)
+            }
+            .help(AppLabels.Tooltip.addTask)
+          }
+        }
+
+        if hasClosableProvider {
+          ToolbarItem(placement: .automatic) {
+            Button {
+              showCompleted.toggle()
+              if showCompleted { Task { await loadCompleted() } }
+            } label: {
+              let spec = showCompleted ? AppLabels.View.hideCompleted : AppLabels.View.showCompleted
+              Label(spec.title, systemImage: spec.systemImage)
+            }
+            .help(showCompleted ? AppLabels.Tooltip.hideCompleted : AppLabels.Tooltip.showCompleted)
+          }
+        }
+
+        ToolbarItem(placement: .automatic) {
+          Picker("Layout", selection: $settings.taskPickerLayout) {
+            Label(
+              AppLabels.View.listLayout.title, systemImage: AppLabels.View.listLayout.systemImage
+            )
+            .tag(TaskPickerLayout.list)
+            Label(
+              AppLabels.View.gridLayout.title, systemImage: AppLabels.View.gridLayout.systemImage
+            )
+            .tag(TaskPickerLayout.grid)
+          }
+          .pickerStyle(.segmented)
+          .help("Toggle between list and grid view")
+        }
+
+        ToolbarItem(placement: .automatic) {
+          sortMenu
+        }
+      }
+      .focusedSceneValue(\.focusSearch, { isSearchFocused = true })
+      .focusedSceneValue(\.addTask, writableProvider != nil ? { isAddingTask = true } : nil)
+      .focusedSceneValue(
+        \.toggleCompleted,
+        hasClosableProvider
+          ? {
+            showCompleted.toggle()
+            if showCompleted { Task { await loadCompleted() } }
+          } : nil
+      )
+      .focusedSceneValue(
+        \.toggleCompletedTitle,
+        hasClosableProvider ? completedToggleSpec.title : nil
+      )
+      .focusedSceneValue(
+        \.toggleCompletedIcon,
+        hasClosableProvider ? completedToggleSpec.systemImage : nil
+      )
+  }
+
+  /// Change-tracking modifiers applied on top of ``navigationView``.
+  ///
+  /// Split from ``body`` to keep each property's modifier chain short enough
+  /// for the Swift type-checker.
+  private var splitView: some View {
+    navigationView
+      .onChange(of: isAddingTask) { _, adding in
+        if !adding { Task { await refresh() } }
+      }
+      .onChange(of: isEditingTask) { _, editing in
+        if !editing { Task { await refresh() } }
+      }
+      .onChange(of: registry.enabledIDs) { _, _ in Task { await refresh() } }
+      .onChange(of: registry.selection) { _, _ in
+        query = ""
+        Task { await refresh() }
+      }
+      .onChange(of: registry.providerLists) { _, _ in Task { await refresh() } }
+      .onChange(of: settings.taskSortField) { _, _ in Task { await refresh() } }
+      .onChange(of: settings.taskSortDirection) { _, _ in Task { await refresh() } }
+      .onChange(of: registry.providerAuthorizationStates) { _, _ in
+        Task { await refresh() }
+      }
+  }
+
+  /// The ``NavigationSplitView`` with search and initial data-loading modifiers.
+  private var navigationView: some View {
     NavigationSplitView(
       columnVisibility: Binding(
         get: { nav.sidebarVisible ? .all : .detailOnly },
@@ -75,76 +183,10 @@ struct TasksTabView: View {
       detailColumn
     }
     .searchable(text: $query, placement: .toolbar, prompt: "Search tasks")
+    .searchFocused($isSearchFocused)
     .task(id: query) { await refresh() }
     .task { await subscribeToProviderUpdates() }
     .onAppear { Task { await refresh() } }
-    .onChange(of: isAddingTask) { _, adding in
-      if !adding { Task { await refresh() } }
-    }
-    .onChange(of: isEditingTask) { _, editing in
-      if !editing { Task { await refresh() } }
-    }
-    .onChange(of: registry.enabledIDs) { _, _ in Task { await refresh() } }
-    .onChange(of: registry.selection) { _, _ in
-      query = ""
-      Task { await refresh() }
-    }
-    .onChange(of: registry.providerLists) { _, _ in Task { await refresh() } }
-    .onChange(of: settings.taskSortField) { _, _ in Task { await refresh() } }
-    .onChange(of: settings.taskSortDirection) { _, _ in Task { await refresh() } }
-    .onChange(of: registry.providerAuthorizationStates) { _, _ in
-      Task { await refresh() }
-    }
-    .sheet(isPresented: $isAddingTask) {
-      if let provider = writableProvider {
-        AddTaskView(provider: provider, isPresented: $isAddingTask)
-      }
-    }
-    .sheet(isPresented: $isEditingTask) {
-      if let task = taskToEdit, let provider = registry.writableProvider(for: task.id) {
-        AddTaskView(provider: provider, isPresented: $isEditingTask, taskToEdit: task)
-      }
-    }
-    .toolbar {
-      if writableProvider != nil {
-        ToolbarItem(placement: .automatic) {
-          Button {
-            isAddingTask = true
-          } label: {
-            Label("Add Task", systemImage: "plus")
-          }
-          .help("Add a task")
-        }
-      }
-
-      if hasClosableProvider {
-        ToolbarItem(placement: .automatic) {
-          Button {
-            showCompleted.toggle()
-            if showCompleted { Task { await loadCompleted() } }
-          } label: {
-            Label(
-              showCompleted ? "Hide Completed" : "Show Completed",
-              systemImage: showCompleted ? "eye.slash" : "eye"
-            )
-          }
-          .help(showCompleted ? "Hide completed tasks" : "Show completed tasks")
-        }
-      }
-
-      ToolbarItem(placement: .automatic) {
-        Picker("Layout", selection: $settings.taskPickerLayout) {
-          Label("List", systemImage: "list.bullet").tag(TaskPickerLayout.list)
-          Label("Grid", systemImage: "square.grid.2x2").tag(TaskPickerLayout.grid)
-        }
-        .pickerStyle(.segmented)
-        .help("Toggle between list and grid view")
-      }
-
-      ToolbarItem(placement: .automatic) {
-        sortMenu
-      }
-    }
   }
 
   // MARK: - Detail content
@@ -257,14 +299,14 @@ struct TasksTabView: View {
     Button {
       select(task)
     } label: {
-      Label(TaskLabel.Menu.trackTask, systemImage: "timer")
+      Label(AppLabels.Task.track.title, systemImage: AppLabels.Task.track.systemImage)
     }
     if registry.writableProvider(for: task.id) != nil {
       Button {
         taskToEdit = task
         isEditingTask = true
       } label: {
-        Label("Edit…", systemImage: "pencil")
+        Label(AppLabels.Task.edit.title, systemImage: AppLabels.Task.edit.systemImage)
       }
     }
     Divider()
@@ -272,7 +314,7 @@ struct TasksTabView: View {
       Button {
         handleComplete(task)
       } label: {
-        Label(TaskLabel.Menu.markAsCompleted, systemImage: "checkmark.circle.fill")
+        Label(AppLabels.Task.complete.title, systemImage: AppLabels.Task.complete.systemImage)
       }
     }
   }
@@ -284,14 +326,14 @@ struct TasksTabView: View {
       Button {
         handleRestore(task)
       } label: {
-        Label(TaskLabel.Menu.restoreTask, systemImage: "arrow.counterclockwise")
+        Label(AppLabels.Task.restore.title, systemImage: AppLabels.Task.restore.systemImage)
       }
     }
     if registry.provider(for: task.id) is (any WritableTaskProvider) {
       Button(role: .destructive) {
         handleDelete(task)
       } label: {
-        Label(TaskLabel.Menu.deletePermanently, systemImage: "trash")
+        Label(AppLabels.Task.delete.title, systemImage: AppLabels.Task.delete.systemImage)
       }
     }
   }

--- a/app/Taskmato/MainWindow/TasksTabViewSortMenu.swift
+++ b/app/Taskmato/MainWindow/TasksTabViewSortMenu.swift
@@ -20,10 +20,10 @@ extension TasksTabView {
         ForEach(TaskSortField.allCases, id: \.self) { field in
           Button {
             settings.taskSortField = field
-            settings.taskSortDirection = defaultDirection(for: field)
+            settings.taskSortDirection = field.defaultSortDirection
           } label: {
             Label(
-              displayName(for: field),
+              field.displayName,
               systemImage: settings.taskSortField == field ? "checkmark" : "")
           }
         }
@@ -33,53 +33,19 @@ extension TasksTabView {
         settings.taskSortDirection = .ascending
       } label: {
         Label(
-          ascendingLabel(for: settings.taskSortField),
+          settings.taskSortField.ascendingLabel,
           systemImage: settings.taskSortDirection == .ascending ? "checkmark" : "")
       }
       Button {
         settings.taskSortDirection = .descending
       } label: {
         Label(
-          descendingLabel(for: settings.taskSortField),
+          settings.taskSortField.descendingLabel,
           systemImage: settings.taskSortDirection == .descending ? "checkmark" : "")
       }
     } label: {
-      Label("Sort", systemImage: "arrow.up.arrow.down")
+      Label(AppLabels.View.sort.title, systemImage: AppLabels.View.sort.systemImage)
     }
     .help("Sort tasks")
-  }
-
-  func displayName(for field: TaskSortField) -> String {
-    switch field {
-    case .dueDate: return "Due Date"
-    case .priority: return "Priority"
-    case .title: return "Title"
-    case .creationDate: return "Creation Date"
-    }
-  }
-
-  /// The natural sort direction for a field: used when switching fields so the
-  /// user always lands in the most intuitive order without an extra click.
-  func defaultDirection(for field: TaskSortField) -> TaskSortDirection {
-    switch field {
-    case .dueDate, .creationDate, .title: return .ascending
-    case .priority: return .descending
-    }
-  }
-
-  func ascendingLabel(for field: TaskSortField) -> String {
-    switch field {
-    case .dueDate, .creationDate: return "Earliest First"
-    case .priority: return "Lowest First"
-    case .title: return "A → Z"
-    }
-  }
-
-  func descendingLabel(for field: TaskSortField) -> String {
-    switch field {
-    case .dueDate, .creationDate: return "Latest First"
-    case .priority: return "Highest First"
-    case .title: return "Z → A"
-    }
   }
 }

--- a/app/Taskmato/MainWindow/TimerTabView.swift
+++ b/app/Taskmato/MainWindow/TimerTabView.swift
@@ -49,7 +49,7 @@ struct TimerTabView: View {
         Button {
           nav.browseTasksAndPick()
         } label: {
-          Label("Browse Tasks…", systemImage: "checklist")
+          Label(AppLabels.View.browseTask.title, systemImage: AppLabels.View.browseTask.systemImage)
             .font(.caption)
         }
         .buttonStyle(.plain)
@@ -72,19 +72,34 @@ struct TimerTabView: View {
   private var controls: some View {
     HStack(spacing: 12) {
       if engine.isRunning {
-        ControlButton(label: "Pause", icon: "pause.fill") { engine.pause() }
+        ControlButton(
+          label: AppLabels.Timer.pause.title,
+          icon: AppLabels.Timer.pause.systemImage
+        ) { engine.pause() }
       } else if case .paused = engine.state {
-        ControlButton(label: "Resume", icon: "play.fill") { engine.resume() }
+        ControlButton(
+          label: AppLabels.Timer.resume.title,
+          icon: AppLabels.Timer.resume.systemImage
+        ) { engine.resume() }
       } else {
-        ControlButton(label: "Start", icon: "play.fill") { startSession() }
-          .disabled(selectionStore.activeTask == nil)
-          .help(selectionStore.activeTask == nil ? "Select a task before starting" : "")
+        ControlButton(
+          label: AppLabels.Timer.start.title,
+          icon: AppLabels.Timer.start.systemImage
+        ) { startSession() }
+        .disabled(selectionStore.activeTask == nil)
+        .help(selectionStore.activeTask == nil ? AppLabels.Tooltip.selectTaskFirst : "")
       }
 
-      ControlButton(label: "Skip", icon: "forward.fill") { skipPhase() }
+      ControlButton(
+        label: AppLabels.Timer.skip.title,
+        icon: AppLabels.Timer.skip.systemImage
+      ) { skipPhase() }
 
-      ControlButton(label: "Stop", icon: "stop.fill") { engine.stop() }
-        .disabled(engine.state == .idle)
+      ControlButton(
+        label: AppLabels.Timer.stop.title,
+        icon: AppLabels.Timer.stop.systemImage
+      ) { engine.stop() }
+      .disabled(engine.state == .idle)
     }
   }
 
@@ -147,17 +162,9 @@ struct TimerTabView: View {
   private var phaseName: String {
     switch engine.state {
     case .idle:
-      switch nextStartPhase {
-      case .focus: return "Ready to focus"
-      case .shortBreak: return "Short Break"
-      case .longBreak: return "Long Break"
-      }
+      return nextStartPhase.idleLabel
     case .running(let phase, _, _), .paused(let phase, _):
-      switch phase {
-      case .focus: return "Focus"
-      case .shortBreak: return "Short Break"
-      case .longBreak: return "Long Break"
-      }
+      return phase.displayName
     }
   }
 }

--- a/app/Taskmato/Session/SessionEngine.swift
+++ b/app/Taskmato/Session/SessionEngine.swift
@@ -16,6 +16,27 @@ enum SessionPhase: Equatable, Codable {
   case longBreak
 }
 
+extension SessionPhase {
+
+  /// Display name used when a session is running or paused in this phase.
+  var displayName: String {
+    switch self {
+    case .focus: return "Focus"
+    case .shortBreak: return "Short Break"
+    case .longBreak: return "Long Break"
+    }
+  }
+
+  /// Display name used when the engine is idle and this phase is queued next.
+  var idleLabel: String {
+    switch self {
+    case .focus: return "Ready to focus"
+    case .shortBreak: return "Short Break"
+    case .longBreak: return "Long Break"
+    }
+  }
+}
+
 /// The current state of the session engine's state machine.
 enum SessionState: Equatable {
   /// No session is active. The engine is ready to start a new focus interval.

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -83,6 +83,9 @@ struct TaskmatoApp: App {
     }
     .defaultSize(width: 480, height: 520)
     .windowResizability(.contentMinSize)
+    .commands {
+      TaskmatoCommands(nav: composition.nav, settings: composition.settings)
+    }
 
     Settings {
       SettingsView(
@@ -108,5 +111,141 @@ struct TaskmatoApp: App {
       seconds = Int(composition.engine.timeRemaining)
     }
     return String(format: "%02d:%02d", seconds / 60, seconds % 60)
+  }
+}
+
+// MARK: - Commands
+
+/// Menu commands and keyboard shortcuts for the main application window.
+struct TaskmatoCommands: Commands {
+
+  @FocusedValue(\.selectedTab) private var selectedTab
+  @FocusedValue(\.focusSearch) private var focusSearch
+  @FocusedValue(\.addTask) private var addTask
+  @FocusedValue(\.toggleCompleted) private var toggleCompleted
+  @FocusedValue(\.toggleCompletedTitle) private var toggleCompletedTitle
+  @FocusedValue(\.toggleCompletedIcon) private var toggleCompletedIcon
+  @FocusedValue(\.timerToggle) private var timerToggle
+  @FocusedValue(\.timerToggleTitle) private var timerToggleTitle
+  @FocusedValue(\.timerSkip) private var timerSkip
+  @FocusedValue(\.timerStop) private var timerStop
+
+  /// The navigation model used to switch tabs from the View menu.
+  var nav: MainNavigation
+  /// App settings used to read and write layout and sort state for View menu checkmarks.
+  @Bindable var settings: AppSettings
+
+  var body: some Commands {
+    // File → New Task (⌘N); disabled when no writable provider is available.
+    CommandGroup(replacing: .newItem) {
+      Button(AppLabels.Task.add.title) { addTask?() }
+        .keyboardShortcut("n")
+        .disabled(addTask == nil)
+    }
+    // Edit → Find… (⌘F); disabled when not on the Tasks tab.
+    CommandGroup(after: .textEditing) {
+      Divider()
+      Button(AppLabels.View.find.title) { focusSearch?() }
+        .keyboardShortcut("f")
+        .disabled(focusSearch == nil)
+    }
+    // View → Suppress the default broken sidebar toggle; our replacement lives at the bottom below.
+    CommandGroup(replacing: .sidebar) {}
+    // View → tab navigation (⌘1/2/3), layout, completed toggle (⌘⇧C), Sort By, then Show/Hide
+    // Sidebar (⌘⌃S) — placed last so it sits directly above the system "Enter Full Screen" item.
+    CommandGroup(after: .sidebar) {
+      Divider()
+      Button {
+        nav.showTasks()
+      } label: {
+        Label(AppLabels.Tab.tasks.title, systemImage: nav.selectedTab == .tasks ? "checkmark" : "")
+      }
+      .keyboardShortcut("1")
+      Button {
+        nav.showTimer()
+      } label: {
+        Label(AppLabels.Tab.timer.title, systemImage: nav.selectedTab == .timer ? "checkmark" : "")
+      }
+      .keyboardShortcut("2")
+      Button {
+        nav.showStats()
+      } label: {
+        Label(AppLabels.Tab.stats.title, systemImage: nav.selectedTab == .stats ? "checkmark" : "")
+      }
+      .keyboardShortcut("3")
+      Divider()
+      Picker("Layout", selection: $settings.taskPickerLayout) {
+        Label(AppLabels.View.listLayout.title, systemImage: AppLabels.View.listLayout.systemImage)
+          .tag(TaskPickerLayout.list)
+        Label(AppLabels.View.gridLayout.title, systemImage: AppLabels.View.gridLayout.systemImage)
+          .tag(TaskPickerLayout.grid)
+      }
+      .pickerStyle(.inline)
+      .disabled(selectedTab != .tasks)
+      Divider()
+      Button {
+        toggleCompleted?()
+      } label: {
+        Label(
+          toggleCompletedTitle ?? AppLabels.View.showCompleted.title,
+          systemImage: toggleCompletedIcon ?? AppLabels.View.showCompleted.systemImage
+        )
+      }
+      .keyboardShortcut("c", modifiers: [.command, .shift])
+      .disabled(toggleCompleted == nil)
+      Divider()
+      Menu {
+        ForEach(TaskSortField.allCases, id: \.self) { field in
+          Button {
+            settings.taskSortField = field
+            settings.taskSortDirection = field.defaultSortDirection
+          } label: {
+            Label(
+              field.displayName,
+              systemImage: settings.taskSortField == field ? "checkmark" : "")
+          }
+        }
+        Divider()
+        Button {
+          settings.taskSortDirection = .ascending
+        } label: {
+          Label(
+            settings.taskSortField.ascendingLabel,
+            systemImage: settings.taskSortDirection == .ascending ? "checkmark" : "")
+        }
+        Button {
+          settings.taskSortDirection = .descending
+        } label: {
+          Label(
+            settings.taskSortField.descendingLabel,
+            systemImage: settings.taskSortDirection == .descending ? "checkmark" : "")
+        }
+      } label: {
+        Label(AppLabels.View.sort.title, systemImage: AppLabels.View.sort.systemImage)
+      }
+      .disabled(selectedTab != .tasks)
+      Divider()
+      let sidebarSpec = nav.sidebarVisible ? AppLabels.View.hideSidebar : AppLabels.View.showSidebar
+      Button {
+        nav.sidebarVisible.toggle()
+      } label: {
+        Label(sidebarSpec.title, systemImage: sidebarSpec.systemImage)
+      }
+      .keyboardShortcut("s", modifiers: [.command, .control])
+      .disabled(selectedTab != .tasks)
+    }
+    // Timer menu — Start/Pause/Resume (⌘⏎), Skip Phase (⌘K), Stop (⌘.).
+    CommandMenu("Timer") {
+      Button(timerToggleTitle ?? AppLabels.Timer.start.title) { timerToggle?() }
+        .keyboardShortcut(.return)
+        .disabled(timerToggle == nil)
+      Button(AppLabels.Timer.skip.title) { timerSkip?() }
+        .keyboardShortcut("k")
+        .disabled(timerSkip == nil)
+      Divider()
+      Button(AppLabels.Timer.stop.title) { timerStop?() }
+        .keyboardShortcut(".", modifiers: .command)
+        .disabled(timerStop == nil)
+    }
   }
 }

--- a/app/Taskmato/Tasks/TaskSortField.swift
+++ b/app/Taskmato/Tasks/TaskSortField.swift
@@ -20,3 +20,42 @@ enum TaskSortField: String, CaseIterable, Sendable {
   /// Sort by the wall-clock time the task was created in its source provider.
   case creationDate
 }
+
+extension TaskSortField {
+
+  /// Display name shown in sort menus and toolbar items.
+  var displayName: String {
+    switch self {
+    case .dueDate: return "Due Date"
+    case .priority: return "Priority"
+    case .title: return "Title"
+    case .creationDate: return "Creation Date"
+    }
+  }
+
+  /// The natural sort direction to apply when this field is first selected.
+  var defaultSortDirection: TaskSortDirection {
+    switch self {
+    case .dueDate, .creationDate, .title: return .ascending
+    case .priority: return .descending
+    }
+  }
+
+  /// Label for the ascending direction of this sort field.
+  var ascendingLabel: String {
+    switch self {
+    case .dueDate, .creationDate: return "Earliest First"
+    case .priority: return "Lowest First"
+    case .title: return "A → Z"
+    }
+  }
+
+  /// Label for the descending direction of this sort field.
+  var descendingLabel: String {
+    switch self {
+    case .dueDate, .creationDate: return "Latest First"
+    case .priority: return "Highest First"
+    case .title: return "Z → A"
+    }
+  }
+}

--- a/app/Taskmato/TimerView.swift
+++ b/app/Taskmato/TimerView.swift
@@ -82,7 +82,7 @@ struct TimerView: View {
           nav.openMainWindow()
           DispatchQueue.main.async { popover?.close() }
         } label: {
-          Label("Browse Tasks…", systemImage: "checklist")
+          Label(AppLabels.View.browseTask.title, systemImage: AppLabels.View.browseTask.systemImage)
             .font(.caption)
         }
         .buttonStyle(.plain)
@@ -120,19 +120,34 @@ struct TimerView: View {
   private var controls: some View {
     HStack(spacing: 12) {
       if engine.isRunning {
-        ControlButton(label: "Pause", icon: "pause.fill") { engine.pause() }
+        ControlButton(
+          label: AppLabels.Timer.pause.title,
+          icon: AppLabels.Timer.pause.systemImage
+        ) { engine.pause() }
       } else if case .paused = engine.state {
-        ControlButton(label: "Resume", icon: "play.fill") { engine.resume() }
+        ControlButton(
+          label: AppLabels.Timer.resume.title,
+          icon: AppLabels.Timer.resume.systemImage
+        ) { engine.resume() }
       } else {
-        ControlButton(label: "Start", icon: "play.fill") { startSession() }
-          .disabled(selectionStore.activeTask == nil)
-          .help(selectionStore.activeTask == nil ? "Select a task before starting" : "")
+        ControlButton(
+          label: AppLabels.Timer.start.title,
+          icon: AppLabels.Timer.start.systemImage
+        ) { startSession() }
+        .disabled(selectionStore.activeTask == nil)
+        .help(selectionStore.activeTask == nil ? AppLabels.Tooltip.selectTaskFirst : "")
       }
 
-      ControlButton(label: "Skip", icon: "forward.fill") { skipPhase() }
+      ControlButton(
+        label: AppLabels.Timer.skip.title,
+        icon: AppLabels.Timer.skip.systemImage
+      ) { skipPhase() }
 
-      ControlButton(label: "Stop", icon: "stop.fill") { engine.stop() }
-        .disabled(engine.state == .idle)
+      ControlButton(
+        label: AppLabels.Timer.stop.title,
+        icon: AppLabels.Timer.stop.systemImage
+      ) { engine.stop() }
+      .disabled(engine.state == .idle)
     }
   }
 
@@ -195,17 +210,9 @@ struct TimerView: View {
   private var phaseName: String {
     switch engine.state {
     case .idle:
-      switch nextStartPhase {
-      case .focus: return "Ready to focus"
-      case .shortBreak: return "Short Break"
-      case .longBreak: return "Long Break"
-      }
+      return nextStartPhase.idleLabel
     case .running(let phase, _, _), .paused(let phase, _):
-      switch phase {
-      case .focus: return "Focus"
-      case .shortBreak: return "Short Break"
-      case .longBreak: return "Long Break"
-      }
+      return phase.displayName
     }
   }
 }

--- a/app/Taskmato/Views/TaskCardView.swift
+++ b/app/Taskmato/Views/TaskCardView.swift
@@ -66,7 +66,7 @@ struct TaskCardView: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
-        .help(TaskLabel.Tooltip.markAsCompleted)
+        .help(AppLabels.Tooltip.markAsCompleted)
       }
     case .completed(let onRestore, _):
       Button(action: onRestore) {
@@ -74,7 +74,7 @@ struct TaskCardView: View {
           .foregroundStyle(Color.accentColor)
       }
       .buttonStyle(.plain)
-      .help(TaskLabel.Tooltip.restore)
+      .help(AppLabels.Tooltip.restore)
     }
   }
 
@@ -131,7 +131,7 @@ struct TaskCardView: View {
           .foregroundStyle(.secondary)
       }
       .buttonStyle(.plain)
-      .help(TaskLabel.Tooltip.deletePermanently)
+      .help(AppLabels.Tooltip.deletePermanently)
     }
   }
 

--- a/app/Taskmato/Views/TaskLabel.swift
+++ b/app/Taskmato/Views/TaskLabel.swift
@@ -3,14 +3,28 @@
 //  Taskmato
 //
 
-/// String constants for task-action labels used across all task views.
+/// A paired title and SF Symbol name used consistently across menus, toolbars, and buttons.
+struct AppLabel {
+  /// Title-style string for menus and toolbar labels.
+  let title: String
+  /// SF Symbol name for the accompanying icon.
+  let systemImage: String
+
+  init(_ title: String, systemImage: String) {
+    self.title = title
+    self.systemImage = systemImage
+  }
+}
+
+/// String constants and icon pairings for all app-level UI labels.
 ///
 /// `Tooltip` entries use sentence-style capitalization per the macOS HIG.
-/// `Menu` entries use title-style capitalization per the macOS HIG.
-enum TaskLabel {
+/// All other entries use title-style capitalization per the macOS HIG.
+enum AppLabels {
 
-  /// Tooltip strings for task action buttons — sentence-style capitalization.
+  /// Tooltip strings for action buttons — sentence-style capitalization.
   enum Tooltip {
+    // Task item state buttons
     /// Shown on the completion circle when no session is running.
     static let markAsCompleted = "Mark as completed"
     /// Shown on the completion circle when a timer session is active.
@@ -19,17 +33,97 @@ enum TaskLabel {
     static let restore = "Restore task"
     /// Shown on the trash button of a completed task row or card.
     static let deletePermanently = "Delete permanently"
+    // Active task row
+    /// Shown on the swap button when a session is active.
+    static let swapTask = "Swap task — pauses the session and opens the task list"
+    /// Shown on the clear button in the active task row.
+    static let clearTask = "Clear task"
+    // Timer controls
+    /// Shown on the Start button when no task is selected.
+    static let selectTaskFirst = "Select a task before starting"
+    // Tasks toolbar
+    /// Shown on the Add Task toolbar button.
+    static let addTask = "Add a task"
+    /// Shown on the Show Completed toolbar button when the section is hidden.
+    static let showCompleted = "Show completed tasks"
+    /// Shown on the Show Completed toolbar button when the section is visible.
+    static let hideCompleted = "Hide completed tasks"
   }
 
-  /// Context menu item strings — title-style capitalization.
-  enum Menu {
-    /// Sets the task as active and switches to the timer tab.
-    static let trackTask = "Track Task"
+  /// Labels for task CRUD and lifecycle actions.
+  enum Task {
+    /// Sets the task as active and switches to the Timer tab.
+    static let track = AppLabel("Track Task", systemImage: "timer")
+    /// Opens the Add Task sheet.
+    static let add = AppLabel("New Task", systemImage: "plus")
+    /// Opens the Edit Task sheet.
+    static let edit = AppLabel("Edit Task…", systemImage: "pencil")
     /// Marks the task as completed via its closable provider.
-    static let markAsCompleted = "Mark as Completed"
+    static let complete = AppLabel("Mark as Completed", systemImage: "checkmark.circle.fill")
     /// Restores a completed task to the active list.
-    static let restoreTask = "Restore Task"
-    /// Permanently deletes a completed task via its writable provider.
-    static let deletePermanently = "Delete Permanently"
+    static let restore = AppLabel("Restore Task", systemImage: "arrow.counterclockwise")
+    /// Permanently deletes a task via its writable provider.
+    static let delete = AppLabel("Delete Permanently", systemImage: "trash")
+  }
+
+  /// Labels for view-state commands: layout, completed section, sort, and search.
+  enum View {
+    /// Focuses the search field.
+    static let find = AppLabel("Find…", systemImage: "magnifyingglass")
+    /// Shows the completed tasks section.
+    static let showCompleted = AppLabel("Show Completed", systemImage: "eye")
+    /// Hides the completed tasks section.
+    static let hideCompleted = AppLabel("Hide Completed", systemImage: "eye.slash")
+    /// Switches the task picker to list layout.
+    static let listLayout = AppLabel("as List", systemImage: "list.bullet")
+    /// Switches the task picker to grid layout.
+    static let gridLayout = AppLabel("as Grid", systemImage: "square.grid.2x2")
+    /// The sort toolbar menu.
+    static let sort = AppLabel("Sort", systemImage: "arrow.up.arrow.down")
+    /// Opens the task browser from the timer views.
+    static let browseTask = AppLabel("Browse Tasks…", systemImage: "checklist")
+    /// Shows the provider sidebar column.
+    static let showSidebar = AppLabel("Show Sidebar", systemImage: "sidebar.left")
+    /// Hides the provider sidebar column.
+    static let hideSidebar = AppLabel("Hide Sidebar", systemImage: "sidebar.left")
+  }
+
+  /// Labels for timer session controls.
+  enum Timer {
+    /// Starts a new focus session.
+    static let start = AppLabel("Start", systemImage: "play.fill")
+    /// Pauses the running session.
+    static let pause = AppLabel("Pause", systemImage: "pause.fill")
+    /// Resumes a paused session.
+    static let resume = AppLabel("Resume", systemImage: "play.fill")
+    /// Skips the current phase and advances to the next.
+    static let skip = AppLabel("Skip Phase", systemImage: "forward.fill")
+    /// Stops the current session.
+    static let stop = AppLabel("Stop", systemImage: "stop.fill")
+  }
+
+  /// Labels for the three main-window tabs.
+  enum Tab {
+    static let tasks = AppLabel("Tasks", systemImage: "checklist")
+    static let timer = AppLabel("Timer", systemImage: "timer")
+    static let stats = AppLabel("Stats", systemImage: "chart.bar")
+  }
+
+  /// Labels for provider sidebar actions.
+  enum Sidebar {
+    /// Opens the Add Task sheet targeted at a specific list.
+    static let addTask = AppLabel("Add Task…", systemImage: "plus.circle")
+    /// Marks a list as the default for its provider.
+    static let setDefault = AppLabel("Set as Default", systemImage: "star")
+    /// Begins an inline rename of the selected list.
+    static let rename = AppLabel("Rename", systemImage: "pencil")
+    /// Deletes the selected list from its provider.
+    static let deleteList = AppLabel("Delete", systemImage: "trash")
+    /// Opens the provider configuration sheet.
+    static let configure = AppLabel("Configure…", systemImage: "gear")
+    /// Disables and removes the provider from the sidebar.
+    static let remove = AppLabel("Remove", systemImage: "trash")
+    /// Opens the Add Provider menu at the sidebar bottom.
+    static let addProvider = AppLabel("Add Provider", systemImage: "plus.circle")
   }
 }

--- a/app/Taskmato/Views/TaskRowView.swift
+++ b/app/Taskmato/Views/TaskRowView.swift
@@ -60,7 +60,7 @@ struct TaskRowView: View {
         }
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
-        .help(TaskLabel.Tooltip.markAsCompleted)
+        .help(AppLabels.Tooltip.markAsCompleted)
       }
     case .completed(let onRestore, _):
       Button(action: onRestore) {
@@ -68,7 +68,7 @@ struct TaskRowView: View {
           .foregroundStyle(Color.accentColor)
       }
       .buttonStyle(.plain)
-      .help(TaskLabel.Tooltip.restore)
+      .help(AppLabels.Tooltip.restore)
     }
   }
 
@@ -125,7 +125,7 @@ struct TaskRowView: View {
           .foregroundStyle(.secondary)
       }
       .buttonStyle(.plain)
-      .help(TaskLabel.Tooltip.deletePermanently)
+      .help(AppLabels.Tooltip.deletePermanently)
     }
   }
 

--- a/docs/architecture/design/0005-pre-1.0-architecture-pass.md
+++ b/docs/architecture/design/0005-pre-1.0-architecture-pass.md
@@ -268,7 +268,7 @@ Each row is one PR. Ordered so PRs are mergeable in isolation and the next build
 | 15 | Fix `Calendar.endOfToday` DST bug | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), 6.5 |
 | 16 | Add `os.Logger` to `SessionStore` and `LocalProvider` save paths | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), T (part) |
 
-Already-planned 0.7.0 issues (#260, #293, #303, ~~#330~~, #341, #370, ~~#383~~, #392) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 (closed by PR 11). **#388** closes as part of PR 12.
+Already-planned 0.7.0 issues (#260, #293, #303, ~~#330~~, #341, #370, ~~#383~~, ~~#392~~) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 (closed by PR 11). **#388** closes as part of PR 12. **#392** keyboard shortcut pass (⌘F search focus, ⌘N new task, ⌘1–3 tab navigation) ✅ this branch.
 
 ### 0.8.0 — Stats expansion + SwiftData session migration
 


### PR DESCRIPTION
## Summary

Adds macOS menu commands and keyboard shortcuts for common Taskmato workflows: creating tasks, focusing task search, switching tabs, toggling completed tasks, changing task layout and sort order, toggling the sidebar, and controlling the timer from a new Timer menu.

## Linked issue

Closes #392

## Type of change

_Put an `x` in the boxes that apply._

- [ ] Bug fix
- [x] Feature
- [x] Maintenance / cleanup
- [x] Documentation / content
- [ ] Breaking change

## Details

- Adds `TaskmatoCommands` to the main window scene and wires menu actions through focused scene values so commands enable only when the active tab/view can handle them.
- Adds task search focus support via `.searchFocused`, plus focused actions for Add Task and Show/Hide Completed.
- Adds View menu entries for Tasks/Timer/Stats tab navigation, task layout, completed tasks, Sort By, and sidebar visibility.
- Adds a Timer menu with Start/Pause/Resume, Skip Phase, and Stop commands that reuse the same timer behavior as the visible controls.
- Centralizes shared labels, icons, and tooltips in `AppLabels`, and moves sort field labels/default directions onto `TaskSortField` for reuse by both toolbar and menu commands.
- Updates timer phase display helpers and the pre-1.0 architecture pass design doc to account for system menus and centralized labels.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [ ] Manually verified changes
- [x] Documentation updated where appropriate

`git diff --check origin/main...HEAD` passes. I did not run lint, unit tests, or manual app verification while drafting this PR.

## Reviewer notes

The branch includes a follow-up commit updating `.claude/settings.json` allowed permissions. Reviewers should verify that the new focused command actions stay disabled in the expected tabs and that the keyboard shortcuts do not conflict with system menu behavior.