### PR TITLE
chore: sync PR templates, labeler, and guardrail comments from template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,0 +1,36 @@
+## Summary
+
+Describe the bug being fixed and the impact of the fix.
+
+## Linked issue
+
+Closes #
+
+## Root cause
+
+What was wrong and why it produced the observed behavior.
+
+## Fix
+
+How the change addresses the root cause.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Added or updated a regression test
+- [ ] Manually verified the original bug no longer reproduces
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Anything else that would help with review.

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,31 @@
+## Summary
+
+Describe the documentation or content change.
+
+## Linked issue
+
+Closes #
+
+## Scope
+
+What docs, pages, or content are updated.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Links checked
+- [ ] Rendered output reviewed (preview deploy or local build)
+- [ ] Spelling and grammar reviewed
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+
+## Reviewer notes
+
+Anything else worth highlighting.

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -1,0 +1,37 @@
+## Summary
+
+Describe the new capability or improvement and why it exists.
+
+## Linked issue
+
+Closes #
+
+## Approach
+
+How the feature is implemented. Call out important tradeoffs or alternatives considered.
+
+## Out of scope
+
+What this PR deliberately does not include.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Added or updated tests covering the new behavior
+- [ ] Manually verified the new behavior
+- [ ] Documentation updated where appropriate
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Follow-up work, screenshots, or anything else worth highlighting.

--- a/.github/PULL_REQUEST_TEMPLATE/task.md
+++ b/.github/PULL_REQUEST_TEMPLATE/task.md
@@ -1,0 +1,36 @@
+## Summary
+
+Describe the maintenance, cleanup, refactor, or process change.
+
+## Linked issue
+
+Closes #
+
+## Motivation
+
+What pain, risk, inconsistency, or gap this addresses.
+
+## Changes
+
+The notable changes in this PR.
+
+## Validation
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Lint passes locally
+- [ ] Unit tests pass locally
+- [ ] Behavior is unchanged (refactor) or covered by existing/new tests
+- [ ] Manually verified where applicable
+
+## Release / deploy impact
+
+_Put an `x` in the boxes that apply._
+
+- [ ] Preview deploy is useful for reviewing this change
+- [ ] Safe to label `no-deploy`
+- [ ] Breaking change (also apply the `breaking-change` label)
+
+## Reviewer notes
+
+Anything else worth highlighting.

--- a/.github/actions/detect-relevant-changes/action.yaml
+++ b/.github/actions/detect-relevant-changes/action.yaml
@@ -2,15 +2,15 @@ name: 'Detect Relevant Changes'
 description: >
   For pull_request events, sets relevant=true when any changed file matches one
   of the supplied regex patterns. For any other event (push, schedule,
-  workflow_run, workflow_call, etc.) sets relevant=true unconditionally so heavy
-  work is preserved on main branch and scheduled runs.
+  workflow_run, etc.) sets relevant=true unconditionally so heavy work is
+  preserved on main branch and scheduled runs.
 
 inputs:
   patterns:
     description: >
       Multi-line list of JavaScript-compatible regex patterns matched against
       the full path of each changed file. When empty, falls back to a default
-      set covering Swift sources, build scripts, and CI config.
+      set covering workflow and action edits.
     required: false
     default: ''
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# Auto-applied PR labels by head-branch prefix.
+# See AGENTS.md for the branch-prefix convention.
+
+bug:
+  - head-branch: ['^(fix|bug|bugfix)-']
+
+enhancement:
+  - head-branch: ['^(feat|feature)-']
+
+task:
+  - head-branch: ['^(chore|refactor|test|build|ci|perf|style|task|maint|maintenance)-']
+
+documentation:
+  - head-branch: ['^(docs|doc)-']

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '23 4 * * 1' # weekly, Monday 04:23 UTC
+    - cron: "23 4 * * 1" # weekly, Monday 04:23 UTC
 
 permissions:
   actions: read
