### PR TITLE
fix(hardening): DST-safe endOfToday and os.Logger on write failures

### DIFF
--- a/app/Taskmato/Session/SessionStore.swift
+++ b/app/Taskmato/Session/SessionStore.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Observation
+import os
 
 /// Persists and provides access to the log of completed Pomodoro sessions.
 ///
@@ -19,6 +20,7 @@ final class SessionStore {
   private let fileURL: URL
   private let encoder = JSONEncoder()
   private let decoder = JSONDecoder()
+  private let logger = Logger(subsystem: "com.taskmato", category: "SessionStore")
 
   /// Creates a store using the default production file path.
   convenience init() {
@@ -94,7 +96,11 @@ final class SessionStore {
   }
 
   private func save() {
-    guard let data = try? encoder.encode(sessions) else { return }
-    try? data.write(to: fileURL, options: .atomic)
+    do {
+      let data = try encoder.encode(sessions)
+      try data.write(to: fileURL, options: .atomic)
+    } catch {
+      logger.error("SessionStore failed to save: \(error.localizedDescription, privacy: .public)")
+    }
   }
 }

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import Observation
+import os
 
 /// A built-in task provider that persists tasks and lists to a JSON file in Application Support.
 ///
@@ -41,6 +42,7 @@ final class LocalProvider: WritableTaskProvider {
   private let fileURL: URL
   private let encoder = JSONEncoder()
   private let decoder = JSONDecoder()
+  private let logger = Logger(subsystem: "com.taskmato", category: "LocalProvider")
 
   /// Creates a provider backed by the default production file path.
   convenience init() {
@@ -230,8 +232,12 @@ final class LocalProvider: WritableTaskProvider {
 
   private func save() {
     let store = LocalStore(lists: taskLists, tasks: allTasks, defaultListID: defaultListID)
-    guard let data = try? encoder.encode(store) else { return }
-    try? data.write(to: fileURL, options: [])
+    do {
+      let data = try encoder.encode(store)
+      try data.write(to: fileURL, options: [])
+    } catch {
+      logger.error("LocalProvider failed to save: \(error.localizedDescription, privacy: .public)")
+    }
   }
 }
 

--- a/app/Taskmato/Tasks/TaskRegistry.swift
+++ b/app/Taskmato/Tasks/TaskRegistry.swift
@@ -475,8 +475,13 @@ final class TaskRegistry {
 // MARK: - Calendar helpers
 
 extension Calendar {
-  /// The last second of today: start of day + 86399 seconds.
+  /// The last instant of today, DST-safe.
+  ///
+  /// Advances `startOfDay` by one calendar day and subtracts one second, rather than
+  /// adding a fixed 86 400-second interval, so the result is correct on DST transition
+  /// days when a civil day is 23 or 25 hours long.
   fileprivate var endOfToday: Date {
-    startOfDay(for: Date()).addingTimeInterval(86400 - 1)
+    let tomorrow = date(byAdding: .day, value: 1, to: startOfDay(for: Date())) ?? Date()
+    return tomorrow.addingTimeInterval(-1)
   }
 }


### PR DESCRIPTION
## Summary

Two small hardening fixes for pre-1.0 cleanup. No user-visible behavior change in the happy path.

## Linked issue

Closes #399

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

### 1. `Calendar.endOfToday` is now DST-safe

The previous implementation added a fixed `86400 - 1` seconds to `startOfDay`, which is wrong on DST transition days when a civil day is 23 or 25 hours long. The new implementation advances `startOfDay` by one calendar day and subtracts one second, which the calendar correctly resolves through any DST shift.

### 2. `os.Logger` on `SessionStore.save` and `LocalProvider.save`

Both `save` methods previously used `try?` for the encode + write pair, so persistent disk-write failures would silently lose user data with no signal. They now use a `do/catch` block that logs failures via `os.Logger(subsystem: "com.taskmato", category: ...)`, surfacing them in Console.app. Functional behavior on the happy path is unchanged.

The third item from the original #399 (request notification authorization once at launch) has been moved to #341 since it overlaps with that ticket's reshaping of `NotificationService`.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [x] Manually verified changes
- [ ] Documentation updated where appropriate

`make lint` and `make format-check` report zero violations. No new tests added — the changes are mechanical (one DST helper rewrite, two log-on-failure additions) and the existing test suite continues to exercise the surrounding code paths.

## Reviewer notes

The `localizedDescription` cast in the log lines is intentional — keeping the message human-readable while marking it `.public` so it shows up in Console.app without redaction.