### PR TITLE
chore(ci): add detect-relevant-changes action and gate heavy CI jobs

### DIFF
--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -1,0 +1,64 @@
+name: 'Detect Relevant Changes'
+description: >
+  For pull_request events, sets relevant=true when any changed file matches one
+  of the supplied regex patterns. For any other event (push, schedule,
+  workflow_run, workflow_call, etc.) sets relevant=true unconditionally so heavy
+  work is preserved on main branch and scheduled runs.
+
+inputs:
+  patterns:
+    description: >
+      Multi-line list of JavaScript-compatible regex patterns matched against
+      the full path of each changed file. When empty, falls back to a default
+      set covering Swift sources, build scripts, and CI config.
+    required: false
+    default: ''
+
+outputs:
+  relevant:
+    description: 'true when heavy steps should run; false when the job should noop'
+    value: ${{ steps.detect.outputs.relevant }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: detect
+      uses: actions/github-script@v7
+      env:
+        PATTERNS: ${{ inputs.patterns }}
+      with:
+        script: |
+          const DEFAULT_PATTERNS = [
+            String.raw`^app/`,
+            String.raw`^scripts/`,
+            String.raw`^Makefile$`,
+            String.raw`^\.github/(workflows|actions)/`,
+          ];
+
+          if (context.eventName !== 'pull_request') {
+            core.info(`Event ${context.eventName}: running heavy work unconditionally.`);
+            core.setOutput('relevant', 'true');
+            return;
+          }
+
+          const raw = (process.env.PATTERNS || '').trim();
+          const sources = raw
+            ? raw.split('\n').map((s) => s.trim()).filter(Boolean)
+            : DEFAULT_PATTERNS;
+          const patterns = sources.map((s) => new RegExp(s));
+
+          const files = await github.paginate(github.rest.pulls.listFiles, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number,
+            per_page: 100,
+          });
+
+          const hit = files.find((f) => patterns.some((p) => p.test(f.filename)));
+          if (hit) {
+            core.info(`Relevant change detected: ${hit.filename}`);
+            core.setOutput('relevant', 'true');
+          } else {
+            core.info(`No relevant changes in ${files.length} files.`);
+            core.setOutput('relevant', 'false');
+          }

--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -8,8 +8,23 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/detect-relevant-changes
+        id: detect
+
   build:
+    needs: check
+    if: needs.check.outputs.relevant == 'true'
     runs-on: macos-15
     steps:
       - name: Checkout source code

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -11,10 +11,22 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
   security-events: write
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/detect-relevant-changes
+        id: detect
+
   analyze:
+    needs: check
+    if: needs.check.outputs.relevant == 'true'
     name: analyze
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -8,8 +8,23 @@ concurrency:
   group: lint-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/detect-relevant-changes
+        id: detect
+
   lint:
+    needs: check
+    if: needs.check.outputs.relevant == 'true'
     runs-on: macos-15
 
     steps:

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -10,9 +10,21 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.detect.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: ./.github/actions/detect-relevant-changes
+        id: detect
+
   test:
+    needs: check
+    if: needs.check.outputs.relevant == 'true'
     runs-on: macos-15
 
     steps:


### PR DESCRIPTION
## Summary

Adds a reusable composite action that detects whether a pull request touches
files relevant to the Swift build, and uses it to skip expensive macOS runner
jobs when only docs, assets, or other non-code files changed.

## Linked issue

Closes #

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Maintenance / cleanup
- [ ] Documentation / content
- [ ] Breaking change

## Details

**New action** — `.github/actions/detect-relevant-changes/action.yaml`

A composite action wrapping `actions/github-script` that:
- Returns `relevant=true` unconditionally for push, schedule, and
  `workflow_call` events (heavy work always runs on main and scheduled scans).
- On `pull_request` events, paginates the changed-file list and matches against
  regex patterns. Defaults to Swift-specific paths:
  - `^app/` — Swift sources and Xcode project
  - `^scripts/` — build scripts (`sync-version.sh`, etc.)
  - `^Makefile$` — build/lint/format targets
  - `^\.github/(workflows|actions)/` — CI config

**Workflow changes** — `code-build.yaml`, `code-lint.yaml`, `code-test.yaml`,
`code-codeql.yaml`

Each workflow gains a fast `check` job (ubuntu-latest) that runs the action.
The heavy macOS job adds `needs: check` and
`if: needs.check.outputs.relevant == 'true'`. Also restores
`pull-requests: read` to all four workflows — required by the action to call
`pulls.listFiles`, and previously absent from `code-codeql`.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] This PR intentionally updates the version

## Validation

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated tests where appropriate
- [ ] Manually verified changes
- [x] Documentation updated where appropriate

## Reviewer notes

The `check` job uses `actions/checkout` before calling the local action — this
is required for composite actions referenced by relative path. The checkout is
lightweight (ubuntu-latest, no Xcode selection or build) and completes in
seconds, so the gate adds minimal latency to PRs that do need the heavy jobs.