@@ -32,6 +32,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Override per-repo: each `include` entry is (language, runner).
+        # 'actions' analyzes the workflow YAML itself and is always safe.
+        #
+        # Common (language, runner) pairings:
+        #   actions, javascript-typescript, python, ruby, go,
+        #   csharp, java-kotlin, c-cpp  -> ubuntu-latest
+        #   swift                       -> macos-latest
+        #     (Swift extractor only runs on macOS)
+        #
+        # PATH FILTERS: The detect-relevant-changes action defaults to
+        # .github/workflows/** and .github/actions/**. When adding a
+        # language entry here, pass the relevant source patterns via the
+        # `patterns` input so the job noop's when nothing important changed.
+        # Per-language pattern selection can be done inline:
+        #   patterns: ${{ matrix.language == 'actions' && '...' || '...' }}
+        #
+        # COMPILED LANGUAGES (swift, c-cpp, java-kotlin, csharp) require a
+        # build step BEFORE 'Perform CodeQL analysis' so the extractor can
+        # observe source compilation. Example for Swift:
+        #
+        #   - name: Build (Swift)
+        #     if: matrix.language == 'swift'
+        #     run: |
+        #       sudo xcode-select -s /Applications/Xcode_16.3.app
+        #       xcodebuild build -project Your.xcodeproj -scheme Your \
+        #         -configuration Debug -destination 'platform=macOS' \
+        #         CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+        #
+        # Each include entry registers its own status check, named
+        # `analyze (<language>, <runner>)`. Update branch protection
+        # rulesets to require those exact contexts. Keep this matrix
+        # free of extra keys — anything added here becomes part of the
+        # status check name and would break the required-check contexts.
         include:
           - language: actions
             runner: ubuntu-latest

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -1,0 +1,20 @@
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels from branch prefix
+        uses: actions/labeler@v6.1.0
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,4 +1,7 @@
 name: Release
+# No paths filter: release-please must see every push to main so it can
+# parse conventional commits and drive version bumps. Filtering by path
+# would silently skip commits and break the release train.
 on:
   push:
     branches: [main]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,31 @@ Breaking changes: append `!` (e.g., `feat!: rename public API`) or include a `BR
 - Branches must be up to date with `main` before merging (strict status checks).
 - Commits must be signed.
 
+### Branch prefixes
+
+Name branches with a hyphen-delimited type prefix that mirrors the Conventional Commit type. The PR labeler workflow uses this prefix to apply the matching label automatically.
+
+| Prefix                                                                                                | Label           |
+| ----------------------------------------------------------------------------------------------------- | --------------- |
+| `feat-`, `feature-`                                                                                   | `enhancement`   |
+| `fix-`, `bug-`, `bugfix-`                                                                             | `bug`           |
+| `docs-`, `doc-`                                                                                       | `documentation` |
+| `chore-`, `refactor-`, `test-`, `build-`, `ci-`, `perf-`, `style-`, `task-`, `maint-`, `maintenance-` | `task`          |
+
+Example: `feature-add-search`, `fix-login-redirect`, `docs-readme-update`.
+
+## Pull requests
+
+This repo ships four PR templates aligned with the issue templates: `bug.md`, `enhancement.md`, `task.md`, `documentation.md` in `.github/PULL_REQUEST_TEMPLATE/`.
+
+Pick one by appending `?template=<name>.md` to the compare URL, for example:
+
+```
+https://github.com/richwklein/taskmato/compare/main...<branch>?template=enhancement.md
+```
+
+Type labels (`bug`, `enhancement`, `task`, `documentation`) are applied automatically by the PR labeler workflow based on the branch prefix above. Apply `breaking-change` manually when a PR introduces a backwards-incompatible change.
+
 ## Stop Conditions
 
 Stop and ask for guidance if:


### PR DESCRIPTION
## Summary

Sync the repo with `richwklein/repo-template-base` after running `/repo-template-audit`: adopt the branch-prefix PR labeler and PR templates, and restore the explanatory guardrail comments that had drifted out of the local CI workflows.

## Linked issue

Closes #

## Motivation

The drift audit surfaced six missing files (four PR templates, a labeler config, and the `pr-labeler` workflow) and several deletion-containing diffs in CI files where template guardrail comments had been removed. Bringing these back keeps the repo aligned with the template baseline and turns on automatic PR labeling driven by branch prefix.

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE/{bug,enhancement,task,documentation}.md`.
- Add `.github/labeler.yml` and `.github/workflows/pr-labeler.yaml` to apply type labels from branch prefixes.
- Document the branch-prefix convention and PR template selection in `AGENTS.md`.
- Restore the template's description text in `.github/actions/detect-relevant-changes/action.yaml` (the local Swift-specific default patterns are kept).
- Restore the matrix-guidance comment block and original cron quote style in `.github/workflows/code-codeql.yaml` (the local `check` gate and Swift matrix entry are kept).
- Restore the "No paths filter" guardrail comment in `.github/workflows/release-please.yaml`.

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

Pure documentation, PR-templates, and comment-only changes — no Swift sources touched, so `make lint` / `make format-check` were not run.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The PR labeler workflow takes effect on the next PR after merge; this PR itself will not be auto-labeled. The Swift-specific additions to `detect-relevant-changes` (the `^app/`, `^scripts/`, `^Makefile$` patterns) and the `check`-gate / `swift` matrix entry in `code-codeql.yaml` are intentional local extensions and were preserved.
