### PR TITLE
feat(url-scheme): provider targeting and default writable provider setting

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -49,7 +49,7 @@ struct AppComposition {
     let nav = MainNavigation(settings: settings)
     let urlHandler = URLSchemeHandler(
       registry: registry, selectionStore: selectionStore,
-      engine: engine, settings: settings, localProvider: localProvider,
+      engine: engine, settings: settings,
       nav: nav
     )
     engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in

--- a/app/Taskmato/MainWindow/TasksTabView.swift
+++ b/app/Taskmato/MainWindow/TasksTabView.swift
@@ -28,15 +28,18 @@ struct TasksTabView: View {
   @State private var completedTasks: [TaskItem] = []
   @State private var isLoadingCompleted = false
 
-  /// Returns the writable provider for the current sidebar selection, or the first
-  /// enabled writable provider when the selection is `.today` or unresolved.
+  /// Returns the writable provider for the current sidebar selection, falling back to the
+  /// default writable provider (from settings, then first enabled in registration order).
   private var writableProvider: (any WritableTaskProvider)? {
     guard case .list(let sel) = registry.selection,
       let provider = registry.providers.first(where: {
         $0.id == sel.providerID && registry.isEnabled($0.id)
       }),
       let writable = provider as? (any WritableTaskProvider)
-    else { return registry.firstEnabledWritableProvider }
+    else {
+      return registry.resolveDefaultWritableProvider(
+        preferredID: settings.defaultWritableProviderID)
+    }
     return writable
   }
 

--- a/app/Taskmato/Settings/AppSettings.swift
+++ b/app/Taskmato/Settings/AppSettings.swift
@@ -80,6 +80,12 @@ final class AppSettings {
     didSet { defaults.set(taskSortDirection.rawValue, forKey: Keys.taskSortDirection) }
   }
 
+  /// The provider ID of the preferred writable provider for new ad-hoc tasks and the
+  /// Add Task sheet, or `nil` to automatically select the first enabled writable provider.
+  var defaultWritableProviderID: String? {
+    didSet { defaults.set(defaultWritableProviderID, forKey: Keys.defaultWritableProviderID) }
+  }
+
   /// `focusMinutes` expressed as a `TimeInterval` in seconds.
   var focusDuration: TimeInterval { TimeInterval(focusMinutes * 60) }
 
@@ -114,6 +120,7 @@ final class AppSettings {
       defaults.string(forKey: Keys.taskSortField).flatMap(TaskSortField.init) ?? .dueDate
     taskSortDirection =
       defaults.string(forKey: Keys.taskSortDirection).flatMap(TaskSortDirection.init) ?? .ascending
+    defaultWritableProviderID = defaults.string(forKey: Keys.defaultWritableProviderID)
   }
 
   private enum Keys {
@@ -129,6 +136,7 @@ final class AppSettings {
     static let sidebarVisible = "taskRegistry.sidebarVisible"
     static let taskSortField = "taskSort.field"
     static let taskSortDirection = "taskSort.direction"
+    static let defaultWritableProviderID = "tasks.defaultWritableProviderID"
   }
 }
 

--- a/app/Taskmato/Settings/SettingsView.swift
+++ b/app/Taskmato/Settings/SettingsView.swift
@@ -36,30 +36,47 @@ struct SettingsView: View {
           .foregroundStyle(.secondary)
       }
 
-      #if DEBUG
-        Section("Debug") {
-          if let task = selectionStore.activeTask {
-            LabeledContent("Active task", value: task.title)
+      Section("Tasks") {
+        Picker(
+          "Default writable provider",
+          selection: Binding(
+            get: { settings.defaultWritableProviderID ?? "" },
+            set: { settings.defaultWritableProviderID = $0.isEmpty ? nil : $0 }
+          )
+        ) {
+          Text("Automatic").tag("")
+          ForEach(writableProviderEntries) { entry in
+            Label(entry.displayName, systemImage: entry.icon).tag(entry.id)
           }
-          Button("Set test task") {
-            selectionStore.select(
-              TaskItem(
-                id: TaskRef(providerID: "debug", nativeID: "1"),
-                title: "Write release notes",
-                format: .plainText,
-                priority: .high
-              ))
-          }
-          Button("Clear active task", role: .destructive) {
-            selectionStore.clearActiveTask()
-          }
-          .disabled(selectionStore.activeTask == nil)
         }
-      #endif
+        Text(
+          "The provider used when creating ad-hoc tasks from the command line or the Add Task sheet."
+        )
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      }
     }
     .formStyle(.grouped)
     .navigationTitle("\(Bundle.main.appName) Settings")
   }
+
+  /// Registered providers that are currently enabled and conform to ``WritableTaskProvider``,
+  /// formatted for display in the default-provider picker.
+  private var writableProviderEntries: [ProviderEntry] {
+    registry.providers.compactMap { provider in
+      guard registry.isEnabled(provider.id),
+        provider is (any WritableTaskProvider)
+      else { return nil }
+      return ProviderEntry(id: provider.id, displayName: provider.displayName, icon: provider.icon)
+    }
+  }
+}
+
+/// A lightweight display model for a writable provider in the settings picker.
+private struct ProviderEntry: Identifiable {
+  let id: String
+  let displayName: String
+  let icon: String
 }
 
 /// A labelled row combining a text field for direct input and a stepper for nudging.

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -52,10 +52,12 @@ struct TaskmatoApp: App {
         }
         if let params = composition.urlHandler.pendingAdHocParams {
           Button("Create new \"\(params.title)\"") {
-            let task = composition.urlHandler.makeAdHocTask(from: params)
-            composition.selectionStore.select(task)
-            composition.urlHandler.pendingDisambiguation = nil
-            composition.nav.showTimerInMainWindow()
+            Task {
+              let task = await composition.urlHandler.makeAdHocTask(from: params)
+              composition.selectionStore.select(task)
+              composition.urlHandler.pendingDisambiguation = nil
+              composition.nav.showTimerInMainWindow()
+            }
           }
         }
         Button("Cancel", role: .cancel) {

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -122,7 +122,7 @@ final class LocalProvider: WritableTaskProvider {
   ///
   /// If `draft.listID` is `nil`, the task is assigned to the provider's default list.
   @discardableResult
-  func addTask(_ draft: TaskDraft) -> TaskItem {
+  func addTask(_ draft: TaskDraft) async throws -> TaskItem {
     var resolved = draft
     if resolved.listID == nil {
       resolved.listID = defaultListID ?? taskLists.first?.id.uuidString
@@ -134,7 +134,7 @@ final class LocalProvider: WritableTaskProvider {
   }
 
   /// Persists `listID` as the default target for new tasks.
-  func setDefaultList(_ listID: String) throws {
+  func setDefaultList(_ listID: String) async throws {
     guard taskLists.contains(where: { $0.id.uuidString == listID }) else {
       throw LocalProviderError.listNotFound(listID)
     }
@@ -143,7 +143,7 @@ final class LocalProvider: WritableTaskProvider {
   }
 
   /// Applies `draft` to the task identified by `ref`.
-  func updateTask(_ ref: TaskRef, draft: TaskDraft) throws {
+  func updateTask(_ ref: TaskRef, draft: TaskDraft) async throws {
     guard let idx = allTasks.firstIndex(where: { $0.id.uuidString == ref.nativeID }) else {
       throw LocalProviderError.taskNotFound(ref.nativeID)
     }
@@ -152,7 +152,7 @@ final class LocalProvider: WritableTaskProvider {
   }
 
   /// Permanently removes the task identified by `ref` from the store.
-  func deleteTask(_ ref: TaskRef) throws {
+  func deleteTask(_ ref: TaskRef) async throws {
     guard allTasks.contains(where: { $0.id.uuidString == ref.nativeID }) else {
       throw LocalProviderError.taskNotFound(ref.nativeID)
     }
@@ -164,7 +164,7 @@ final class LocalProvider: WritableTaskProvider {
 
   /// Appends a new list with the given name and returns the provider-agnostic ``TaskList``.
   @discardableResult
-  func createList(name: String) -> TaskList {
+  func createList(name: String) async throws -> TaskList {
     let list = LocalList(id: UUID(), name: name)
     taskLists.append(list)
     save()
@@ -172,7 +172,7 @@ final class LocalProvider: WritableTaskProvider {
   }
 
   /// Renames the list identified by `listID` to `name`.
-  func renameList(_ listID: String, name: String) throws {
+  func renameList(_ listID: String, name: String) async throws {
     guard let idx = taskLists.firstIndex(where: { $0.id.uuidString == listID }) else {
       throw LocalProviderError.listNotFound(listID)
     }
@@ -184,7 +184,7 @@ final class LocalProvider: WritableTaskProvider {
   ///
   /// Throws ``LocalProviderError/cannotDeleteDefaultList(_:)`` when `listID` is the
   /// current default. Promote another list via ``setDefaultList(_:)`` first.
-  func deleteList(_ listID: String) throws {
+  func deleteList(_ listID: String) async throws {
     guard listID != defaultListID else {
       throw LocalProviderError.cannotDeleteDefaultList(listID)
     }

--- a/app/Taskmato/Tasks/TaskRegistry.swift
+++ b/app/Taskmato/Tasks/TaskRegistry.swift
@@ -325,6 +325,31 @@ final class TaskRegistry {
       as? (any WritableTaskProvider)
   }
 
+  /// Returns the enabled writable provider with the given ID, or `nil`.
+  /// - Parameter id: The provider ID to resolve exactly.
+  func enabledWritableProvider(id: String) -> (any WritableTaskProvider)? {
+    providers.first { $0.id == id && isEnabled($0.id) }
+      as? (any WritableTaskProvider)
+  }
+
+  /// Returns the preferred writable provider for new tasks.
+  ///
+  /// Resolution order:
+  /// 1. The provider with `preferredID` if it is currently enabled and conforms to
+  ///    ``WritableTaskProvider``.
+  /// 2. ``firstEnabledWritableProvider`` — the first enabled writable provider in
+  ///    registration order.
+  ///
+  /// Returns `nil` when no enabled writable provider is registered.
+  /// - Parameter preferredID: A provider ID to try first, typically from ``AppSettings``
+  ///   user preference. Pass `nil` to skip directly to the fallback.
+  func resolveDefaultWritableProvider(preferredID: String?) -> (any WritableTaskProvider)? {
+    if let preferredID, let writable = enabledWritableProvider(id: preferredID) {
+      return writable
+    }
+    return firstEnabledWritableProvider
+  }
+
   /// The authorization state of each registered provider, in registration order.
   ///
   /// Observe this in views to react when any provider's `isAuthorized` changes.

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -16,6 +16,11 @@ struct AdHocTaskParams {
   let dueDate: Date?
   /// Raw list name from the URL, or `nil` if the param was absent.
   let listName: String?
+  /// Raw provider ID from the URL, or `nil` if the param was absent.
+  ///
+  /// When set and the named provider is an enabled ``WritableTaskProvider``, ad-hoc task
+  /// creation targets that provider regardless of the default-provider setting.
+  let providerID: String?
 }
 
 /// Parses and dispatches `taskmato://` deep links to select a task and, when auto-start is
@@ -44,7 +49,6 @@ final class URLSchemeHandler {
   private let selectionStore: TaskSelectionStore
   private let engine: SessionEngine
   private let settings: AppSettings
-  private let localProvider: LocalProvider
   private let nav: MainNavigation
 
   init(
@@ -52,14 +56,12 @@ final class URLSchemeHandler {
     selectionStore: TaskSelectionStore,
     engine: SessionEngine,
     settings: AppSettings,
-    localProvider: LocalProvider,
     nav: MainNavigation
   ) {
     self.registry = registry
     self.selectionStore = selectionStore
     self.engine = engine
     self.settings = settings
-    self.localProvider = localProvider
     self.nav = nav
   }
 
@@ -86,23 +88,44 @@ final class URLSchemeHandler {
 
   /// Creates an ad-hoc task from the given params.
   ///
-  /// If ``LocalProvider`` is enabled, the task is written to its default list (or to the
-  /// local list whose name matches `adHocParams.listName`, if one exists). Otherwise a
-  /// transient ``TaskItem`` is returned without persisting it to any provider.
-  func makeAdHocTask(from adHocParams: AdHocTaskParams) -> TaskItem {
-    if registry.isEnabled(LocalProvider.providerID) {
+  /// Provider resolution order:
+  /// 1. `adHocParams.providerID` (URL `provider=` param) if set and the named provider is
+  ///    an enabled ``WritableTaskProvider``.
+  /// 2. ``AppSettings/defaultWritableProviderID`` if set and the named provider is enabled.
+  /// 3. ``TaskRegistry/firstEnabledWritableProvider`` — the first enabled writable provider
+  ///    in registration order.
+  ///
+  /// Falls back to a transient ``TaskItem`` (providerID `"adhoc"`) when no enabled writable
+  /// provider is available.
+  func makeAdHocTask(from adHocParams: AdHocTaskParams) async -> TaskItem {
+    // Level 1: URL param targets a specific provider (strict — no implicit fallback within level).
+    let urlTargeted = adHocParams.providerID.flatMap(registry.enabledWritableProvider(id:))
+    // Level 2 & 3: settings default, then first enabled writable provider.
+    let writable =
+      urlTargeted
+      ?? registry.resolveDefaultWritableProvider(preferredID: settings.defaultWritableProviderID)
+
+    if let writable {
       var draft = TaskDraft()
       draft.title = adHocParams.title
       draft.priority = adHocParams.priority
       draft.dueDate = adHocParams.dueDate
       if let name = adHocParams.listName {
+        let lists: [TaskList]
+        if let cached = registry.providerLists[writable.id] {
+          lists = cached
+        } else {
+          lists = (try? await writable.lists()) ?? []
+        }
         draft.listID =
-          localProvider.taskLists.first {
-            $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame
-          }?.id.uuidString ?? localProvider.defaultListID
+          lists.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }?.id
+          ?? writable.defaultListID
       }
-      return localProvider.addTask(draft)
+      if let item = try? await writable.addTask(draft) {
+        return item
+      }
     }
+
     let list = adHocParams.listName.map { name in
       TaskList(
         id: name.lowercased().replacingOccurrences(of: " ", with: "-"),
@@ -165,7 +188,7 @@ final class URLSchemeHandler {
         pendingAdHocParams = buildAdHocParams(from: params, title: title)
         return nil
       }
-      return makeAdHocTask(from: buildAdHocParams(from: params, title: title))
+      return await makeAdHocTask(from: buildAdHocParams(from: params, title: title))
     }
 
     return nil
@@ -190,7 +213,8 @@ final class URLSchemeHandler {
   }
 
   private func lookupByTitle(_ title: String, providerID: String) async -> TaskItem? {
-    guard let provider = registry.providers.first(where: { $0.id == providerID })
+    guard let provider = registry.providers.first(where: { $0.id == providerID }),
+      registry.isEnabled(provider.id)
     else { return nil }
     let all = (try? await provider.tasks(in: nil)) ?? []
     return all.first { $0.title.localizedCaseInsensitiveContains(title) }
@@ -207,7 +231,8 @@ final class URLSchemeHandler {
       title: title,
       priority: params["priority"].flatMap(TaskPriority.init(urlParam:)) ?? .none,
       dueDate: params["due"].flatMap(parseDate(_:)),
-      listName: params["list"]
+      listName: params["list"],
+      providerID: params["provider"]
     )
   }
 

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -70,18 +70,18 @@ struct LocalProviderTests {
     #expect(second.defaultListID == storedID)
   }
 
-  @Test func setDefaultListChangesDefault() throws {
+  @Test func setDefaultListChangesDefault() async throws {
     let provider = makeProvider()
-    provider.createList(name: "Work")
+    try await provider.createList(name: "Work")
     let workID = provider.taskLists[1].id.uuidString
-    try provider.setDefaultList(workID)
+    try await provider.setDefaultList(workID)
     #expect(provider.defaultListID == workID)
   }
 
-  @Test func setDefaultListThrowsForUnknownID() {
+  @Test func setDefaultListThrowsForUnknownID() async {
     let provider = makeProvider()
-    #expect(throws: LocalProviderError.self) {
-      try provider.setDefaultList(UUID().uuidString)
+    await #expect(throws: LocalProviderError.self) {
+      try await provider.setDefaultList(UUID().uuidString)
     }
   }
 
@@ -129,7 +129,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "My task"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let tasks = try await provider.tasks(in: nil)
     #expect(tasks.count == 1)
     #expect(tasks[0].title == "My task")
@@ -140,7 +140,7 @@ struct LocalProviderTests {
     let before = Date()
     var draft = TaskDraft()
     draft.title = "Timestamped"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let after = Date()
     let tasks = try await provider.tasks(in: nil)
     let createdAt = try #require(tasks.first?.createdAt)
@@ -153,7 +153,7 @@ struct LocalProviderTests {
     let defaultID = provider.defaultListID!
     var draft = TaskDraft()
     draft.title = "Orphan"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
 
     let list = TaskList(id: defaultID, providerID: LocalProvider.providerID, name: "Default")
     let tasks = try await provider.tasks(in: list)
@@ -166,7 +166,7 @@ struct LocalProviderTests {
     let first = LocalProvider(fileURL: url)
     var draft = TaskDraft()
     draft.title = "Persisted"
-    first.addTask(draft)
+    try await first.addTask(draft)
 
     let second = LocalProvider(fileURL: url)
     let tasks = try await second.tasks(in: nil)
@@ -177,7 +177,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "To complete"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
     try await provider.complete(ref)
     let remaining = try await provider.tasks(in: nil)
@@ -188,7 +188,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Done"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
     try await provider.complete(ref)
     let completed = try await provider.completedTasks()
@@ -200,7 +200,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "With Date"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
     let before = Date()
     try await provider.complete(ref)
@@ -216,7 +216,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Reopen me"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
     try await provider.complete(ref)
     try await provider.reopen(ref)
@@ -231,10 +231,9 @@ struct LocalProviderTests {
     for title in ["A", "B", "C"] {
       var draft = TaskDraft()
       draft.title = title
-      provider.addTask(draft)
+      try await provider.addTask(draft)
     }
     let active = try await provider.tasks(in: nil)
-    // Complete only the first two.
     try await provider.complete(active[0].id)
     try await provider.complete(active[1].id)
     let completed = try await provider.completedTasks()
@@ -247,9 +246,9 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Delete me"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
-    try provider.deleteTask(ref)
+    try await provider.deleteTask(ref)
     #expect(try await provider.tasks(in: nil).isEmpty)
     #expect(try await provider.completedTasks().isEmpty)
   }
@@ -258,7 +257,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Completed and deleted"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
     try await provider.complete(ref)
     let writable: any WritableTaskProvider = provider
@@ -270,11 +269,11 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Original"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let ref = try await provider.tasks(in: nil)[0].id
     var updated = TaskDraft()
     updated.title = "Updated"
-    try provider.updateTask(ref, draft: updated)
+    try await provider.updateTask(ref, draft: updated)
     let tasks = try await provider.tasks(in: nil)
     #expect(tasks[0].title == "Updated")
   }
@@ -283,7 +282,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Markdown task"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     let tasks = try await provider.tasks(in: nil)
     #expect(tasks[0].format == .markdown)
   }
@@ -318,7 +317,7 @@ struct LocalProviderTests {
     let provider = makeProvider()
     var draft = TaskDraft()
     draft.title = "Count me"
-    provider.addTask(draft)
+    try await provider.addTask(draft)
     #expect(provider.activeTaskCount == 1)
     let ref = try await provider.tasks(in: nil)[0].id
     try await provider.complete(ref)
@@ -327,35 +326,35 @@ struct LocalProviderTests {
 
   // MARK: - List CRUD
 
-  @Test func createListAddsToProvider() {
+  @Test func createListAddsToProvider() async throws {
     let provider = makeProvider()
-    provider.createList(name: "Work")
+    try await provider.createList(name: "Work")
     #expect(provider.taskLists.count == 2)
     #expect(provider.taskLists.map(\.name).contains("Work"))
   }
 
-  @Test func renameListUpdatesName() throws {
+  @Test func renameListUpdatesName() async throws {
     let provider = makeProvider()
     let listID = provider.taskLists[0].id.uuidString
-    try provider.renameList(listID, name: "Personal")
+    try await provider.renameList(listID, name: "Personal")
     #expect(provider.taskLists[0].name == "Personal")
   }
 
   @Test func deleteNonDefaultListMovesTasksToDefault() async throws {
     let provider = makeProvider()
-    provider.createList(name: "Secondary")
+    try await provider.createList(name: "Secondary")
     let primaryID = provider.taskLists[0].id.uuidString  // Default = current default
     let secondaryID = provider.taskLists[1].id.uuidString
 
     // Promote "Secondary" so we can delete "Default"
-    try provider.setDefaultList(secondaryID)
+    try await provider.setDefaultList(secondaryID)
 
     var draft = TaskDraft()
     draft.title = "Orphaned"
     draft.listID = primaryID
-    provider.addTask(draft)
+    try await provider.addTask(draft)
 
-    try provider.deleteList(primaryID)
+    try await provider.deleteList(primaryID)
 
     let secondaryList = TaskList(
       id: secondaryID, providerID: LocalProvider.providerID, name: "Secondary")
@@ -363,27 +362,27 @@ struct LocalProviderTests {
     #expect(tasks.map(\.title).contains("Orphaned"))
   }
 
-  @Test func deleteDefaultListThrows() throws {
+  @Test func deleteDefaultListThrows() async {
     let provider = makeProvider()
     let defaultID = provider.defaultListID!
-    #expect(throws: LocalProviderError.self) {
-      try provider.deleteList(defaultID)
+    await #expect(throws: LocalProviderError.self) {
+      try await provider.deleteList(defaultID)
     }
   }
 
-  @Test func renameListThrowsForUnknownID() {
+  @Test func renameListThrowsForUnknownID() async {
     let provider = makeProvider()
     let unknown = UUID().uuidString
-    #expect(throws: (any Error).self) {
-      try provider.renameList(unknown, name: "Ghost")
+    await #expect(throws: (any Error).self) {
+      try await provider.renameList(unknown, name: "Ghost")
     }
   }
 
-  @Test func deleteTaskThrowsForUnknownRef() {
+  @Test func deleteTaskThrowsForUnknownRef() async {
     let provider = makeProvider()
     let ref = TaskRef(providerID: LocalProvider.providerID, nativeID: UUID().uuidString)
-    #expect(throws: (any Error).self) {
-      try provider.deleteTask(ref)
+    await #expect(throws: (any Error).self) {
+      try await provider.deleteTask(ref)
     }
   }
 }

--- a/app/TaskmatoTests/TaskRegistryTests.swift
+++ b/app/TaskmatoTests/TaskRegistryTests.swift
@@ -359,6 +359,87 @@ struct TaskRegistryTests {
     #expect(registry.firstEnabledWritableProvider?.id == "writable")
   }
 
+  // MARK: enabledWritableProvider
+
+  @Test func enabledWritableProviderReturnsExactEnabledWritableProvider() {
+    let registry = makeRegistry()
+    let provider = StubWritableProvider(id: "writable")
+    registry.register(provider)
+    registry.enable(provider)
+    #expect(registry.enabledWritableProvider(id: "writable")?.id == "writable")
+  }
+
+  @Test func enabledWritableProviderReturnsNilForDisabledProvider() {
+    let registry = makeRegistry()
+    let provider = StubWritableProvider(id: "writable")
+    registry.register(provider)
+    #expect(registry.enabledWritableProvider(id: "writable") == nil)
+  }
+
+  @Test func enabledWritableProviderReturnsNilForReadOnlyProvider() {
+    let registry = makeRegistry()
+    let provider = StubProvider(id: "read-only")
+    registry.register(provider)
+    registry.enable(provider)
+    #expect(registry.enabledWritableProvider(id: "read-only") == nil)
+  }
+
+  // MARK: resolveDefaultWritableProvider
+
+  @Test func resolveDefaultWritableProviderNilIDFallsBackToFirst() {
+    let registry = makeRegistry()
+    let provider = StubWritableProvider(id: "writable")
+    registry.register(provider)
+    registry.enable(provider)
+    #expect(registry.resolveDefaultWritableProvider(preferredID: nil)?.id == "writable")
+  }
+
+  @Test func resolveDefaultWritableProviderNilIDReturnsNilWhenNoneRegistered() {
+    let registry = makeRegistry()
+    #expect(registry.resolveDefaultWritableProvider(preferredID: nil) == nil)
+  }
+
+  @Test func resolveDefaultWritableProviderReturnsPreferredWhenEnabled() {
+    let registry = makeRegistry()
+    let first = StubWritableProvider(id: "first")
+    let second = StubWritableProvider(id: "second")
+    registry.register(first)
+    registry.register(second)
+    registry.enable(first)
+    registry.enable(second)
+    #expect(registry.resolveDefaultWritableProvider(preferredID: "second")?.id == "second")
+  }
+
+  @Test func resolveDefaultWritableProviderFallsBackWhenPreferredIsDisabled() {
+    let registry = makeRegistry()
+    let first = StubWritableProvider(id: "first")
+    let second = StubWritableProvider(id: "second")
+    registry.register(first)
+    registry.register(second)
+    registry.enable(first)
+    // "second" is registered but not enabled
+    #expect(registry.resolveDefaultWritableProvider(preferredID: "second")?.id == "first")
+  }
+
+  @Test func resolveDefaultWritableProviderFallsBackWhenPreferredIsReadOnly() {
+    let registry = makeRegistry()
+    let readOnly = StubProvider(id: "read-only")
+    let writable = StubWritableProvider(id: "writable")
+    registry.register(readOnly)
+    registry.register(writable)
+    registry.enable(readOnly)
+    registry.enable(writable)
+    #expect(registry.resolveDefaultWritableProvider(preferredID: "read-only")?.id == "writable")
+  }
+
+  @Test func resolveDefaultWritableProviderFallsBackWhenPreferredIsUnknown() {
+    let registry = makeRegistry()
+    let provider = StubWritableProvider(id: "writable")
+    registry.register(provider)
+    registry.enable(provider)
+    #expect(registry.resolveDefaultWritableProvider(preferredID: "ghost")?.id == "writable")
+  }
+
   // MARK: Provider ordering
 
   @Test func registerSortsProvidersByDisplayOrder() {

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -15,6 +15,7 @@ private struct HandlerContext {
   let registry: TaskRegistry
   let selectionStore: TaskSelectionStore
   let localProvider: LocalProvider
+  let settings: AppSettings
 }
 
 // MARK: - Fakes
@@ -38,6 +39,52 @@ private final class StubTaskProvider: TaskProvider {
   func observe() -> AsyncStream<[TaskItem]>? { nil }
 }
 
+private final class StubWritableProvider: WritableTaskProvider {
+  let id: String
+  let displayName: String
+  let icon: String = "square"
+  let entitlement: ProviderEntitlement = .free
+  let defaultListID: String? = nil
+
+  init(id: String) {
+    self.id = id
+    self.displayName = id
+  }
+
+  nonisolated func authorize() async throws {}
+  func lists() async throws -> [TaskList] { [] }
+  func tasks(in _: TaskList?) async throws -> [TaskItem] { [] }
+  func observe() -> AsyncStream<[TaskItem]>? { nil }
+  func complete(_: TaskRef) async throws {}
+  func reopen(_: TaskRef) async throws {}
+
+  @discardableResult
+  func addTask(_ draft: TaskDraft) async throws -> TaskItem {
+    TaskItem(
+      id: TaskRef(providerID: id, nativeID: UUID().uuidString),
+      title: draft.title,
+      notes: draft.notes,
+      format: .plainText,
+      priority: draft.priority,
+      dueDate: draft.dueDate,
+      scheduledDate: nil,
+      startDate: nil,
+      list: nil,
+      section: nil,
+      sourceURL: nil
+    )
+  }
+
+  func setDefaultList(_: String) async throws {}
+  func createList(name: String) async throws -> TaskList {
+    TaskList(id: UUID().uuidString, providerID: id, name: name)
+  }
+  func renameList(_: String, name _: String) async throws {}
+  func deleteList(_: String) async throws {}
+  func updateTask(_: TaskRef, draft _: TaskDraft) async throws {}
+  func deleteTask(_: TaskRef) async throws {}
+}
+
 // MARK: - Tests
 
 @MainActor
@@ -54,13 +101,16 @@ struct URLSchemeHandlerTests {
   /// Builds a fully wired handler. Pass `enableLocalProvider: false` to test the transient path.
   private func makeHandler(
     stubProviderTasks: [TaskItem] = [],
-    enableLocalProvider: Bool = true
+    enableLocalProvider: Bool = true,
+    defaultWritableProviderID: String? = nil
   ) -> HandlerContext {
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
     let selectionStore = TaskSelectionStore(defaults: defaults)
     let engine = SessionEngine()
     let registry = TaskRegistry(defaults: defaults)
     let localProvider = LocalProvider(fileURL: makeTempURL())
+    let settings = AppSettings(defaults: defaults)
+    settings.defaultWritableProviderID = defaultWritableProviderID
 
     registry.register(localProvider)
     if enableLocalProvider {
@@ -73,20 +123,19 @@ struct URLSchemeHandlerTests {
       registry.enable(stub)
     }
 
-    let settings = AppSettings(defaults: defaults)
     let handler = URLSchemeHandler(
       registry: registry,
       selectionStore: selectionStore,
       engine: engine,
       settings: settings,
-      localProvider: localProvider,
       nav: MainNavigation(settings: settings)
     )
     return HandlerContext(
       handler: handler,
       registry: registry,
       selectionStore: selectionStore,
-      localProvider: localProvider
+      localProvider: localProvider,
+      settings: settings
     )
   }
 
@@ -106,7 +155,7 @@ struct URLSchemeHandlerTests {
     )
   }
 
-  // MARK: - Ad-hoc task creation (LocalProvider enabled)
+  // MARK: - Ad-hoc task creation (LocalProvider enabled — default provider)
 
   @Test func adHocTaskWrittenToLocalProviderWhenEnabled() async throws {
     let ctx = makeHandler(enableLocalProvider: true)
@@ -119,7 +168,7 @@ struct URLSchemeHandlerTests {
 
   @Test func adHocTaskMatchesLocalListByName() async throws {
     let ctx = makeHandler(enableLocalProvider: true)
-    ctx.localProvider.createList(name: "Work")
+    try await ctx.localProvider.createList(name: "Work")
     await ctx.handler.handle(URL(string: "taskmato://start?title=Meeting&list=Work")!)
     let tasks = try await ctx.localProvider.tasks(in: nil)
     #expect(tasks.first?.list?.name == "Work")
@@ -151,6 +200,67 @@ struct URLSchemeHandlerTests {
     let ctx = makeHandler()
     await ctx.handler.handle(URL(string: "taskmato://start?title=Due+Task&due=2026-12-01")!)
     #expect(ctx.selectionStore.activeTask?.dueDate != nil)
+  }
+
+  // MARK: - Ad-hoc: URL param provider override
+
+  @Test func adHocTaskURLProviderParamTargetsSpecificProvider() async throws {
+    let ctx = makeHandler(enableLocalProvider: true)
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Override&provider=\(LocalProvider.providerID)")!)
+    #expect(ctx.selectionStore.activeTask?.id.providerID == LocalProvider.providerID)
+    let items = try await ctx.localProvider.tasks(in: nil)
+    #expect(items.map(\.title).contains("Override"))
+  }
+
+  @Test func adHocTaskURLProviderParamFallsBackWhenProviderDisabled() async {
+    // provider= refers to a disabled/unknown provider → falls back to settings/firstEnabled
+    let ctx = makeHandler(enableLocalProvider: true)
+    ctx.registry.disable(providerID: LocalProvider.providerID)
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Fallback&provider=\(LocalProvider.providerID)")!)
+    // No enabled writable provider → transient
+    #expect(ctx.selectionStore.activeTask?.id.providerID == "adhoc")
+  }
+
+  @Test func adHocTaskURLProviderParamFallsBackToSettingsDefaultWhenDisabled() async {
+    let ctx = makeHandler(enableLocalProvider: false, defaultWritableProviderID: "zzz-default")
+    let first = StubWritableProvider(id: "aaa-first")
+    let defaultProvider = StubWritableProvider(id: "zzz-default")
+    let disabledTarget = StubWritableProvider(id: "target-disabled")
+    ctx.registry.register(first)
+    ctx.registry.register(defaultProvider)
+    ctx.registry.register(disabledTarget)
+    ctx.registry.enable(first)
+    ctx.registry.enable(defaultProvider)
+
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Fallback&provider=target-disabled")!)
+
+    #expect(ctx.selectionStore.activeTask?.id.providerID == "zzz-default")
+  }
+
+  // MARK: - Ad-hoc: settings default writable provider
+
+  @Test func adHocTaskUsesSettingsDefaultProvider() async throws {
+    let ctx = makeHandler(
+      enableLocalProvider: true,
+      defaultWritableProviderID: LocalProvider.providerID
+    )
+    await ctx.handler.handle(URL(string: "taskmato://start?title=Settings+Task")!)
+    #expect(ctx.selectionStore.activeTask?.id.providerID == LocalProvider.providerID)
+    let items = try await ctx.localProvider.tasks(in: nil)
+    #expect(items.map(\.title).contains("Settings Task"))
+  }
+
+  @Test func adHocTaskIgnoresSettingsDefaultWhenProviderDisabled() async {
+    let ctx = makeHandler(
+      enableLocalProvider: false,
+      defaultWritableProviderID: LocalProvider.providerID
+    )
+    await ctx.handler.handle(URL(string: "taskmato://start?title=No+Provider")!)
+    // Settings points at disabled provider → falls through to transient
+    #expect(ctx.selectionStore.activeTask?.id.providerID == "adhoc")
   }
 
   // MARK: - Step 1: Lookup by provider + ID
@@ -211,6 +321,16 @@ struct URLSchemeHandlerTests {
     #expect(ctx.selectionStore.activeTask?.id == existing.id)
   }
 
+  @Test func lookupByTitleIgnoresDisabledProvider() async {
+    let existing = makeTask(title: "Disabled Title", providerID: "stub")
+    let ctx = makeHandler(stubProviderTasks: [existing])
+    ctx.registry.disable(providerID: "stub")
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?provider=stub&title=Disabled%20Title")!)
+    #expect(ctx.selectionStore.activeTask?.id.providerID == LocalProvider.providerID)
+    #expect(ctx.selectionStore.activeTask?.title == "Disabled Title")
+  }
+
   // MARK: - Step 4: Cross-provider title search
 
   @Test func crossProviderSearchFindsBeforeAdHoc() async {
@@ -238,13 +358,13 @@ struct URLSchemeHandlerTests {
     #expect(ctx.handler.pendingAdHocParams?.priority == .high)
   }
 
-  @Test func makeAdHocTaskFromDisambiguationUsesLocalProvider() async throws {
+  @Test func makeAdHocTaskFromDisambiguationUsesDefaultProvider() async throws {
     let task1 = makeTask(title: "Deploy")
     let task2 = makeTask(title: "Deploy")
     let ctx = makeHandler(stubProviderTasks: [task1, task2], enableLocalProvider: true)
     await ctx.handler.handle(URL(string: "taskmato://start?title=Deploy")!)
     let params = ctx.handler.pendingAdHocParams!
-    let task = ctx.handler.makeAdHocTask(from: params)
+    let task = await ctx.handler.makeAdHocTask(from: params)
     #expect(task.id.providerID == LocalProvider.providerID)
     let localItems = try await ctx.localProvider.tasks(in: nil)
     #expect(localItems.map(\.title).contains("Deploy"))

--- a/docs/architecture/design/0005-pre-1.0-architecture-pass.md
+++ b/docs/architecture/design/0005-pre-1.0-architecture-pass.md
@@ -71,6 +71,8 @@ The 27-line side-effect cascade currently inside `TaskmatoApp.init` (append sess
 
 Today `LocalProvider.addTask`, `setDefaultList`, `createList`, etc. are declared sync; the protocol declares them `async throws`. Sync-satisfies-async works in Swift but lets callers bypass the protocol — and `URLSchemeHandler` does exactly that today, calling `localProvider.addTask(draft)` directly with a concrete-type reference. Matching the shape closes the bypass and, once `URLSchemeHandler` routes through `ProviderRegistry.firstEnabledWritableProvider`, closes issues #387 and #303 at the same time.
 
+Implemented in the URL-handler surface pass: `URLSchemeHandler` no longer receives a concrete `LocalProvider`, ad-hoc task creation resolves through enabled `WritableTaskProvider` instances, and named-provider title lookup now mirrors ID lookup by ignoring disabled providers. The remaining registry split should preserve this by exposing enabled-provider iteration and exact enabled lookup APIs rather than pushing callers back to raw `providers.first` searches.
+
 ## Target architecture
 
 ### Composition
@@ -260,15 +262,15 @@ Each row is one PR. Ordered so PRs are mergeable in isolation and the next build
 | ✅ 7 | Introduce `MainNavigation` with `bindOpenMainWindow` | Routing | [#396](https://github.com/richwklein/taskmato/issues/396), F (part) |
 | ✅ 8 | Add URL buffer in `AppDelegate` (option A — drain on first scene mount) | Routing | [#396](https://github.com/richwklein/taskmato/issues/396) |
 | ✅ 9 | Replace NotificationCenter routing with `MainNavigation` calls; delete `AppNotifications.swift` | Routing | [#396](https://github.com/richwklein/taskmato/issues/396), F |
-| 10 | Match `LocalProvider` method signatures to `WritableTaskProvider` (`async throws`) | Surface | [#397](https://github.com/richwklein/taskmato/issues/397), Q (part) |
-| 11 | Route `URLSchemeHandler.makeAdHocTask` through `ProviderRegistry.firstEnabledWritableProvider`; drop `localProvider:` from URL handler init | Surface | [#397](https://github.com/richwklein/taskmato/issues/397), Q, **#387**, **#303** |
+| ✅ 10 | Match `LocalProvider` method signatures to `WritableTaskProvider` (`async throws`) | Surface | [#397](https://github.com/richwklein/taskmato/issues/397), Q (part) |
+| ✅ 11 | Route `URLSchemeHandler.makeAdHocTask` through the registry's enabled writable provider resolution; drop `localProvider:` from URL handler init; keep URL lookups from reading disabled providers | Surface | [#397](https://github.com/richwklein/taskmato/issues/397), Q, **#387**, **#303** |
 | 12 | Restructure `Views/` into subfolders (MenuBar, Timer, Tasks, Stats, Settings, App); move provider adapters under `Views/Settings/<Provider>/` | Structure | [#398](https://github.com/richwklein/taskmato/issues/398), T, **#388** |
 | 13 | Create `Services/`; move `AppSettings`, `TaskSelectionStore`, `NotificationService`, `SoundService` into it. Move `TaskPickerLayout` → `Tasks/Models/` | Structure | [#398](https://github.com/richwklein/taskmato/issues/398), T |
 | 14 | Single-shot notification authorization at launch; drop per-`send` auth | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), O |
 | 15 | Fix `Calendar.endOfToday` DST bug | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), 6.5 |
 | 16 | Add `os.Logger` to `SessionStore` and `LocalProvider` save paths | Hardening | [#399](https://github.com/richwklein/taskmato/issues/399), T (part) |
 
-Already-planned 0.7.0 issues (#260, #293, #303, ~~#330~~, #341, #370, ~~#383~~, #392) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 (closed by PR 11). **#388** closes as part of PR 12.
+Already-planned 0.7.0 issues (#260, #293, ~~#303~~, ~~#330~~, #341, #370, ~~#383~~, #392) run alongside. Issue **#387** moves from 0.9.0 → 0.7.0 and closes with PR 11. **#388** closes as part of PR 12.
 
 ### 0.8.0 — Stats expansion + SwiftData session migration
 

--- a/scripts/taskmato
+++ b/scripts/taskmato
@@ -5,9 +5,16 @@
 # Usage:
 #   taskmato <title>
 #   taskmato --title <title> [--priority none|lowest|low|medium|high|highest]
-#             [--due YYYY-MM-DD] [--list <name>]
+#             [--due YYYY-MM-DD] [--list <name>] [--provider <id>]
 #   taskmato --provider <id> --id <native-id>
 #   taskmato --provider <id> --title <title>
+#
+# Ad-hoc task creation (zero title matches):
+#   Provider resolution order:
+#     1. --provider <id>  — write to the named provider if it is enabled and writable.
+#     2. Settings default — the "Default writable provider" set in Taskmato's Settings.
+#     3. First enabled writable provider in registration order.
+#   If no writable provider is available the task is transient (lost on quit).
 
 set -euo pipefail
 
@@ -49,7 +56,8 @@ Positional:
 
 Options:
   --title <title>         Task title (creates ad-hoc or searches providers)
-  --provider <id>         Scope lookup to a specific provider
+  --provider <id>         Scope lookup to a specific provider; also targets that provider
+                          for ad-hoc creation when no matching task is found
   --id <native-id>        Look up task by its native provider ID (requires --provider)
   --priority <level>      Priority: none, lowest, low, medium, high, highest
   --due <YYYY-MM-DD>      Due date for ad-hoc task creation


### PR DESCRIPTION
## Summary

Implements three levels of ad-hoc task provider resolution for the `taskmato://` URL scheme and the Add Task sheet, replacing the previous hard-wired `LocalProvider` dependency in `URLSchemeHandler`:

1. **URL `provider=` param** — targets a specific enabled writable provider directly (strict; no implicit fallback within this level).
2. **"Default writable provider" setting** — a new `AppSettings` preference exposed in a new Tasks section of SettingsView, shared by both the URL handler and the Add Task sheet.
3. **`firstEnabledWritableProvider`** — final fallback in registration order.

A new `TaskRegistry.resolveDefaultWritableProvider(preferredID:)` helper encapsulates levels 2 and 3, keeping resolution logic DRY across `URLSchemeHandler` and `TasksTabView`.

`LocalProvider`'s mutating methods are now declared `async throws` to satisfy `WritableTaskProvider` through the existential (removing the direct concrete-type dependency from the URL handler). The Debug section is removed from SettingsView.

## Linked issue

Closes #397
Closes #303
Closes #387

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

- **`TaskRegistry.enabledWritableProvider(id:)`** — new helper that returns a provider only when it is both registered and enabled as a `WritableTaskProvider`.
- **`TaskRegistry.resolveDefaultWritableProvider(preferredID:)`** — DRY resolution: returns the preferred provider if enabled+writable, otherwise `firstEnabledWritableProvider`.
- **`AdHocTaskParams.providerID`** — new field forwarding the URL `provider=` param into `makeAdHocTask` for strict override.
- **`URLSchemeHandler.makeAdHocTask`** — now `async` and works against `any WritableTaskProvider`; the `??` autoclosure issue (Swift does not allow `await` inside non-async autoclosures) is resolved by an explicit `if let cached` branch.
- **`SettingsView`** — Debug section removed; new Tasks section with a Picker for the default writable provider, defaulting to "Automatic".
- **`scripts/taskmato`** — header comment updated to document the three-level provider resolution order.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

Tests added:
- `TaskRegistryTests` — 6 new tests covering `resolveDefaultWritableProvider` (nil ID fallback, preferred enabled, preferred disabled, preferred read-only, preferred unknown)
- `URLSchemeHandlerTests` — 4 new tests covering URL `provider=` param override, settings default provider, disabled-provider fallback, and transient fallback when no writable provider is available

## Reviewer notes

The `async` in `makeAdHocTask` is required because calling `lists()` and `addTask()` on `any WritableTaskProvider` crosses an async protocol boundary. The `try? await` inside the old `??` expression was the root cause of the build failure — Swift's `??` operator uses a non-`async` autoclosure, so the `await` had to be hoisted into an explicit `if let` branch.