### PR TITLE
chore: move macOS/Swift skills from global to project scope

### DIFF
--- a/.claude/skills/app-store/SKILL.md
+++ b/.claude/skills/app-store/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: app-store
+description: App Store optimization and marketing skills for descriptions, screenshots, keywords, review responses, and comprehensive promotional strategy. Use when user needs help with App Store presence, ASO, marketing, or customer communication.
+allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+---
+
+# App Store Optimization & Marketing Skills
+
+Skills for optimizing your app's App Store presence and building promotional strategies — from descriptions to comprehensive marketing campaigns.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Needs to write App Store description or promotional text
+- Wants to plan screenshot sequence and captions
+- Asks about ASO (App Store Optimization) or keywords
+- Needs help responding to App Store reviews
+- Wants to improve app discoverability
+- Asks about marketing strategy, promotion, or user acquisition
+- Wants to use App Store features (events, custom pages, offers, featuring)
+- Asks about paid acquisition or Apple Search Ads
+- App was rejected or wants to avoid rejection
+
+## Available Skills
+
+### marketing-strategy/ ⭐ NEW
+Comprehensive marketing strategy advisor — describe your app and get a tailored promotional plan.
+- Analyzes app type, monetization model, audience, and lifecycle stage
+- Recommends the right App Store features for your situation
+- Builds promotional calendar with implementation roadmap
+- Orchestrates generator sub-skills for implementation
+- Strategy templates for subscription, paid, freemium, and game apps
+
+### app-description-writer/
+Generate compelling App Store descriptions that convert.
+- Promotional text (170 chars)
+- Full description (4000 chars)
+- What's New text for updates
+- Localization guidance
+
+### screenshot-planner/
+Plan App Store screenshot sequences with captions.
+- 5-10 screenshot storyboard
+- Caption writing
+- Device frame recommendations
+- Localization considerations
+
+### keyword-optimizer/
+Optimize app title, subtitle, and keywords for search.
+- Keyword research methodology
+- Character limit optimization (100 chars)
+- Competitor analysis
+- Localization keyword strategy
+- **NEW:** Advanced tactics (cross-localization, screenshot indexing)
+- **NEW:** Keyword criteria (Pop/Diff sweet spots, opportunity scoring)
+- **NEW:** Existing app strategy (safe optimization)
+
+### review-response-writer/
+Professional responses to App Store reviews.
+- Templates for common scenarios
+- Tone and brand voice guidelines
+- Turning negative reviews into opportunities
+- When to respond vs. when not to
+
+### apple-search-ads/
+Apple Search Ads campaign strategy for indie developers.
+- Readiness assessment (minimum thresholds before spending)
+- Campaign types and keyword strategy
+- Budget planning by app stage (launch, growth, scale)
+- Bid optimization with CPT benchmarks by category
+- Campaign structure templates and measurement KPIs
+- Custom Product Pages integration for ad groups
+
+### rejection-handler/
+Handle App Store rejections and prepare submissions to avoid them.
+- Pre-submission audit checklist by guideline section
+- Rejection analysis and response strategy
+- Resolution Center response templates
+- Appeal escalation path (Resolution Center → phone → App Review Board)
+- Top 20 common rejections with fixes (common-rejections.md)
+
+## Related Generator Skills
+
+These generator skills produce code, metadata, and configuration for App Store features:
+
+| Skill | Purpose |
+|-------|---------|
+| `generators/subscription-offers` | StoreKit 2 code for all subscription offer types |
+| `generators/win-back-offers` | Win-back flow for churned subscribers |
+| `generators/promoted-iap` | Promoted In-App Purchase setup |
+| `generators/in-app-events` | In-App Event metadata templates |
+| `generators/custom-product-pages` | Custom Product Page strategy and metadata |
+| `generators/product-page-optimization` | A/B test plans for product page |
+| `generators/featuring-nomination` | App Store featuring pitch templates |
+| `generators/offer-codes-setup` | Offer code distribution strategies |
+| `generators/pre-orders` | Pre-order setup and launch timelines |
+| `generators/app-store-assets` | Asset specs for all App Store media |
+
+## How to Use
+
+1. User requests App Store help
+2. For strategy questions → Read `marketing-strategy/SKILL.md`
+3. For paid acquisition → Read `apple-search-ads/SKILL.md`
+4. For rejections or submission prep → Read `rejection-handler/SKILL.md`
+5. For specific content → Read the relevant sub-skill's SKILL.md
+6. For code/implementation → Read the relevant generator skill
+7. Ask clarifying questions about the app
+8. Generate optimized content
+9. Provide alternatives and explain choices
+
+## Key Principles
+
+### 1. User-Focused Copy
+- Lead with benefits, not features
+- Speak to user pain points
+- Use clear, simple language
+- Include social proof where possible
+
+### 2. Platform Guidelines
+- Stay within character limits
+- Follow Apple's content guidelines
+- Avoid prohibited terms (free, best, #1)
+- Don't mention competing platforms
+
+### 3. Search Optimization
+- Use high-value keywords naturally
+- Don't stuff keywords
+- Consider localized search terms
+- Update for seasonal relevance

--- a/.claude/skills/app-store/app-description-writer/SKILL.md
+++ b/.claude/skills/app-store/app-description-writer/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: app-description-writer
+description: Generate compelling App Store descriptions that convert browsers into users. Use when writing initial descriptions, improving existing copy, or drafting promotional text and What's New for a major update.
+allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# App Description Writer
+
+Generate compelling App Store descriptions that convert browsers into users.
+
+## When This Skill Activates
+
+- User needs to write initial App Store description
+- User wants to improve existing description
+- User is preparing for a major update
+- User asks about promotional text or What's New
+
+## Information Gathering
+
+Before writing, ask about:
+
+1. **App Basics**
+   - What does the app do? (one sentence)
+   - Who is it for? (target audience)
+   - What problem does it solve?
+
+2. **Key Features**
+   - Top 3-5 features
+   - What makes it unique vs competitors?
+   - Any awards or recognition?
+
+3. **Social Proof**
+   - Number of users/downloads (if impressive)
+   - Notable reviews or press mentions
+   - Any partnerships or integrations?
+
+4. **Tone**
+   - Professional / Casual / Fun / Technical?
+   - Brand voice keywords?
+
+## Output Format
+
+Generate all three text types:
+
+### 1. Promotional Text (170 characters)
+- First thing users see
+- Should create curiosity or urgency
+- Can be updated without app review
+- Good for seasonal/sale messaging
+
+### 2. Full Description (4000 characters max)
+Structure:
+```
+[Opening Hook - 1-2 sentences, problem/benefit focused]
+
+[Key Features with emoji bullets]
+• Feature 1 - benefit
+• Feature 2 - benefit
+• Feature 3 - benefit
+
+[Social Proof paragraph - optional]
+
+[How it works - brief explanation]
+
+[Call to action]
+
+[Support/contact info]
+```
+
+### 3. What's New (4000 characters)
+For updates:
+```
+[Version X.X highlights]
+
+NEW
+• Feature addition
+
+IMPROVED
+• Enhancement
+
+FIXED
+• Bug fix
+
+Thank you for your feedback!
+```
+
+## Best Practices
+
+### Do's
+- Lead with the biggest benefit
+- Use short paragraphs (2-3 lines max)
+- Include relevant keywords naturally
+- Use emojis sparingly for scannability
+- End with clear call-to-action
+- Mention if there's a free trial/tier
+
+### Don'ts
+- Don't start with "Welcome to..."
+- Don't use ALL CAPS excessively
+- Don't mention prices (they change)
+- Don't claim "#1" or "best" without proof
+- Don't mention competitors by name
+- Don't include URLs (they're not clickable)
+
+## Examples
+
+### Promotional Text Examples
+
+**Productivity App:**
+```
+Transform chaos into clarity. The task manager that adapts to how YOU work.
+```
+
+**Weather App:**
+```
+Know before you go. Hyperlocal forecasts down to your street corner. ⛅️
+```
+
+**Finance App:**
+```
+Your money, finally making sense. Budgeting that doesn't feel like homework.
+```
+
+### Description Opening Examples
+
+**Problem-First:**
+```
+Tired of losing track of important tasks? [App] turns your scattered thoughts
+into organized action plans in seconds.
+```
+
+**Benefit-First:**
+```
+Capture ideas the moment they strike. [App] is the fastest way to go from
+thought to organized note, anywhere.
+```
+
+**Curiosity-First:**
+```
+What if your to-do list actually helped you get things done? Introducing
+a smarter way to manage your day.
+```
+
+## Localization Tips
+
+When localizing descriptions:
+- Don't just translate—adapt to cultural context
+- Research local competitors' descriptions
+- Adjust feature emphasis by market
+- Use native speakers for review
+- Consider character limits in other languages (German expands ~30%)
+
+## Character Limits Reference
+
+| Field | Limit |
+|-------|-------|
+| App Name | 30 characters |
+| Subtitle | 30 characters |
+| Promotional Text | 170 characters |
+| Description | 4000 characters |
+| What's New | 4000 characters |
+| Keywords | 100 characters |
+
+## Templates
+
+### Template: Utility App
+```
+[One-line value proposition]
+
+Stop [pain point]. Start [desired outcome].
+
+✨ KEY FEATURES
+
+• [Feature 1] — [Benefit in user terms]
+• [Feature 2] — [Benefit in user terms]
+• [Feature 3] — [Benefit in user terms]
+• [Feature 4] — [Benefit in user terms]
+
+💡 HOW IT WORKS
+
+[2-3 sentences explaining the core flow]
+
+🎯 PERFECT FOR
+
+• [User type 1]
+• [User type 2]
+• [User type 3]
+
+[Social proof if available]
+
+Download now and [call to action with benefit].
+
+Questions? We're here to help: [support email]
+```
+
+### Template: Creative App
+```
+[Evocative opening that sparks imagination]
+
+[App Name] puts [creative power] in your pocket.
+
+🎨 CREATE
+
+• [Creative feature 1]
+• [Creative feature 2]
+• [Creative feature 3]
+
+📤 SHARE
+
+• [Sharing/export feature]
+• [Community feature if applicable]
+
+🔓 UNLOCK YOUR CREATIVITY
+
+[Inspirational paragraph about what users can achieve]
+
+Join [X] creators already using [App Name].
+
+[Call to action]
+```
+
+### Template: What's New
+```
+Thanks for using [App Name]! Here's what's new in version X.X:
+
+🆕 NEW
+• [Major new feature with brief explanation]
+
+⚡️ IMPROVED
+• [Performance improvement]
+• [UX enhancement]
+
+🔧 FIXED
+• [Bug fix users complained about]
+
+Love [App Name]? Leave us a review — it helps more than you know! 💙
+
+Feedback? [support email]
+```

--- a/.claude/skills/app-store/apple-search-ads/SKILL.md
+++ b/.claude/skills/app-store/apple-search-ads/SKILL.md
@@ -1,0 +1,468 @@
+---
+name: apple-search-ads
+description: Apple Search Ads campaign strategy for indie developers — paid acquisition, keyword bidding, budget planning, and ROAS optimization. Use when user asks about running ads, paid user acquisition, or Apple Search Ads campaigns.
+allowed-tools: [Read, Glob, Grep, AskUserQuestion, WebSearch]
+---
+
+# Apple Search Ads for Indie Developers
+
+Plan, launch, and optimize Apple Search Ads campaigns that deliver profitable user acquisition for indie apps.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Asks about paid user acquisition or running ads for their app
+- Mentions "Apple Search Ads", "Search Ads", or "ASA"
+- Wants to set up ad campaigns in the App Store
+- Asks about keyword bidding, CPT, or CPA optimization
+- Needs help with campaign structure or budget allocation
+- Wants to understand if paid acquisition makes sense for their app
+- Asks how to complement ASO with paid promotion
+
+## Pre-Requisite Check: Are You Ready for Ads?
+
+Before recommending any campaign setup, verify these minimum thresholds. Running ads on an unoptimized listing burns money.
+
+### Minimum Thresholds
+
+| Requirement | Threshold | Why |
+|-------------|-----------|-----|
+| Organic downloads | 100+/month | Proves baseline demand exists |
+| App Store page CVR | > 20% | Ads amplify your listing — a bad listing wastes spend |
+| Screenshots | 5+ optimized | Paid traffic sees your product page first |
+| Ratings | 3.5+ stars (or none) | Low ratings kill conversion from ads |
+| Crash-free rate | > 99% | Crashes destroy ROAS through refunds and bad reviews |
+| Monetization | Active | No point acquiring users you can't monetize |
+
+**If thresholds are not met:**
+- Focus on organic ASO first (use `keyword-optimizer` skill)
+- Fix product page conversion (use `screenshot-planner` and `app-description-writer` skills)
+- Improve app quality and ratings before spending on acquisition
+
+### Readiness Decision
+
+```
+Have 100+ organic downloads/month?
+├── NO → Stop. Fix organic first.
+└── YES → Is your product page CVR > 20%?
+    ├── NO → Optimize listing first, then run ads.
+    └── YES → Ready for Apple Search Ads.
+```
+
+## Campaign Types
+
+Apple Search Ads offers four placement types. Not all are useful for indie developers.
+
+### Search Results (Recommended Starting Point)
+
+- **Where**: Top of search results when users search specific keywords
+- **Targeting**: Keyword-based (exact match or broad match)
+- **Cost model**: Cost Per Tap (CPT)
+- **Best for**: High-intent users actively looking for your category
+- **Indie priority**: Start here. This is where you get the most control and best ROAS.
+
+### Search Tab
+
+- **Where**: Top of the Search tab before user types anything
+- **Targeting**: Audience-based (demographics, customer type)
+- **Cost model**: Cost Per Tap (CPT)
+- **Best for**: Brand awareness and discovery
+- **Indie priority**: Use after Search Results campaigns are profitable. Good for launch visibility.
+
+### Today Tab
+
+- **Where**: Today tab in the App Store
+- **Targeting**: Audience-based
+- **Cost model**: Cost Per Tap (CPT)
+- **Best for**: Mass awareness, seasonal pushes
+- **Indie priority**: Usually too expensive for indie budgets. Skip unless budget allows $500+/day.
+
+### Product Page (You Might Also Like)
+
+- **Where**: "You Might Also Like" section on other apps' product pages
+- **Targeting**: Audience and category-based
+- **Cost model**: Cost Per Tap (CPT)
+- **Best for**: Reaching users browsing competitor or related apps
+- **Indie priority**: Good second campaign after Search Results. Lower intent but can find relevant users.
+
+### Recommended Progression for Indie Developers
+
+```
+Stage 1: Search Results (exact match keywords)
+    ↓ profitable?
+Stage 2: Search Results (broad match for discovery)
+    ↓ profitable?
+Stage 3: Product Page (competitor audiences)
+    ↓ profitable?
+Stage 4: Search Tab (brand awareness)
+```
+
+## Keyword Strategy
+
+### Keyword Categories
+
+**1. Brand Keywords (Your App Name)**
+- Bid on these ONLY if competitors are bidding on your name
+- Check by searching your app name — if a competitor appears above you, bid
+- Otherwise, save the budget; you already rank #1 organically
+
+**2. Category Keywords (Generic Terms)**
+- Examples: "todo app", "weather radar", "habit tracker"
+- High volume, high competition, expensive
+- Target long-tail variants: "simple todo app", "habit tracker no account"
+- These are your bread and butter for growth
+
+**3. Competitor Keywords (Rival App Names)**
+- Legal and common practice in Apple Search Ads
+- Lower conversion (users wanted the other app) but can be effective
+- Best when your app has a clear advantage over that competitor
+- Use Custom Product Pages to message directly against competitors
+
+**4. Discovery Keywords (Problem/Solution)**
+- Examples: "stop procrastinating", "save money automatically", "focus while studying"
+- Lower volume but very high intent
+- Often cheapest CPT because few advertisers target them
+- Excellent ROAS potential
+
+### Keyword Research Process
+
+1. **Start with brainstorming** — List 50+ terms a user might search
+2. **Use Search Ads keyword suggestions** — Apple provides recommendations in the campaign manager
+3. **Mine your ASO research** — Keywords from `keyword-optimizer` skill that you can't rank organically
+4. **Check autocomplete** — Type partial queries in the App Store
+5. **Analyze competitors** — What keywords trigger their ads?
+6. **Use Search Ads intelligence tools** — SearchAds.com, SplitMetrics Acquire, AppTweak
+
+### Keyword Selection Criteria
+
+| Factor | Target | Notes |
+|--------|--------|-------|
+| Relevance | High | Only bid on keywords your app genuinely serves |
+| Search volume | Medium-High | Low volume = too few impressions to matter |
+| Competition | Low-Medium | High competition = expensive CPT |
+| Intent | Transactional | "best X app" > "what is X" |
+
+## Budget Planning
+
+### Budget by App Stage
+
+| Stage | Daily Budget | Monthly Budget | Strategy |
+|-------|-------------|----------------|----------|
+| **Launch** (first 30 days) | $10-30/day | $300-900 | Discovery, keyword validation |
+| **Growth** (months 2-6) | $50-100/day | $1,500-3,000 | Scale winners, cut losers |
+| **Scale** (6+ months) | $100+/day | $3,000+ | Maximize profitable keywords |
+
+### Launch Budget Allocation
+
+```
+Total: $20/day example
+
+Search Results (Exact Match): $12/day (60%)
+  → 10-15 carefully chosen keywords
+  → Focus on category + discovery keywords
+
+Search Results (Broad Match): $5/day (25%)
+  → 3-5 broad terms for keyword discovery
+  → Mine Search Terms report weekly for new exact match targets
+
+Product Page Ads: $3/day (15%)
+  → Target 2-3 competitor categories
+  → Test which audiences convert
+```
+
+### When to Increase Budget
+
+- ROAS > 1.5x target → Increase budget 20-30%
+- High impression share on profitable keywords → Increase bid, not budget
+- Discovered new profitable keyword clusters → Add budget for new ad groups
+
+### When to Decrease Budget
+
+- ROAS < 0.5x target for 7+ days → Pause or reduce
+- CPT climbing with flat CVR → Market is getting competitive, reassess
+- Seasonal dip in your category → Reduce and wait
+
+## Bid Optimization
+
+### CPT Benchmarks by Category
+
+These are approximate ranges for the US market. Actual CPT varies by competition and keyword.
+
+| Category | Low CPT | Median CPT | High CPT |
+|----------|---------|------------|----------|
+| Utilities | $0.30 | $0.80 | $2.00 |
+| Productivity | $0.50 | $1.50 | $4.00 |
+| Health & Fitness | $0.60 | $1.80 | $5.00 |
+| Finance | $1.00 | $3.00 | $8.00 |
+| Games (Casual) | $0.20 | $0.60 | $1.50 |
+| Games (Mid-core) | $0.50 | $1.50 | $4.00 |
+| Education | $0.40 | $1.20 | $3.00 |
+| Photo & Video | $0.30 | $1.00 | $3.00 |
+| Social | $0.40 | $1.20 | $3.50 |
+| Shopping | $0.50 | $1.50 | $4.00 |
+
+### Bid Strategy
+
+**Starting bids:**
+- Set initial bids at the median CPT for your category
+- Let campaigns run for 3-5 days before adjusting
+- Need at least 100 impressions per keyword to evaluate
+
+**Raise bids when:**
+- Impression share is low on a profitable keyword (you're being outbid)
+- CVR is high but volume is low (more taps would mean more installs)
+- ROAS is well above target (room to pay more per user)
+
+**Lower bids when:**
+- CPT is above your CPA target and CVR is average
+- Impressions are high but TTR is low (keyword may not be relevant)
+- ROAS is negative after 7+ days of data
+
+**Pause keywords when:**
+- 1000+ impressions, zero installs
+- CPA is 3x+ your target after 14 days
+- Keyword is clearly irrelevant (check Search Terms report)
+
+## Custom Product Pages Integration
+
+Apple Search Ads supports linking ad groups to Custom Product Pages (CPPs) for tailored messaging.
+
+### When to Use CPPs with Ads
+
+| Scenario | CPP Strategy |
+|----------|-------------|
+| Competitor keywords | Highlight advantages over that competitor |
+| Feature keywords | Show the specific feature being searched |
+| Audience segments | Different messaging for students vs. professionals |
+| Seasonal campaigns | Holiday or event-themed screenshots/descriptions |
+
+### CPP Setup for Ads
+
+1. Create Custom Product Pages in App Store Connect (max 35)
+2. Design screenshots and promotional text for each audience
+3. In Search Ads, create separate ad groups per CPP
+4. Assign relevant keywords to each ad group
+5. Monitor CVR per CPP to see which messaging converts best
+
+Use the `generators/custom-product-pages` skill for CPP metadata and strategy.
+
+## Campaign Structure Template
+
+### Recommended Organization
+
+```
+CAMPAIGN: [App Name] - Search Results
+├── AD GROUP: Brand Defense
+│   ├── Keywords: [your app name], [your app name + category]
+│   ├── Match: Exact
+│   ├── CPP: Default product page
+│   └── Budget: 10% of campaign
+│
+├── AD GROUP: Category - Core
+│   ├── Keywords: [top 10 category terms, exact match]
+│   ├── Match: Exact
+│   ├── CPP: Feature-focused product page
+│   └── Budget: 40% of campaign
+│
+├── AD GROUP: Category - Discovery
+│   ├── Keywords: [5 broad category terms]
+│   ├── Match: Broad
+│   ├── Negative keywords: [brand terms, irrelevant terms]
+│   ├── CPP: Default product page
+│   └── Budget: 20% of campaign
+│
+├── AD GROUP: Competitor
+│   ├── Keywords: [competitor app names]
+│   ├── Match: Exact
+│   ├── CPP: Comparison-focused product page
+│   └── Budget: 15% of campaign
+│
+└── AD GROUP: Problem/Solution
+    ├── Keywords: [pain point searches]
+    ├── Match: Exact
+    ├── CPP: Problem-solution product page
+    └── Budget: 15% of campaign
+
+CAMPAIGN: [App Name] - Product Page
+├── AD GROUP: Related Category
+│   └── Audience: Users browsing [related category]
+└── AD GROUP: Competitor Users
+    └── Audience: Users viewing [competitor apps]
+```
+
+## Measurement & KPIs
+
+### Key Metrics
+
+| Metric | Definition | Target Range |
+|--------|-----------|--------------|
+| **TTR** (Tap-Through Rate) | Taps / Impressions | 5-12% |
+| **CVR** (Conversion Rate) | Installs / Taps | 30-60% |
+| **CPT** (Cost Per Tap) | Spend / Taps | Category-dependent (see benchmarks) |
+| **CPA** (Cost Per Acquisition) | Spend / Installs | < Customer LTV |
+| **ROAS** (Return on Ad Spend) | Revenue / Spend | > 1.0 (ideally > 2.0) |
+
+### Interpreting Metrics
+
+**High TTR + Low CVR:**
+- Your ad is attractive but your product page doesn't convert
+- Fix: Improve screenshots, description, ratings
+- Check: Is the keyword truly relevant to your app?
+
+**Low TTR + High CVR:**
+- Users who do tap convert well, but few are tapping
+- Fix: Raise bid to get better placement, review keyword relevance
+- Consider: Your app name/icon may not stand out in results
+
+**High CPA + High CVR:**
+- You're paying too much per tap but converting well
+- Fix: Find cheaper keywords with similar intent
+- Consider: Lower bids and accept fewer impressions
+
+**Low CPA + Low ROAS:**
+- Cheap installs but users aren't monetizing
+- Fix: Check onboarding-to-conversion funnel, not the ad
+- Consider: The keyword may attract wrong user segment
+
+### Reporting Cadence
+
+| Frequency | What to Check | Action |
+|-----------|---------------|--------|
+| Daily | Spend, CPA | Pause runaway spend |
+| Weekly | Keyword performance, Search Terms | Add negatives, find new keywords |
+| Bi-weekly | ROAS, campaign-level metrics | Adjust bids, reallocate budget |
+| Monthly | Overall ROI, LTV/CPA ratio | Strategic changes, new campaigns |
+
+## Common Mistakes
+
+### 1. Bidding on Your Own Brand Name Too Early
+
+- You already rank #1 organically for your name
+- Brand defense is only needed when competitors actively bid on your name
+- Check first by searching — if no competitor ad appears, save the budget
+
+### 2. Starting with Broad Match Only
+
+- Broad match burns budget on irrelevant queries
+- Always start with exact match on validated keywords
+- Use broad match in a separate, low-budget discovery ad group
+- Mine the Search Terms report to find exact match winners
+
+### 3. No Negative Keywords
+
+- Without negative keywords, broad match campaigns waste 30-50% of spend
+- Add negative keywords weekly from Search Terms report
+- Pre-load obvious negatives: competitor names in discovery groups, unrelated terms
+
+### 4. Running Ads Before Optimizing Your Listing
+
+- Ads drive traffic to your product page — if it doesn't convert, ads just cost money
+- Optimize screenshots, description, and ratings FIRST
+- Target 30%+ CVR organically before turning on ads
+
+### 5. Setting Daily Budget Too High Initially
+
+- Start small ($10-20/day) to gather data
+- Scale only after 2+ weeks of data confirms profitability
+- A $100/day budget on day one with no data is gambling, not marketing
+
+### 6. Ignoring the Search Terms Report
+
+- This is the most valuable data Apple gives you
+- Shows ACTUAL queries that triggered your broad match ads
+- Review weekly, add winners as exact match, add losers as negatives
+
+### 7. Not Linking Custom Product Pages
+
+- Generic product page for all keyword intents wastes conversion potential
+- Different searchers need different messaging
+- Even 2-3 CPPs can significantly improve CVR
+
+### 8. Expecting Instant Results
+
+- Apple Search Ads needs 7-14 days minimum to gather meaningful data
+- Don't change bids daily — let data accumulate
+- Statistical significance requires volume: aim for 100+ taps per keyword before judging
+
+## Output Format
+
+When advising on Apple Search Ads, produce this document:
+
+```markdown
+# Apple Search Ads Strategy: [App Name]
+
+## Readiness Assessment
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Organic downloads | ✅/❌ | [X/month] |
+| Product page CVR | ✅/❌ | [X%] |
+| Screenshots | ✅/❌ | [X screenshots] |
+| Ratings | ✅/❌ | [X.X stars] |
+| Crash-free rate | ✅/❌ | [X%] |
+| Monetization | ✅/❌ | [Model] |
+
+**Verdict**: [Ready / Optimize first / Not ready]
+
+## Recommended Campaign Structure
+
+### Campaign 1: [Name]
+- **Type**: [Search Results / Product Page / etc.]
+- **Daily budget**: $X
+- **Ad groups**: [List]
+
+### Ad Group: [Name]
+- **Keywords**: [List with match type]
+- **Starting CPT bid**: $X.XX
+- **Custom Product Page**: [Default / specific CPP]
+- **Target CPA**: $X.XX
+
+[Repeat for each ad group]
+
+## Keyword Plan
+
+| Keyword | Match | Category | Est. CPT | Priority |
+|---------|-------|----------|----------|----------|
+| [keyword] | Exact | Category | $X.XX | High |
+| [keyword] | Exact | Discovery | $X.XX | High |
+| [keyword] | Broad | Discovery | $X.XX | Medium |
+
+## Budget Summary
+
+| Campaign | Daily | Monthly | % of Total |
+|----------|-------|---------|------------|
+| [Campaign 1] | $X | $X | X% |
+| [Campaign 2] | $X | $X | X% |
+| **Total** | **$X** | **$X** | **100%** |
+
+## KPI Targets
+
+| Metric | Target | Review Frequency |
+|--------|--------|-----------------|
+| TTR | X% | Weekly |
+| CVR | X% | Weekly |
+| CPA | $X.XX | Bi-weekly |
+| ROAS | X.Xx | Monthly |
+
+## Negative Keywords (Pre-loaded)
+- [List of terms to exclude from broad match]
+
+## Week 1-2 Action Items
+1. [First thing to set up]
+2. [Second thing to set up]
+3. [Third thing to set up]
+
+## Month 1 Review Checklist
+- [ ] Review Search Terms report
+- [ ] Add negative keywords
+- [ ] Evaluate keyword-level ROAS
+- [ ] Adjust bids on top/bottom performers
+- [ ] Consider CPP creation for top ad groups
+```
+
+## References
+
+- Related: `app-store/keyword-optimizer` — ASO keyword strategy (organic, complements paid)
+- Related: `app-store/screenshot-planner` — Product page optimization (improves ad CVR)
+- Related: `generators/custom-product-pages` — Custom Product Page creation for ad groups
+- Related: `app-store/marketing-strategy` — Overall marketing strategy including paid acquisition
+- Apple Search Ads documentation: https://searchads.apple.com

--- a/.claude/skills/app-store/keyword-optimizer/SKILL.md
+++ b/.claude/skills/app-store/keyword-optimizer/SKILL.md
@@ -1,0 +1,411 @@
+---
+name: keyword-optimizer
+description: Optimize app title, subtitle, and keywords for maximum App Store discoverability. Use when launching a new app, improving search rankings, entering new markets/languages, or safely optimizing ASO for an app with existing traffic.
+allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+---
+
+# Keyword Optimizer
+
+Optimize app title, subtitle, and keywords for maximum App Store discoverability.
+
+## When This Skill Activates
+
+- User is launching a new app
+- User wants to improve search rankings
+- User asks about ASO (App Store Optimization)
+- User is entering new markets/languages
+- User wants to analyze keyword opportunities
+- User needs safe optimization for existing apps
+
+## Reference Files
+
+Before optimizing, load these reference materials:
+
+| File | Purpose |
+|------|---------|
+| **keyword-criteria.md** | Popularity/Difficulty sweet spots, opportunity scoring |
+| **advanced-tactics.md** | Cross-localization, screenshot indexing, velocity boost |
+| **existing-app-strategy.md** | Safe optimization for apps with existing traffic |
+
+## Information Gathering
+
+Before optimizing, ask about:
+
+1. **App Identity**
+   - What does the app do in one sentence?
+   - What category is it in?
+   - What's the current app name (if exists)?
+
+2. **Target Keywords**
+   - What would users search to find this app?
+   - What problem words would they use?
+   - Any branded terms to include?
+
+3. **Competition**
+   - Main competitors?
+   - What keywords do they target?
+   - Where can you realistically compete?
+
+4. **Goals**
+   - Brand awareness vs. category traffic?
+   - Specific markets to prioritize?
+
+## Keyword Strategy
+
+### Where Keywords Count
+
+| Field | Limit | Weight | Notes |
+|-------|-------|--------|-------|
+| **App Name** | 30 chars | Highest | Most valuable real estate |
+| **Subtitle** | 30 chars | High | Visible in search, below name |
+| **Keywords** | 100 chars | Medium | Not visible to users |
+| **Description** | 4000 chars | Low* | *Apple says indexed, debated |
+
+### Keyword Types
+
+1. **Branded** - Your app name, company name
+2. **Category** - Generic terms (e.g., "todo app", "weather")
+3. **Feature** - Specific functionality (e.g., "offline maps")
+4. **Problem** - User pain points (e.g., "forget tasks")
+5. **Long-tail** - Specific phrases (e.g., "minimalist habit tracker")
+
+## Optimization Process
+
+### Step 1: Keyword Research
+
+**Generate Initial List:**
+```
+1. Brainstorm 50+ keywords
+2. What would YOU search for this app?
+3. Check competitor names/subtitles
+4. Use autocomplete suggestions
+5. Consider misspellings users make
+```
+
+**Research Tools:**
+- App Store Search Autocomplete
+- AppFollow, Sensor Tower, AppTweak (paid)
+- Google Keyword Planner (related terms)
+- Competitor subtitle/keyword analysis
+
+### Step 2: Prioritize Keywords
+
+Rate each keyword on:
+
+| Factor | Question |
+|--------|----------|
+| **Relevance** | Does it accurately describe your app? |
+| **Volume** | Do people actually search this? |
+| **Difficulty** | Can you realistically rank? |
+| **Intent** | Will searchers want your app? |
+
+**Priority Matrix:**
+```
+High Volume + Low Difficulty = 🎯 Target First
+High Volume + High Difficulty = 💪 Long-term Goal
+Low Volume + Low Difficulty = ✅ Easy Wins
+Low Volume + High Difficulty = ❌ Skip
+```
+
+### Step 3: Allocate Keywords
+
+**App Name (30 characters):**
+```
+[Brand Name] - [Top Keyword Phrase]
+or
+[Brand Name]: [Value Proposition]
+
+Examples:
+"Notion - Notes & Docs"
+"Calm: Sleep & Meditation"
+"Fantastical - Calendar & Tasks"
+```
+
+**Subtitle (30 characters):**
+```
+[Second Priority Keywords] / [Unique Value]
+
+Examples:
+"Focus Timer & Daily Planner"
+"Simple Habit Building"
+"Weather Radar & Forecasts"
+```
+
+**Keywords Field (100 characters):**
+```
+Rules:
+- Comma-separated, NO spaces after commas
+- No plurals (Apple handles it)
+- No duplicates from name/subtitle
+- No category name (already indexed)
+- Single words perform better than phrases
+
+Example:
+"timer,pomodoro,focus,concentration,study,productivity,work,session,break,technique"
+```
+
+## Character Optimization
+
+### Maximize 100 Characters
+
+**Bad (wastes characters):**
+```
+task manager, todo list, productivity app, reminder app, checklist
+```
+
+**Good (efficient):**
+```
+task,todo,productivity,reminder,checklist,planner,organize,gtd,schedule,daily
+```
+
+**Savings:**
+- Remove spaces after commas
+- Don't repeat words in different forms
+- Skip obvious words (app, free, best)
+
+### Word Combinations
+
+Apple combines words from all fields:
+
+```
+Name: "Focus Timer"
+Subtitle: "Pomodoro Technique"
+Keywords: "study,productivity,work,session"
+
+Searchable combinations:
+- "focus timer"
+- "pomodoro timer"
+- "focus productivity"
+- "study timer"
+- "work focus"
+(and more...)
+```
+
+## Cross-Field Deduplication
+
+Apple indexes words from **all three fields** for the same locale. A word only needs to appear **once** — putting it in multiple fields wastes characters and provides zero ranking benefit.
+
+### Priority Cascade
+
+```
+Title (30 chars)     → Highest search weight
+  ↓ words flow down
+Subtitle (30 chars)  → High search weight
+  ↓ words flow down
+Keywords (100 chars) → Medium search weight
+```
+
+**The rule:** If a word appears in your Title, **do not repeat it** in Subtitle or Keywords. If a word appears in your Subtitle, **do not repeat it** in Keywords. Apple already indexes it from the higher-weight field.
+
+### Why This Matters
+
+Every duplicated word steals characters from the Keywords field where you could fit **new** discoverable terms. With only 100 characters, even one wasted word costs you reach.
+
+### Validation Process
+
+For each locale, extract every word from all three fields and check for overlaps:
+
+```
+Step 1: List all words in Title
+Step 2: List all words in Subtitle → flag any that appear in Title
+Step 3: List all words in Keywords → flag any that appear in Title OR Subtitle
+Step 4: Remove flagged words from lower fields
+Step 5: Replace removed words with new keyword opportunities
+```
+
+### Before & After Example
+
+```
+❌ BEFORE (duplicated words waste 23 characters):
+
+Title:    "Focus Timer - Stay Productive"
+Subtitle: "Pomodoro Timer & Focus Sessions"
+Keywords: "timer,focus,pomodoro,productive,study,work,session,break"
+
+Duplicates:
+  "timer"      — in Title AND Subtitle AND Keywords
+  "focus"      — in Title AND Subtitle AND Keywords
+  "pomodoro"   — in Subtitle AND Keywords
+  "productive" — in Title ("Productive") AND Keywords
+  "session"    — in Subtitle ("Sessions") AND Keywords
+
+Wasted: 5 keyword slots = ~38 characters lost
+
+✅ AFTER (zero duplication, 5 new keywords gained):
+
+Title:    "Focus Timer - Stay Productive"
+Subtitle: "Pomodoro Technique & Deep Work"
+Keywords: "study,concentration,interval,tomato,distraction,block,exam,revision,flowstate,desk"
+
+New searchable combinations gained:
+  "focus concentration"  "timer interval"
+  "study timer"          "deep focus"
+  "exam study"           "pomodoro technique"
+```
+
+### Quick Dedup Check
+
+When generating keyword recommendations, always verify:
+
+| Check | Rule |
+|-------|------|
+| Title word in Subtitle? | Remove from Subtitle |
+| Title word in Keywords? | Remove from Keywords |
+| Subtitle word in Keywords? | Remove from Keywords |
+| Plural/singular variant across fields? | Keep only in highest field |
+| Stop words (a, the, and, for)? | Don't include anywhere — auto-indexed |
+
+## Common Mistakes
+
+❌ **Don't Do This:**
+- Using spaces after commas in keywords
+- Duplicating words across fields
+- Including your category name
+- Using competitor brand names
+- Adding "app" or "application"
+- Including "free" (filterable separately)
+- Using special characters or emoji
+- Repeating singular/plural forms
+
+✅ **Do This:**
+- Research before guessing
+- Prioritize relevance over volume
+- Update keywords quarterly
+- Track ranking changes
+- Localize keywords per market
+
+## Keyword Template
+
+```
+APP NAME STRATEGY
+━━━━━━━━━━━━━━━━━
+Current: [existing name or blank]
+Proposed: [Brand] - [Keywords]
+Characters: [X/30]
+Primary keywords: [list]
+
+SUBTITLE STRATEGY
+━━━━━━━━━━━━━━━━━
+Current: [existing subtitle or blank]
+Proposed: [keyword-rich subtitle]
+Characters: [X/30]
+Secondary keywords: [list]
+
+KEYWORDS FIELD (100 chars)
+━━━━━━━━━━━━━━━━━━━━━━━━━
+Proposed: keyword1,keyword2,keyword3,...
+Characters: [X/100]
+
+EXPECTED COMBINATIONS
+━━━━━━━━━━━━━━━━━━━━━
+• [combination 1]
+• [combination 2]
+• [combination 3]
+...
+```
+
+## Localization Strategy
+
+### Priority Markets by Revenue
+
+1. 🇺🇸 United States (English)
+2. 🇨🇳 China (Simplified Chinese)
+3. 🇯🇵 Japan (Japanese)
+4. 🇬🇧 UK (British English - can differ!)
+5. 🇩🇪 Germany (German)
+6. 🇫🇷 France (French)
+7. 🇰🇷 South Korea (Korean)
+8. 🇪🇸 Spain (Spanish)
+9. 🇮🇹 Italy (Italian)
+10. 🇧🇷 Brazil (Portuguese)
+
+### Localization Tips
+
+- Don't just translate—research local search terms
+- Some markets search in English even for local apps
+- Character limits may be tighter in some languages
+- Hire native speakers to verify keywords make sense
+- Consider cultural differences in app usage
+
+## Tracking & Iteration
+
+### What to Track
+
+- Keyword rankings (use ASO tools)
+- Impressions (App Store Connect)
+- Conversion rate
+- Download sources
+
+### When to Update
+
+- **Weekly:** Check ranking changes
+- **Monthly:** Assess underperforming keywords
+- **Quarterly:** Major keyword refresh
+- **Seasonally:** Add seasonal keywords
+
+### A/B Testing
+
+App Store Connect allows testing:
+- App icons
+- Screenshots
+- App previews
+
+Use Product Page Optimization to test different approaches.
+
+## Quick Reference
+
+### Prohibited Terms
+- "Free" (use pricing filter instead)
+- "#1" or "best" without verification
+- Competitor names
+- "App" or "application"
+- Pricing information
+
+### Always Include
+- Core functionality words
+- Problem/solution words
+- Category-relevant terms
+- Action verbs users would search
+
+### Character Limits
+```
+App Name:      30 characters
+Subtitle:      30 characters
+Keywords:     100 characters
+Description: 4000 characters (low SEO value)
+```
+
+## Indie Developer Strategy
+
+For building apps that generate $200-2,000/month:
+
+### The Sweet Spot Formula
+```
+Target keywords where:
+- Popularity > 20 (enough traffic)
+- Difficulty < 60 (beatable competition)
+
+Ideal: Popularity 25-50, Difficulty < 45
+```
+
+### Process
+1. Find underserved keywords using ASO tools (Astro, AppTweak)
+2. Build simple, single-feature apps around those keywords
+3. Double down on winners, abandon losers
+4. Portfolio effect compounds (30 apps × $500 = $15k/month)
+
+See **keyword-criteria.md** for detailed scoring and evaluation.
+
+## Advanced Tactics Summary
+
+### Cross-Localization (Double Keywords)
+Add Spanish (Mexico) locale with English keywords for US market.
+See **advanced-tactics.md** for all locales.
+
+### Screenshot Text Indexing (June 2025)
+Apple OCR reads screenshot captions for keyword ranking.
+Put keywords in top/bottom of screenshots.
+
+### Existing App Optimization
+Never change what's working. Use phased rollout.
+See **existing-app-strategy.md** for safe optimization.

--- a/.claude/skills/app-store/keyword-optimizer/advanced-tactics.md
+++ b/.claude/skills/app-store/keyword-optimizer/advanced-tactics.md
@@ -1,0 +1,303 @@
+# Advanced ASO Tactics
+
+Hidden strategies that most developers don't know. These can significantly boost discoverability.
+
+## 1. Cross-Localization (10x Your Keywords)
+
+Apple indexes keywords from **multiple locales per storefront**. Each additional locale gives you up to **160 extra indexable characters** (30 title + 30 subtitle + 100 keywords). For the US alone, that's up to **1,440 bonus characters**.
+
+### US App Store — 10 Indexed Locales
+
+| # | Locale | Code | Notes |
+|---|--------|------|-------|
+| 1 | English (US) | en-US | Primary |
+| 2 | Spanish (Mexico) | es-MX | Most commonly used secondary |
+| 3 | Arabic | ar | |
+| 4 | Chinese (Simplified) | zh-Hans | |
+| 5 | Chinese (Traditional) | zh-Hant | |
+| 6 | French | fr | |
+| 7 | Korean | ko | |
+| 8 | Portuguese (Brazil) | pt-BR | |
+| 9 | Russian | ru | |
+| 10 | Vietnamese | vi | |
+
+### How to Use
+
+In App Store Connect, add secondary localizations with **English keywords** (you don't need to translate — English words index for the US market regardless of which locale they're in):
+
+```
+English (US) Keywords:
+roommate,group,cost,trip,tab,owe,money,tracker,pay,debt
+
+Spanish (MX) Keywords (English!):
+apartment,utilities,travel,vacation,dinner,friends,shared,divide,fair,easy
+
+Portuguese (BR) Keywords (English!):
+budget,household,groceries,restaurant,rent,settle,balance,fair,receipt,reimburse
+
+Arabic Keywords (English!):
+colleague,lunch,cab,uber,airbnb,weekend,event,party,wedding,gift
+
+... repeat for remaining locales with NEW unique keywords each time
+```
+
+### Rules
+- **No duplicate words across ANY locale** — each word is counted only once even across locales, so repetition provides zero ranking boost
+- Words from different locales **DON'T combine** into phrases (only words within the same locale combine)
+- You CAN use English in any locale if targeting an English-speaking market
+- Apply the same Title → Subtitle → Keywords dedup cascade within each locale
+- Prioritize your highest-value keywords in en-US (highest weight), use secondary locales for long-tail and supplementary terms
+
+### Cross-Localization for All Major Markets
+
+| Market | Primary Locale | Secondary Locales Indexed |
+|--------|---------------|--------------------------|
+| **United States** | English (US) | Spanish (MX), Arabic, Chinese (Simplified), Chinese (Traditional), French, Korean, Portuguese (BR), Russian, Vietnamese |
+| **Canada** | English (Canada) | French (Canada) |
+| **United Kingdom** | English (UK) | — (single locale) |
+| **Australia** | English (Australia) | — (single locale) |
+| **Mexico** | Spanish (Mexico) | English (US) |
+| **Brazil** | Portuguese (Brazil) | English (US) |
+| **Japan** | Japanese | English (US) |
+| **South Korea** | Korean | English (US) |
+| **China (Mainland)** | Chinese (Simplified) | English (US) |
+| **Taiwan** | Chinese (Traditional) | English (US) |
+| **Germany** | German | English (UK) |
+| **France** | French | English (UK) |
+| **Spain** | Spanish (Spain) | English (UK), Catalan |
+| **Italy** | Italian | English (UK) |
+| **Netherlands** | Dutch | English (UK) |
+| **Portugal** | Portuguese (Portugal) | English (UK) |
+| **Russia** | Russian | English (UK) |
+| **India** | English (India) | Hindi |
+| **Switzerland** | German (Switzerland) | French, Italian, English (UK) |
+| **Belgium** | Dutch (Belgium) | French (Belgium) |
+| **Sweden** | Swedish | English (UK) |
+| **Norway** | Norwegian | English (UK) |
+| **Denmark** | Danish | English (UK) |
+| **Finland** | Finnish | English (UK) |
+
+**Key pattern:** English (UK) is the fallback for most European markets. English (US) is the fallback for most Asian and Latin American markets.
+
+### Implementation Priority
+
+For an English-language app targeting the US market:
+
+```
+Phase 1 (Day 1): Set up en-US with your best keywords
+Phase 2 (Day 1): Add es-MX with next-best English keywords
+Phase 3 (Week 1): Add pt-BR, fr, ko with more English keywords
+Phase 4 (Week 2): Add zh-Hans, zh-Hant, ar, ru, vi to fill remaining slots
+Phase 5 (Week 3): If targeting EU/Asia, add en-UK keywords for European reach
+```
+
+### Character Budget Calculator
+
+```
+US Market Total Indexable Characters:
+  10 locales × (30 title + 30 subtitle + 100 keywords) = 1,600 characters
+
+Minus primary en-US:                                     = 1,440 bonus characters
+Minus realistic dedup overhead (~15%):                   ≈ 1,220 usable bonus characters
+
+That's 12x your single-locale keyword capacity.
+```
+
+## 2. Screenshot Text Indexing (June 2025)
+
+Apple now uses **OCR to read screenshot captions** and indexes them for search.
+
+### What Changed
+
+```
+Before: Screenshots = conversion only
+Now:    Screenshots = conversion + keyword ranking
+```
+
+### Where Apple Scans
+
+Apple OCR focuses on **top and bottom** of screenshots:
+
+```
+┌─────────────────────┐
+│ "SPLIT BILLS FAST"  │  ← TOP: Keywords here
+│                     │
+│    [App UI]         │
+│                     │
+│ "With roommates"    │  ← BOTTOM: Keywords here
+└─────────────────────┘
+```
+
+### Caption Strategy
+
+| Old Caption (Bad) | New Caption (Keyword-Rich) |
+|-------------------|---------------------------|
+| "Easy to use!" | "Split Bills Instantly" |
+| "Track everything" | "Track Shared Expenses" |
+| "Simple & fast" | "Settle Up with Friends" |
+
+### Important Notes
+- Keywords in screenshots DON'T compete with metadata keywords
+- Apple EXPECTS keyword repetition in screenshots (unlike metadata)
+- Use your most important keywords in first 2 screenshots
+- Reported 22% boost in search visibility within 30 days
+
+## 3. In-App Events (Free Featuring)
+
+Apple allows **5 live events** that appear in search results. Most developers ignore this.
+
+### Benefits
+- Events get **separate search indexing**
+- Can appear in "Events" tab = extra visibility
+- Apple sometimes **features** interesting events
+- Re-engages existing users
+
+### Event Ideas by Category
+
+| Category | Event Idea |
+|----------|-----------|
+| Finance | "New Year Budget Challenge" |
+| Health | "30-Day Fitness Challenge" |
+| Productivity | "Productivity Week" |
+| Education | "Back to School Special" |
+| Games | "Weekend Tournament" |
+
+### Event Metadata = More Keywords
+Event title and description are indexed separately from your app's main keywords.
+
+## 4. First 48 Hours Velocity Boost
+
+Apple gives new apps/updates a **temporary ranking boost**. Maximize it:
+
+### Launch Strategy
+1. Have friends/family download on Day 1
+2. Share on social media immediately
+3. Email your list on launch day
+4. Coordinate with any press/coverage
+
+### Update Strategy
+- Don't waste updates on bug fixes alone
+- Bundle bug fixes with keyword changes
+- Time updates for when you can promote them
+
+## 5. Manipulate "Most Helpful" Reviews
+
+Hidden feature: **Long-press any review** → Mark as "Helpful"
+
+### Strategy
+1. Find your best 5-star reviews
+2. Long-press each one
+3. Mark as "Helpful"
+4. They'll rise to "Most Helpful" section
+
+Your top 3 "most helpful" reviews show first to potential users.
+
+## 6. UK English for Extra Keywords
+
+Add **English (UK)** localization with different keywords. These index for:
+- United Kingdom
+- Partially for other EU countries
+
+### US vs UK Variations
+
+| US Term | UK Term |
+|---------|---------|
+| roommate | flatmate |
+| apartment | flat |
+| vacation | holiday |
+| check | cheque |
+| color | colour |
+| organization | organisation |
+
+## 7. Left-to-Right Keyword Weight
+
+Apple's algorithm reads title/subtitle **left to right** and gives more weight to words that appear first.
+
+### Examples
+
+```
+Weaker:  Bills Split - Expense App
+Stronger: Expense Split - Settle Up
+          ↑ Most important word first
+```
+
+### Application
+- Put your primary keyword FIRST in title
+- Put secondary keyword FIRST in subtitle
+- Front-load your keyword field too
+
+## 8. Singular vs Plural (Don't Waste Space)
+
+Apple treats these as equivalent:
+```
+bill = bills
+expense = expenses
+tracker = trackers
+```
+
+**Never include both forms** — it wastes precious characters.
+
+## 9. Stop Words Are Auto-Indexed
+
+Don't waste keyword space on:
+```
+a, an, the, and, for, with, of, to, by, app, application
+```
+
+Apple indexes these automatically.
+
+## 10. Review Keywords = Ranking Boost
+
+When users mention keywords in reviews, it can boost ranking.
+
+### Prompt Strategy
+```
+"If you love splitting bills with roommates,
+please leave a review!"
+```
+
+Natural keyword inclusion in reviews = organic boost.
+
+## 11. Conversion Rate Affects Ranking
+
+Apple tracks **impressions → downloads** ratio. Higher conversion = higher ranking.
+
+### Improve Conversion
+- Better icon (A/B test with Product Page Optimization)
+- First screenshot is most important (70% decide from it alone)
+- First 3 words of subtitle are visible in search results
+
+## Quick Reference Checklist
+
+### Zero-Risk Additions
+- [ ] Add all 9 secondary US locales (es-MX, ar, zh-Hans, zh-Hant, fr, ko, pt-BR, ru, vi) with unique English keywords
+- [ ] Add en-UK locale with extra keywords (for European market reach)
+- [ ] Update screenshot captions with keywords
+- [ ] Create In-App Events
+- [ ] Mark best reviews as "Helpful"
+
+### Optimization Rules
+- [ ] No duplicate words across fields (Title → Subtitle → Keywords cascade)
+- [ ] No duplicate words across locales (each word counted once globally)
+- [ ] No spaces after commas in keywords
+- [ ] No stop words wasting space
+- [ ] No singular AND plural forms
+- [ ] Primary keywords at START of title/subtitle
+- [ ] Most important keywords in first 2 screenshots
+
+### Tracking
+- [ ] Note baseline metrics before changes
+- [ ] Check rankings weekly
+- [ ] Update keywords every 4-6 weeks
+- [ ] Swap underperforming keywords (rank >100)
+
+## Sources
+
+- [ASO.dev: Cross-Localization Guide](https://aso.dev/metadata/cross-localization/)
+- [AppTweak: Cross-Localization Guide](https://www.apptweak.com/en/aso-blog/how-to-benefit-from-cross-localization-on-the-app-store)
+- [AppFollow: App Store Keywords Localizations](https://appfollow.io/app-store-keywords-localizations)
+- [Appfigures: 10x Your Keyword List](https://appfigures.com/resources/guides/extend-keyword-list)
+- [OutrankApps: Cross-Localization Guide](https://outrankapps.com/app-store-optimization-cross-localization/)
+- [Appfigures: Screenshot Algorithm Update](https://appfigures.com/resources/guides/app-store-algorithm-update-2025)
+- [Appfigures: Advanced ASO Secrets](https://appfigures.com/resources/guides/advanced-aso-secrets)
+- [MobileAction: Cross-Localization](https://www.mobileaction.co/blog/aso-keyword-research/)

--- a/.claude/skills/app-store/keyword-optimizer/existing-app-strategy.md
+++ b/.claude/skills/app-store/keyword-optimizer/existing-app-strategy.md
@@ -1,0 +1,213 @@
+# Existing App Optimization Strategy
+
+How to improve ASO for apps that already have downloads without risking existing traffic.
+
+## The Risk
+
+When optimizing an existing app:
+- You can see **rankings** but not which keywords drive **actual downloads**
+- Changing keywords that are working can **kill traffic**
+- Recovery can take weeks if you make mistakes
+
+## Identify Traffic Sources
+
+### Method 1: Math-Based Estimation
+
+Traffic from a keyword ≈ **Popularity × Position Factor**
+
+| Position | Approx. Click Share |
+|----------|-------------------|
+| #1-3 | 40-60% of searches |
+| #4-10 | 10-25% of searches |
+| #11-30 | 2-8% of searches |
+| #30+ | <1% of searches |
+
+### Method 2: Opportunity Score
+
+```
+Score = (Popularity × 2) - Difficulty
+
+High Score + Good Rank = Likely driving traffic
+Low Score + Any Rank = Probably not driving traffic
+```
+
+### Analysis Template
+
+| Keyword | Pop | Rank | Est. Traffic | Protect? |
+|---------|-----|------|--------------|----------|
+| [keyword] | [X] | #[Y] | High/Med/Low | Yes/No |
+
+**Example:**
+| Keyword | Pop | Rank | Est. Traffic | Protect? |
+|---------|-----|------|--------------|----------|
+| settle up | 29 | #4 | HIGH | YES |
+| expense split | 5 | #6 | Low | No |
+| settle | 21 | #18 | Medium | YES |
+| split bill | 21 | #211 | None | No |
+
+## The Golden Rule
+
+**Never touch what's working.**
+
+```
+KEEP (don't change):
+- Keywords where you rank Top 10 + Popularity >15
+- Your app title if ranking well for branded terms
+
+SAFE TO CHANGE:
+- Subtitle (if current keywords not ranking well)
+- Keyword field (low-ranking keywords only)
+- Add new locales (purely additive)
+- Screenshot captions (purely additive)
+```
+
+## Phased Rollout Plan
+
+### Phase 1: Additive Only (Week 1-2)
+
+**Zero Risk Actions:**
+- [ ] Add Spanish (Mexico) locale with new keywords
+- [ ] Add English (UK) locale with new keywords
+- [ ] Update screenshot captions with keywords
+- [ ] Create 1-2 In-App Events
+
+These don't affect existing rankings — they only ADD opportunities.
+
+### Phase 2: Monitor & Measure (Week 3-4)
+
+Track in your ASO tool:
+- [ ] Did new keywords start ranking?
+- [ ] Did downloads increase?
+- [ ] Did existing rankings stay stable?
+
+**Baseline Tracking Template:**
+```
+Date: ___________
+Daily downloads: ___
+Keyword 1: ___ rank #___
+Keyword 2: ___ rank #___
+Keyword 3: ___ rank #___
+```
+
+### Phase 3: Careful Optimization (Week 5-6)
+
+**Only if Phase 2 shows stable/improved metrics:**
+
+- [ ] Update subtitle only (keep title same)
+- [ ] Replace lowest-performing keywords in keyword field
+- [ ] Keep all top-ranking keywords untouched
+
+### Phase 4: Evaluate Full Changes (Week 7+)
+
+**Only if downloads stable/increased:**
+- Consider title adjustments (if needed)
+- Continue keyword field optimization
+- Always protect your best-ranking keywords
+
+## Safe Change Examples
+
+### Subtitle Change
+
+```
+Before: "Simple expense sharing"
+After:  "Split bills & rent easily"
+
+Why Safe:
+- Keeps core meaning
+- Adds target keywords (bills, rent)
+- Doesn't remove existing ranking keywords
+```
+
+### Keyword Field Change
+
+```
+Before: task,todo,list,note,reminder,productivity,organize,manage,plan
+After:  todo,reminder,productivity,organize,roommate,trip,dinner,vacation
+
+Why Safe:
+- Removed low-value keywords (task, list, note - rank >100)
+- Kept high-value keywords (todo, reminder, productivity)
+- Added new opportunity keywords
+```
+
+## What NOT to Change
+
+### Protect These Keywords
+
+1. **Top 10 Rankings** — Don't touch if Pop >15
+2. **Branded Terms** — Your app name/company
+3. **Core Category Terms** — If you're a "timer app", keep "timer"
+
+### Red Flags
+
+Don't change if:
+- Keyword ranks Top 5 with Pop >20
+- Keyword drives measurable traffic (from Apple Search Ads data)
+- It's your app's core identity term
+
+## Apple Search Ads for Data
+
+If possible, run a small Apple Search Ads campaign ($20-50):
+
+### What You Learn
+- Exact keywords driving installs
+- Conversion rates per keyword
+- Cost per install (indicates competition)
+
+### Campaign Strategy
+1. Create "Exact Match" ad groups
+2. Add your suspected traffic-driving keywords
+3. Run for 1-2 weeks
+4. Analyze which keywords convert
+
+This data is **gold** for deciding what to protect vs. change.
+
+## Recovery Plan
+
+If rankings drop after changes:
+
+### Immediate (Day 1-3)
+- Document what changed
+- Check if rankings are actually down or just fluctuating
+- Don't panic — rankings fluctuate naturally
+
+### Short-Term (Week 1)
+- If significant drop, consider reverting changes
+- Reversion takes ~1 week to re-index
+
+### Long-Term (Week 2+)
+- If still down, revert to previous metadata
+- Wait for full re-indexing (2-4 weeks)
+- Try smaller changes next time
+
+## Checklist: Before Making Changes
+
+- [ ] Documented current rankings for all tracked keywords
+- [ ] Identified which keywords are likely driving traffic
+- [ ] Listed keywords that are PROTECTED (won't change)
+- [ ] Planned additive changes first (new locales, screenshots)
+- [ ] Have a rollback plan if things go wrong
+- [ ] Set calendar reminder to check metrics in 1 week
+
+## Example: Safe Optimization Flow
+
+**App:** Expense Split (7 downloads/day)
+
+**Current Rankings:**
+- "settle up" — #4, Pop 29 → PROTECT
+- "settle" — #18, Pop 21 → PROTECT
+- "split bill" — #211, Pop 21 → SAFE TO TARGET
+
+**Phase 1 Plan:**
+1. Add Spanish (MX) with: roommate,apartment,utilities,dinner,trip,vacation
+2. Add screenshot caption: "Split Bills with Roommates"
+3. DON'T change title (has "Settle Up")
+
+**Phase 2 Monitor:**
+- Check if new keywords start ranking
+- Verify "settle up" stays at #4
+- Track daily downloads
+
+**Phase 3 (if stable):**
+- Update subtitle to include "split bills"
+- Replace low-value keywords in keyword field

--- a/.claude/skills/app-store/keyword-optimizer/keyword-criteria.md
+++ b/.claude/skills/app-store/keyword-optimizer/keyword-criteria.md
@@ -1,0 +1,235 @@
+# Keyword Selection Criteria
+
+How to evaluate and select keywords for maximum impact with achievable rankings.
+
+## The Indie Developer Strategy
+
+From successful indie devs building $200-2,000/month apps:
+
+```
+Find keywords with:
+- Popularity > 20 (enough traffic)
+- Difficulty < 60 (beatable competition)
+```
+
+Build simple, single-feature apps around those keywords.
+
+## Understanding Scores
+
+### Popularity Score (0-100)
+
+From Apple Search Ads. Represents search volume.
+
+| Score | Traffic Level | Notes |
+|-------|--------------|-------|
+| 5-15 | Very Low | Only target if very niche |
+| 16-25 | Low | Good for long-tail, low competition |
+| 26-40 | Medium | Sweet spot for indie apps |
+| 41-60 | Good | Worthwhile if difficulty allows |
+| 61-80 | High | Usually high competition |
+| 81-100 | Very High | Dominated by brands |
+
+**Important:** Popularity is exponential, not linear.
+- Score 50 is NOT 2x traffic of Score 25
+- Score 80 could be 10x traffic of Score 40
+
+### Difficulty Score (0-100)
+
+Estimated from competitor strength and count.
+
+| Score | Competition | Your Chances |
+|-------|------------|--------------|
+| 0-25 | Very Low | Easy ranking |
+| 26-40 | Low | Good opportunity |
+| 41-55 | Medium | Achievable with good ASO |
+| 56-70 | High | Hard, need excellent app + ASO |
+| 71-100 | Very High | Dominated by established apps |
+
+## The Sweet Spot Matrix
+
+```
+        │ Difficulty
+        │ Low (<40)  │ Med (40-55) │ High (>55)
+────────┼────────────┼─────────────┼──────────────
+Pop     │            │             │
+High    │ GOLD       │ WORTH IT    │ LONG-TERM
+(40+)   │ Target Now │ Target Now  │ GOAL
+────────┼────────────┼─────────────┼──────────────
+Pop     │            │             │
+Med     │ GREAT      │ GOOD        │ SKIP
+(25-40) │ Target Now │ Consider    │ Too Hard
+────────┼────────────┼─────────────┼──────────────
+Pop     │            │             │
+Low     │ MAYBE      │ SKIP        │ SKIP
+(15-25) │ Easy Win   │ Not Worth   │ Not Worth
+────────┼────────────┼─────────────┼──────────────
+Pop     │            │             │
+V.Low   │ SKIP       │ SKIP        │ SKIP
+(<15)   │ No Traffic │ No Traffic  │ No Traffic
+```
+
+## Opportunity Score Formula
+
+Calculate opportunity score for comparison:
+
+```
+Opportunity Score = (Popularity × 2) - Difficulty
+
+Bonus: +20 if Pop 20-50 AND Diff <40 (sweet spot)
+Bonus: +10 if Pop 20-50 AND Diff <50 (good range)
+Penalty: -30 if Diff >70 (very competitive)
+```
+
+### Grading Scale
+
+| Score | Grade | Action |
+|-------|-------|--------|
+| 80+ | A+ | HIGH PRIORITY - Target immediately |
+| 60-79 | A | Good opportunity |
+| 40-59 | B | Worth pursuing |
+| 20-39 | C | Consider if relevant |
+| 0-19 | D | Low priority |
+| <0 | F | Skip |
+
+### Example Calculations
+
+```
+"brown noise" - Pop 25, Diff 30
+Score = (25 × 2) - 30 + 20 (bonus) = 40 → Grade B
+
+"meditation timer" - Pop 35, Diff 45
+Score = (35 × 2) - 45 + 10 (bonus) = 35 → Grade C
+
+"podcast app" - Pop 70, Diff 85
+Score = (70 × 2) - 85 - 30 (penalty) = 25 → Grade C (despite high pop!)
+```
+
+## Keyword Categories by Opportunity
+
+### Tier 1: Target Immediately
+- Pop 25-50, Diff <40
+- Pop 40-60, Diff <50
+- Score 60+
+
+### Tier 2: Good Opportunities
+- Pop 20-40, Diff 40-55
+- Pop 50-70, Diff 50-60
+- Score 40-59
+
+### Tier 3: Long-term Goals
+- Pop 60+, Diff 60-75
+- Build app strength first, then target
+
+### Tier 4: Skip
+- Pop <15 (not enough traffic)
+- Diff >75 (too competitive)
+- Score <20
+
+## Finding Keywords to Analyze
+
+### Tool: Astro (Recommended for Indies)
+
+1. Search a seed keyword
+2. Note Popularity and Difficulty
+3. Check "Related Keywords" suggestions
+4. Look for sweet spot matches
+
+### Seed Keyword Strategy
+
+Start with generic terms, find specific variants:
+
+```
+Seed: "timer"
+├── pomodoro timer (Pop 35, Diff 42) ✅
+├── study timer (Pop 28, Diff 38) ✅
+├── focus timer (Pop 40, Diff 55) ⚠️
+├── interval timer (Pop 32, Diff 35) ✅
+└── countdown timer (Pop 45, Diff 62) ⚠️
+
+Best: "interval timer", "pomodoro timer", "study timer"
+```
+
+### Category-Specific Opportunities
+
+Based on Nov 2025 App Store data:
+
+| Category | High-Opportunity Keywords |
+|----------|--------------------------|
+| Health | "ai coach", "brown noise", "pink noise" |
+| Business | "invoice", "fax", "side hustle" |
+| Utilities | "storage cleaner", "free up space" |
+| Lifestyle | "mood tracker", "gratitude journal" |
+| Music | "metronome", "tuner" |
+| Productivity | "pomodoro timer", "habit tracker" |
+
+## Competitor Keyword Analysis
+
+### Finding Keyword Gaps
+
+1. In Astro, tap on competitor apps
+2. See what keywords they rank for
+3. Find keywords where:
+   - They rank #20-50 (not optimized)
+   - You don't rank at all
+   - Pop >20, Diff <50
+
+### Steal Strategy
+
+Target keywords competitors rank for weakly:
+- Their rank: #30-100
+- Your potential: Top 10 with good ASO
+
+## Trademark Considerations
+
+### Check Before Targeting
+
+Some keywords are trademarked:
+- "Divvy" — Bill.com trademark
+- "Splitwise" — Brand name
+- "Venmo" — Brand name
+
+### Safe vs Risky Keywords
+
+| Safe (Generic) | Risky (Trademarked) |
+|----------------|-------------------|
+| split bill | splitwise |
+| expense tracker | divvy |
+| payment | venmo |
+| settle up | paypal |
+
+### Rule
+
+If a keyword shows high popularity but is a brand name:
+- Traffic is people looking for THAT app
+- Even if you rank, conversion will be poor
+- May get trademark complaint
+
+## Quick Evaluation Checklist
+
+For each keyword:
+
+- [ ] Popularity >20? (enough traffic)
+- [ ] Difficulty <60? (beatable)
+- [ ] Not a trademark/brand?
+- [ ] Relevant to your app?
+- [ ] Makes sense in title/subtitle/keywords?
+
+If all yes → Target it
+If any no → Skip or deprioritize
+
+## Keyword Tracking Template
+
+```csv
+keyword,popularity,difficulty,opportunity_score,grade,current_rank,action
+pomodoro timer,35,42,48,B,-,Target in subtitle
+study timer,28,38,38,C,-,Add to keywords
+interval timer,32,35,49,B,-,Target in title
+meditation,65,78,-31,F,-,Skip - too competitive
+```
+
+## When to Re-evaluate
+
+- **Weekly:** Check ranking changes
+- **Monthly:** Re-run opportunity analysis
+- **Quarterly:** Major keyword strategy review
+- **Seasonally:** Add seasonal keywords (holiday, summer, etc.)

--- a/.claude/skills/app-store/marketing-strategy/SKILL.md
+++ b/.claude/skills/app-store/marketing-strategy/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: marketing-strategy
+description: App Store marketing strategy advisor that analyzes your app and recommends the best promotional features. Orchestrates sub-skills for implementation. Use when planning app promotion, launch strategy, user acquisition, or re-engagement campaigns.
+allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion, WebSearch]
+---
+
+# App Store Marketing Strategy
+
+Analyzes your app's type, monetization model, audience, and lifecycle stage, then builds a tailored promotional strategy using Apple's App Store features. Calls relevant sub-skills to generate implementation code and metadata.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Asks "how should I market my app?" or "what App Store features should I use?"
+- Wants a promotional strategy for launch, growth, or re-engagement
+- Mentions "App Store promotion", "user acquisition", or "app marketing"
+- Wants to increase downloads or reduce churn
+- Asks about in-app events, custom product pages, or win-back offers
+- Is preparing for a major update or seasonal campaign
+- Wants to get featured on the App Store
+
+## Process
+
+### Phase 1: App Profile Collection
+
+Gather information via AskUserQuestion:
+
+**1. App Identity**
+- App name and one-line description
+- App Store category (primary + secondary)
+- Platform(s): iOS, macOS, iPadOS, watchOS, visionOS
+
+**2. Monetization Model**
+- Free (ad-supported)
+- Freemium (free + IAP/subscription)
+- Paid upfront
+- Subscription only
+- Free (no monetization yet)
+
+**3. Target Audience**
+- Primary demographic (age, role, context)
+- Secondary audience (if any)
+- Geographic focus
+
+**4. Lifecycle Stage**
+- Pre-launch (building / TestFlight)
+- Launch (first 30 days)
+- Growth (active, adding users)
+- Mature (stable user base, seeking retention)
+- Re-engagement (declining, need to win back users)
+
+**5. Current State**
+- Monthly active users (approximate)
+- Existing promotional features already configured
+- Upcoming updates or milestones
+- Marketing budget (none / small / moderate)
+
+### Phase 2: Strategy Analysis
+
+Read **decision-matrix.md** to map the app profile to recommended features.
+
+The decision matrix evaluates these dimensions:
+- Monetization model → Which offer types apply
+- Lifecycle stage → Which tactics are highest priority
+- App category → Which featuring angles work
+- Audience segments → Whether custom product pages help
+- Content/events → Whether in-app events fit
+- **Minimum eligibility thresholds** → Whether the app has sufficient scale for each feature
+
+**CRITICAL — Check Eligibility Before Recommending:**
+Not every feature makes sense at every scale. The decision matrix (Dimension 6) defines minimum thresholds. Features that require traffic volume (PPO, CPPs) or user base size (win-back, promotional offers) should NOT be recommended for apps below those thresholds. Instead, recommend the alternatives specified in the matrix. Always be honest about what will and won't work at the app's current scale — recommending PPO to an app with 200 impressions/month wastes their time.
+
+### Phase 3: Strategy Generation
+
+Based on the analysis, read the appropriate strategy template:
+- `strategy-templates/subscription-app.md` — For subscription-based apps
+- `strategy-templates/paid-app.md` — For paid upfront apps
+- `strategy-templates/freemium-app.md` — For freemium with IAP
+- `strategy-templates/game-app.md` — For games (any monetization)
+
+Customize the template with the app's specific details.
+
+### Phase 4: Implementation Roadmap
+
+For each recommended feature, provide:
+1. **Priority** (High / Medium / Low)
+2. **Effort** (Quick win / Moderate / Significant)
+3. **Expected impact** on the primary goal (downloads, retention, revenue)
+4. **Implementation skill** to call for code/metadata generation
+
+#### Available Sub-Skills
+
+| Feature | Generator Skill | What It Produces |
+|---------|----------------|------------------|
+| Introductory/promotional offers | `generators/subscription-offers` | StoreKit 2 offer code + eligibility |
+| Win-back campaigns | `generators/win-back-offers` | Win-back flow + Message API handling |
+| Promoted IAP on product page | `generators/promoted-iap` | StoreKit 2 promoted purchase setup |
+| In-App Events | `generators/in-app-events` | Event metadata + image specs |
+| Custom Product Pages | `generators/custom-product-pages` | Page metadata + screenshot strategy |
+| Product Page Optimization | `generators/product-page-optimization` | A/B test plan + optimization checklist |
+| App Store featuring | `generators/featuring-nomination` | Nomination form + pitch template |
+| Offer codes distribution | `generators/offer-codes-setup` | Distribution strategy + configuration |
+| Pre-launch / pre-orders | `generators/pre-orders` | Pre-order setup + launch timeline |
+| Promotional assets | `generators/app-store-assets` | Asset specs + guidelines |
+
+### Phase 5: Timeline & Calendar
+
+Build a promotional calendar based on:
+- App launch date or next update
+- Seasonal opportunities (back to school, holidays, New Year)
+- Apple events (WWDC, iPhone launch, etc.)
+- Category-specific timing (tax season for finance, January for fitness)
+
+## Output Format
+
+Present the strategy as:
+
+```markdown
+# Marketing Strategy: [App Name]
+
+## App Profile
+| Attribute | Value |
+|-----------|-------|
+| Category | [Category] |
+| Model | [Monetization model] |
+| Stage | [Lifecycle stage] |
+| Audience | [Primary audience] |
+| Platform | [Platforms] |
+
+## Strategic Goals
+1. [Primary goal based on lifecycle stage]
+2. [Secondary goal]
+3. [Tertiary goal]
+
+## Recommended Features (Eligible Now)
+
+### 🔴 High Priority
+
+#### [Feature Name]
+- **Why**: [Rationale for this app]
+- **Effort**: [Quick win / Moderate / Significant]
+- **Impact**: [Expected outcome]
+- **Skill**: `generators/[skill-name]`
+- **Action**: [Specific next step]
+
+### 🟠 Medium Priority
+[Same format]
+
+### 🟢 Nice to Have
+[Same format]
+
+## Not Yet Recommended (Scale Thresholds Not Met)
+
+| Feature | Minimum Needed | Your Current Level | When to Revisit |
+|---------|---------------|-------------------|-----------------|
+| [Feature] | [Threshold] | [Current metric] | [Milestone to hit] |
+
+> These features will become effective once you reach the indicated thresholds.
+> Focus on the eligible features above to grow toward these milestones.
+
+## Promotional Calendar
+
+| Month | Action | Feature | Notes |
+|-------|--------|---------|-------|
+| [M1] | [Action] | [Feature] | [Context] |
+| [M2] | [Action] | [Feature] | [Context] |
+
+## Implementation Order
+
+1. **Week 1-2**: [First actions — quick wins]
+2. **Week 3-4**: [Second wave — moderate effort]
+3. **Month 2**: [Bigger initiatives]
+4. **Ongoing**: [Recurring activities]
+
+## Revenue Impact Estimate
+
+| Feature | Estimated Lift | Confidence |
+|---------|---------------|------------|
+| [Feature] | [+X% downloads / -X% churn] | [High/Medium/Low] |
+
+## Next Steps
+1. [Immediate action item]
+2. [Call specific generator skill]
+3. [Prepare specific asset or metadata]
+```
+
+## Strategy Examples
+
+### Example: Speech Therapy App (Subscription, Growth Stage)
+**Profile**: Blow Quest, freemium + subscription, targeting parents of kids in speech therapy
+**Recommended**:
+- 🔴 In-App Events → Weekly breath challenges to drive engagement
+- 🔴 Custom Product Pages → One for parents, one for SLPs (speech-language pathologists)
+- 🟠 Win-Back Offers → Re-engage churned subscribers with 50% off
+- 🟠 Featuring Nomination → Accessibility + Health angle
+- 🟢 Promoted IAP → Show subscription on product page
+- 🟢 Offer Codes → Partner with SLP clinics for distribution
+
+### Example: Watch Meditation App (Subscription, Launch Stage)
+**Profile**: ChantFlow, Apple Watch, paid + subscription, meditation
+**Recommended**:
+- 🔴 Introductory Offer → 7-day free trial for subscription
+- 🔴 App Store Assets → watchOS screenshots + short-form video
+- 🟠 Product Page Optimization → A/B test meditation vs. mindfulness positioning
+- 🟠 Featuring Nomination → Mindfulness + Apple Watch angle
+- 🟢 Pre-Orders → Build anticipation before major update
+- 🟢 In-App Events → Monthly meditation challenges
+
+### Example: Productivity App (Freemium, Mature Stage)
+**Profile**: TaskFlow, freemium with premium unlock, 50K MAU, stable
+**Recommended**:
+- 🔴 Win-Back Offers → Re-engage lapsed premium users
+- 🔴 Product Page Optimization → Test benefit-led vs. feature-led screenshots
+- 🟠 Custom Product Pages → Pages for students, freelancers, teams
+- 🟠 In-App Events → Productivity Week challenge (January)
+- 🟢 Offer Codes → Influencer/reviewer distribution
+- 🟢 Promotional Offers → Loyalty discount for long-term free users
+
+## References
+
+- **decision-matrix.md** — Feature recommendation logic by app attributes
+- **strategy-templates/** — Monetization-specific strategy playbooks
+- Related: `app-store/keyword-optimizer` — ASO keyword strategy
+- Related: `app-store/app-description-writer` — Product page copy
+- Related: `app-store/screenshot-planner` — Screenshot sequences
+- Related: `monetization` — Pricing and tier strategy

--- a/.claude/skills/app-store/marketing-strategy/decision-matrix.md
+++ b/.claude/skills/app-store/marketing-strategy/decision-matrix.md
@@ -1,0 +1,338 @@
+# Marketing Strategy Decision Matrix
+
+Rules engine that maps app attributes to recommended App Store promotional features.
+
+## How to Use This Matrix
+
+1. Identify the app's monetization model, lifecycle stage, and category
+2. Look up each dimension in the tables below
+3. Combine recommendations — features appearing in multiple dimensions get higher priority
+4. Apply the priority scoring at the bottom
+
+---
+
+## Dimension 1: Monetization Model → Features
+
+### Subscription Apps
+| Feature | Relevance | Rationale |
+|---------|-----------|-----------|
+| Introductory Offers | **Essential** | Free trial or discounted first period drives conversion |
+| Promotional Offers | **Essential** | Re-engage subscribers at risk of churning |
+| Win-Back Offers | **Essential** | Recover churned subscribers with targeted pricing |
+| Offer Codes | **High** | Partner distribution, influencer campaigns |
+| Promoted IAP | **High** | Show subscription directly on product page |
+| In-App Events | **High** | Drive engagement that justifies subscription value |
+| Custom Product Pages | **Medium** | Different pages for different user segments |
+| Product Page Optimization | **Medium** | Test messaging that drives subscription conversion |
+| Featuring Nomination | **Medium** | Increased visibility for subscriber acquisition |
+| Pre-Orders | **Low** | Only for major version launches |
+
+### Paid Upfront Apps
+| Feature | Relevance | Rationale |
+|---------|-----------|-----------|
+| Product Page Optimization | **Essential** | Every visitor must convert — optimize the page |
+| Custom Product Pages | **High** | Tailor messaging to different ad campaigns |
+| Featuring Nomination | **High** | Paid apps benefit enormously from editorial features |
+| In-App Events | **Medium** | Content updates give reasons to buy |
+| App Store Assets | **Medium** | Premium presentation justifies premium price |
+| Pre-Orders | **Medium** | Build anticipation, lock in early buyers |
+| Promotional Offers | **N/A** | No subscription to discount |
+| Win-Back Offers | **N/A** | No subscription to win back |
+
+### Freemium Apps (IAP)
+| Feature | Relevance | Rationale |
+|---------|-----------|-----------|
+| Promoted IAP | **Essential** | Show premium unlock on the product page |
+| Product Page Optimization | **Essential** | Optimize for download (first conversion) |
+| Custom Product Pages | **High** | Different pages for different user types |
+| In-App Events | **High** | Events drive engagement → IAP conversion |
+| Featuring Nomination | **Medium** | Volume-based — more downloads = more IAP |
+| Offer Codes | **Medium** | Premium feature trials for hesitant users |
+| App Store Assets | **Medium** | Showcase premium features in screenshots |
+| Pre-Orders | **Low** | Only for major launches |
+
+### Free (Ad-Supported)
+| Feature | Relevance | Rationale |
+|---------|-----------|-----------|
+| Product Page Optimization | **Essential** | Maximize download volume for ad revenue |
+| In-App Events | **Essential** | Drive engagement = more ad impressions |
+| Custom Product Pages | **High** | Maximize conversions from different sources |
+| Featuring Nomination | **High** | Volume is everything for ad-supported |
+| App Store Assets | **Medium** | Attractive product page drives downloads |
+| Pre-Orders | **Low** | Rarely needed for free apps |
+
+---
+
+## Dimension 2: Lifecycle Stage → Priority Tactics
+
+### Pre-Launch
+| Priority | Tactic | Action |
+|----------|--------|--------|
+| 🔴 High | Pre-Orders | Set up pre-order page to build anticipation |
+| 🔴 High | App Store Assets | Prepare all screenshots, previews, descriptions |
+| 🔴 High | Product Page Optimization | Have initial page ready, plan A/B tests for post-launch |
+| 🟠 Medium | Featuring Nomination | Submit 6-8 weeks before launch |
+| 🟠 Medium | Custom Product Pages | Prepare pages for different launch campaigns |
+| 🟢 Low | In-App Events | Plan launch event for Day 1 |
+
+### Launch (First 30 Days)
+| Priority | Tactic | Action |
+|----------|--------|--------|
+| 🔴 High | Product Page Optimization | Start A/B testing immediately |
+| 🔴 High | Introductory Offers | Launch with free trial or discounted period |
+| 🔴 High | In-App Events | Launch celebration event |
+| 🟠 Medium | Promoted IAP | Configure promoted purchases |
+| 🟠 Medium | Custom Product Pages | Deploy campaign-specific pages |
+| 🟠 Medium | Featuring Nomination | Follow up on nomination |
+
+### Growth (Active, Adding Users)
+| Priority | Tactic | Action |
+|----------|--------|--------|
+| 🔴 High | Product Page Optimization | Continuous A/B testing |
+| 🔴 High | Custom Product Pages | Pages per audience segment |
+| 🔴 High | In-App Events | Regular events to sustain engagement |
+| 🟠 Medium | Promotional Offers | Convert long-term free users |
+| 🟠 Medium | Offer Codes | Partner and influencer distribution |
+| 🟠 Medium | Featuring Nomination | Nominate for category features |
+| 🟢 Low | App Store Assets | Refresh for seasonal relevance |
+
+### Mature (Stable Base, Seeking Retention)
+| Priority | Tactic | Action |
+|----------|--------|--------|
+| 🔴 High | Win-Back Offers | Re-engage churned subscribers |
+| 🔴 High | Promotional Offers | Loyalty rewards for at-risk users |
+| 🔴 High | In-App Events | Fresh content to re-engage existing users |
+| 🟠 Medium | Product Page Optimization | Test retention-focused messaging |
+| 🟠 Medium | Custom Product Pages | Pages for re-engagement campaigns |
+| 🟢 Low | Offer Codes | Win-back distribution via email |
+
+### Re-Engagement (Declining, Need Win-Back)
+| Priority | Tactic | Action |
+|----------|--------|--------|
+| 🔴 High | Win-Back Offers | Aggressive pricing to recover users |
+| 🔴 High | In-App Events | Major event to signal the app is alive |
+| 🔴 High | Promotional Offers | Deep discounts for lapsed subscribers |
+| 🟠 Medium | Offer Codes | Distribute via email to churned users |
+| 🟠 Medium | Product Page Optimization | Test new positioning |
+| 🟠 Medium | Featuring Nomination | "What's New" angle for major update |
+| 🟢 Low | Custom Product Pages | New pages for repositioned app |
+
+---
+
+## Dimension 3: App Category → Featuring Angles
+
+### Health & Fitness
+- **Strong angles**: Accessibility, mental health, physical wellness, health records integration
+- **Seasonal peaks**: January (New Year), September (back to routine)
+- **Apple tie-ins**: HealthKit, Apple Watch, Activity Rings
+- **Event ideas**: Weekly challenges, monthly fitness goals, wellness weeks
+
+### Education & Kids
+- **Strong angles**: Learning innovation, child safety, inclusive design
+- **Seasonal peaks**: August-September (back to school), January
+- **Apple tie-ins**: Schoolwork, Classroom, Apple Pencil
+- **Event ideas**: Learning challenges, subject-specific events, quiz competitions
+
+### Productivity
+- **Strong angles**: Workflow innovation, Apple ecosystem integration, accessibility
+- **Seasonal peaks**: January (organization), September (planning)
+- **Apple tie-ins**: Shortcuts, Widgets, Focus modes, Apple Intelligence
+- **Event ideas**: Productivity weeks, Getting Things Done challenges
+
+### Finance
+- **Strong angles**: Financial literacy, privacy-first design, simplicity
+- **Seasonal peaks**: January (budgeting), April (tax season), year-end
+- **Apple tie-ins**: Apple Pay, FinanceKit
+- **Event ideas**: Savings challenges, tax prep events, budget reviews
+
+### Creative / Photo & Video
+- **Strong angles**: Creative tools, artistic expression, Apple Silicon optimization
+- **Seasonal peaks**: Holiday content creation, summer travel
+- **Apple tie-ins**: Apple Pencil, ProRes, Cinematic mode, Vision Pro
+- **Event ideas**: Creative challenges, themed editing events
+
+### Games
+- **Strong angles**: Innovative gameplay, Apple Arcade consideration, game design
+- **Seasonal peaks**: Holiday season, summer, game award season
+- **Apple tie-ins**: Game Center, Metal, Spatial Audio, Game controllers
+- **Event ideas**: Tournaments, seasonal content, limited-time modes
+
+### Social & Communication
+- **Strong angles**: Community building, privacy, inclusive design
+- **Seasonal peaks**: Varies by focus
+- **Apple tie-ins**: SharePlay, Messages extensions, CallKit
+- **Event ideas**: Community challenges, connection events
+
+### Developer Tools
+- **Strong angles**: Innovation, workflow improvement, Apple platform support
+- **Seasonal peaks**: WWDC (June), September (new OS releases)
+- **Apple tie-ins**: Xcode integration, Swift, Apple APIs
+- **Event ideas**: API workshops, tool release events
+
+---
+
+## Dimension 4: Audience Segments → Custom Product Pages
+
+If the app serves multiple distinct audiences, recommend Custom Product Pages.
+
+### Strong CPP Candidates (create pages)
+- App serves both consumers and professionals (e.g., fitness app for users + trainers)
+- App targets different age groups with different value props
+- App solves different problems for different roles (e.g., note app for students vs. writers)
+- Running paid campaigns on multiple channels with different messaging
+
+### Weak CPP Candidates (skip)
+- Single, focused audience
+- Consistent value proposition across all users
+- No paid acquisition campaigns
+- Very niche app with homogeneous user base
+
+### CPP Strategy by Segment Count
+| Segments | Recommendation |
+|----------|---------------|
+| 1 | Skip CPPs, optimize default page |
+| 2 | Create 1 CPP for secondary audience |
+| 3+ | Create 2-3 CPPs, allocate by traffic source |
+
+---
+
+## Dimension 5: Content & Engagement → In-App Events
+
+### Strong Event Candidates
+- App has recurring engagement loops (daily/weekly activities)
+- Content updates or seasonal themes
+- Community challenges or social features
+- Educational milestones or course completions
+- Health/fitness goal tracking
+
+### Event Frequency by App Type
+| App Type | Recommended Frequency | Event Style |
+|----------|----------------------|-------------|
+| Fitness/Health | Weekly or biweekly | Challenges, goals |
+| Education | Monthly | Learning milestones, quiz events |
+| Games | Weekly | Tournaments, limited content |
+| Productivity | Monthly or quarterly | Themed events, feature highlights |
+| Creative | Monthly | Creative challenges, themed packs |
+| Social | Biweekly | Community events, connection drives |
+
+---
+
+## Dimension 6: Minimum Eligibility Thresholds
+
+**IMPORTANT**: Not every feature makes sense for every app. Below certain thresholds, the effort outweighs the benefit or the feature literally can't produce results. Always check these minimums before recommending a feature.
+
+### Traffic-Dependent Features
+
+| Feature | Minimum Threshold | Below Threshold | Alternative |
+|---------|-------------------|-----------------|-------------|
+| **Product Page Optimization** | ~1,000 impressions/week | Tests never reach statistical significance; you'll wait months for inconclusive results | Make qualitative improvements directly — follow screenshot best practices, don't A/B test |
+| **Custom Product Pages** | ~5,000 impressions/month | Not enough traffic per page to measure effectiveness; splits your already-thin traffic further | Optimize your single default page first; only create CPPs when you have volume to split |
+| **Product Page Optimization + CPP combo** | ~10,000 impressions/month | Can't run PPO tests on individual CPPs meaningfully | Focus on PPO for default page only, add CPPs later |
+
+### User-Base-Dependent Features
+
+| Feature | Minimum Threshold | Below Threshold | Alternative |
+|---------|-------------------|-----------------|-------------|
+| **Win-Back Offers** | ~100+ churned subscribers | Setup effort (code + ASC configuration) not justified for a handful of recoverable users | Focus on preventing churn instead; use personal email outreach for small numbers |
+| **Promotional Offers** | Active subscriber base with measurable churn risk | No at-risk subscribers to target | Focus on acquisition (introductory offers) first |
+| **Offer Codes (email campaigns)** | Email list of 200+ users | Response rates on small lists don't justify campaign setup | Use codes for individual outreach (influencers, partners) instead |
+
+### No Real Minimum (Do These Regardless of Size)
+
+| Feature | Why No Minimum | When to Start |
+|---------|----------------|---------------|
+| **Introductory Offers** | Zero-effort setup in ASC; directly increases trial conversion | Day 1 for any subscription app |
+| **In-App Events** | Increases discoverability even for tiny apps; events surface your app to new users in Browse and Search | As soon as you have content or features to highlight |
+| **Featuring Nomination** | Free to submit; even small apps get featured if quality and timing align | When your app is polished and you have a compelling angle |
+| **Promoted IAP** | Simple ASC configuration; shows purchase option on product page at no cost | As soon as you have IAP configured |
+| **App Store Assets** | Better assets = better conversion regardless of traffic volume | Before launch; refresh regularly |
+| **Pre-Orders** | Accumulates downloads before launch; works even with tiny audience | If you have any marketing channel to announce it |
+
+### The Scale Ladder
+
+As your app grows, unlock features in this order:
+
+```
+ANY SIZE (0+ users)
+├── Introductory Offers
+├── In-App Events
+├── Featuring Nomination
+├── Promoted IAP
+├── App Store Assets
+├── Pre-Orders (if launching)
+│
+SMALL (100-1K MAU)
+├── Offer Codes (influencer/partner only)
+├── Win-Back Offers (if 100+ churned)
+│
+MEDIUM (1K-10K MAU)
+├── Custom Product Pages (if running ads)
+├── Offer Codes (email campaigns)
+├── Promotional Offers
+│
+LARGE (10K+ MAU)
+├── Product Page Optimization (A/B testing)
+├── Custom Product Pages (multi-segment)
+├── Full offer stack (intro + promo + win-back + codes)
+│
+SCALE (50K+ MAU)
+├── PPO on individual CPPs
+├── Multiple concurrent campaigns
+├── Advanced offer segmentation
+```
+
+### Effort vs. Impact by App Size
+
+| Feature | Setup Effort | Small App Impact | Large App Impact |
+|---------|-------------|-----------------|-----------------|
+| Introductory Offers | Low | High | High |
+| In-App Events | Medium | Medium | High |
+| Featuring Nomination | Low | High (if featured) | High (if featured) |
+| Promoted IAP | Low | Low-Medium | Medium |
+| App Store Assets | Medium | Medium | Medium |
+| Product Page Optimization | Medium | **Too small to test** | High |
+| Custom Product Pages | Medium-High | **Not enough traffic** | High |
+| Win-Back Offers | High | **Not enough churn volume** | High |
+| Promotional Offers | Medium | Low (few targets) | High |
+| Offer Codes | Low-Medium | Low (limited reach) | Medium-High |
+| Pre-Orders | Low | Low-Medium | Medium |
+
+---
+
+## Priority Scoring
+
+After evaluating all dimensions, score each feature:
+
+| Score | Criteria | Priority |
+|-------|----------|----------|
+| 4-5 | Appears as Essential/High in 3+ dimensions | 🔴 High — implement first |
+| 2-3 | Appears as Essential/High in 1-2 dimensions | 🟠 Medium — implement second |
+| 0-1 | Appears as Medium/Low or N/A in most dimensions | 🟢 Nice to Have — implement if time permits |
+
+### Tiebreakers
+When two features score equally:
+1. **Prefer quick wins** (less effort for same impact)
+2. **Prefer revenue-impacting** (offers > engagement features)
+3. **Prefer compounding** (features that improve over time, like PPO)
+4. **Prefer seasonal alignment** (features that match upcoming timing)
+
+---
+
+## Feature Dependency Map
+
+Some features work best in combination:
+
+```
+Introductory Offers ──→ Promotional Offers ──→ Win-Back Offers
+(acquire)              (retain)                (recover)
+
+Product Page Optimization ──→ Custom Product Pages
+(optimize default)            (multiply what works)
+
+In-App Events + Promotional Offers = Re-engagement campaign
+In-App Events + Custom Product Pages = Targeted acquisition
+Featuring Nomination + In-App Events = Maximum visibility
+Offer Codes + Win-Back Offers = Email re-engagement campaign
+```
+
+Build the full acquisition-retention-recovery funnel before optimizing individual pieces.

--- a/.claude/skills/app-store/marketing-strategy/strategy-templates/freemium-app.md
+++ b/.claude/skills/app-store/marketing-strategy/strategy-templates/freemium-app.md
@@ -1,0 +1,161 @@
+# Strategy Template: Freemium Apps (IAP)
+
+Playbook for free apps that monetize through non-consumable or consumable in-app purchases.
+
+## Core Strategy: Volume + Conversion
+
+Freemium apps need two funnels: maximize downloads (free), then convert free users to paying users. App Store features serve both goals.
+
+```
+ACQUIRE → ENGAGE → UPGRADE → EXPAND → RE-ENGAGE
+    ↑        ↑        ↑         ↑          ↑
+    |        |        |         |          |
+   PPO    Events   Promoted   Offer     Offer
+   CPP    Content    IAP      Codes     Codes
+  Feat.   Onboard  Paywall   Bundles   Events
+```
+
+---
+
+## Stage 1: Acquire (Maximize Downloads)
+
+### Key Features
+- **Product Page Optimization**: Optimize for download rate (low commitment)
+- **Custom Product Pages**: Per ad campaign / audience segment
+- **Featuring Nomination**: Free apps with IAP are Apple's bread and butter
+
+### Freemium Product Page Strategy
+- **DO** lead with free value — what users get without paying
+- **DON'T** lead with premium features (scares off downloads)
+- Show the app is fully functional for free, with premium as "more"
+
+### Screenshot Strategy
+1. **Screenshot 1**: Core free experience (compelling, complete)
+2. **Screenshot 2-3**: Key free features in action
+3. **Screenshot 4**: Premium features preview ("Unlock Pro")
+4. **Screenshot 5**: Social proof or breadth of features
+
+---
+
+## Stage 2: Engage (Build Investment)
+
+### Key Features
+- **In-App Events**: Regular challenges/content that get free users invested
+- **Push Notifications**: Re-engagement (not an App Store feature, but critical)
+
+### Engagement Before Monetization
+Users must invest time and data before seeing a paywall:
+- **Productivity apps**: Let them create 5+ items before suggesting premium
+- **Creative apps**: Let them complete one project, then offer premium exports
+- **Utility apps**: Let them use core function 10+ times before limits
+- **Content apps**: Give generous free content, then gate advanced/new content
+
+### Event Strategy for Freemium
+| Event Type | Goal | Frequency |
+|-----------|------|-----------|
+| Challenge/competition | Create engagement habit | Weekly/biweekly |
+| Content update | Show app is actively developed | Monthly |
+| Feature spotlight | Showcase premium features organically | Monthly |
+| Community event | Build social investment | Quarterly |
+
+---
+
+## Stage 3: Upgrade (Free → Paid)
+
+### Key Features
+- **Promoted IAP**: Show premium unlock directly on the App Store product page
+- **Paywall Design**: Use `generators/paywall-generator`
+
+### Promoted IAP Best Practices
+- Choose your most compelling IAP to promote (usually "Pro" or "Premium" unlock)
+- Use a clear, benefit-focused name ("Pro — Unlimited Everything")
+- Set an attractive promotional image (1024x1024)
+- This appears on your product page and in search results
+
+### Conversion Trigger Points
+Show upgrade prompt when the user:
+- Hits a free tier limit ("You've used 5 of 5 free projects")
+- Tries to access a premium feature
+- Completes a successful action (positive emotion = higher conversion)
+- Has used the app for 7+ days (investment threshold)
+
+### Pricing for IAP
+| IAP Type | Price Range | Strategy |
+|----------|-------------|----------|
+| Feature unlock | $2.99-$9.99 | One-time, permanent |
+| Pro bundle | $9.99-$29.99 | Unlock everything |
+| Content pack | $0.99-$4.99 | Per pack, expandable |
+| Consumable credits | $0.99-$9.99 | Recurring revenue |
+| Tip jar | $0.99-$9.99 | Optional support |
+
+---
+
+## Stage 4: Expand (Increase Revenue per User)
+
+### Key Features
+- **Offer Codes**: Give premium access to influencers/partners for promotion
+- **Additional IAP**: Upsell existing premium users on add-ons
+
+### Expansion Revenue Tactics
+1. **Content packs**: New themes, templates, tools for existing premium users
+2. **Feature add-ons**: Specialized features beyond the core premium unlock
+3. **Tip jar**: Let satisfied users pay more voluntarily
+4. **Bundle pricing**: "All-in-one" bundle at discount vs. individual purchases
+
+---
+
+## Stage 5: Re-Engage (Bring Back Lapsed Users)
+
+### Key Features
+- **Offer Codes**: Distribute premium access to lapsed users via email
+- **In-App Events**: Major events visible to lapsed users in App Store
+
+### Re-Engagement Timeline
+| Days Lapsed | Action | Method |
+|-------------|--------|--------|
+| 7-14 | Push notification with new content | Notification |
+| 14-30 | In-App Event announcement | App Store |
+| 30-60 | Offer code for free premium trial | Email |
+| 60+ | Major update In-App Event | App Store |
+
+---
+
+## Freemium App Checklist
+
+### Pre-Launch
+- [ ] Define free vs. paid feature split (generous free tier)
+- [ ] Configure IAP products in App Store Connect
+- [ ] Set up Promoted IAP with promotional image
+- [ ] Write product page copy emphasizing free value
+- [ ] Plan launch In-App Event
+
+### Launch
+- [ ] Start Product Page Optimization test
+- [ ] Monitor download-to-IAP conversion funnel
+- [ ] Create Custom Product Pages for different ad sets
+- [ ] Submit featuring nomination
+
+### Growth
+- [ ] Establish In-App Event cadence (weekly or biweekly)
+- [ ] Distribute offer codes to app reviewers/influencers
+- [ ] A/B test paywall timing and messaging
+- [ ] Create Custom Product Pages per audience segment
+- [ ] Plan seasonal expansion content
+
+### Ongoing
+- [ ] Quarterly featuring nominations
+- [ ] Regular content/feature updates
+- [ ] PPO tests running continuously
+- [ ] Offer code campaigns for re-engagement
+
+---
+
+## Freemium App Benchmarks
+
+| Metric | Below Average | Average | Good | Excellent |
+|--------|--------------|---------|------|-----------|
+| Page → Download | < 20% | 20-35% | 35-50% | > 50% |
+| D1 retention | < 25% | 25-35% | 35-50% | > 50% |
+| Free → Paid | < 2% | 2-5% | 5-10% | > 10% |
+| ARPU (monthly) | < $0.05 | $0.05-0.20 | $0.20-1.00 | > $1.00 |
+| IAP refund rate | > 8% | 4-8% | 2-4% | < 2% |

--- a/.claude/skills/app-store/marketing-strategy/strategy-templates/game-app.md
+++ b/.claude/skills/app-store/marketing-strategy/strategy-templates/game-app.md
@@ -1,0 +1,200 @@
+# Strategy Template: Game Apps
+
+Playbook for games of any monetization model (free-to-play, premium, subscription).
+
+## Core Strategy: Live Ops + Event-Driven Growth
+
+Games have unique advantages on the App Store: In-App Events are a natural fit, seasonal content creates recurring visibility, and the competitive/social nature drives organic sharing.
+
+```
+SOFT LAUNCH → LAUNCH → LIVE OPS → SEASONAL → RE-ENGAGEMENT
+      ↑          ↑         ↑          ↑            ↑
+      |          |         |          |            |
+   Pre-Order  Featuring  Events    Events       Win-back
+   Assets     PPO/CPP    Content   CPP/PPO      Offers
+   TestFlight Offers     Updates   Featuring    Events
+```
+
+---
+
+## Stage 1: Soft Launch / Pre-Launch
+
+### Key Features
+- **Pre-Orders**: Build anticipation, collect early commitments
+- **App Store Assets**: Game trailers and screenshots that show gameplay
+- **Featuring Nomination**: Submit early — game features are planned months ahead
+
+### Game-Specific Pre-Launch Tactics
+1. **App Preview video** is essential for games (show gameplay, not cinematics)
+2. **Pre-order with a bonus** ("Download on day 1 for exclusive character/skin")
+3. **TestFlight beta** builds community before launch
+4. **Social media teasers** linked to pre-order page
+
+---
+
+## Stage 2: Launch
+
+### Key Features
+- **Featuring Nomination**: "New Game" placement is the most valuable launch asset
+- **Product Page Optimization**: Test action-focused vs. story-focused screenshots
+- **Custom Product Pages**: One for casual gamers, one for hardcore
+- **Introductory Offers**: Free trial for subscription games, launch price for premium
+
+### Launch In-App Event
+Create a "Launch Celebration" event:
+- **Badge**: Challenge
+- **Duration**: 7-14 days
+- **Content**: Limited-time launch reward/level/character
+- **Purpose**: Creates urgency and drives first-week engagement
+
+### Launch Week Checklist
+- [ ] Featuring nomination submitted 8+ weeks ago
+- [ ] In-App Event "Launch Celebration" configured
+- [ ] App preview video finalized
+- [ ] Custom Product Pages ready for ad campaigns
+- [ ] Product Page Optimization test prepared
+- [ ] Social media launch kit ready
+
+---
+
+## Stage 3: Live Ops (Ongoing Engagement)
+
+### Key Features
+- **In-App Events**: The backbone of game marketing — run events constantly
+- **Content Updates**: New levels, characters, modes keep the game fresh
+
+### Event Calendar Template
+| Week | Event Type | Example |
+|------|-----------|---------|
+| 1 | Weekly challenge | "Speed Run Week — best times win rewards" |
+| 2 | New content | "New level pack available" |
+| 3 | Community event | "Community goal: 1M total points" |
+| 4 | Themed event | "Month-end tournament" |
+
+### Event Types for Games
+| Badge Type | Use For | Duration |
+|------------|---------|----------|
+| Challenge | Skill-based competitions | 3-7 days |
+| Competition | Leaderboard events | 7-14 days |
+| Live Event | Real-time multiplayer events | 1-3 days |
+| Special Event | Content updates, new modes | 7-14 days |
+| Major Update | Big feature releases | 7 days |
+
+### Content Update Rhythm
+| Frequency | Content | Goal |
+|-----------|---------|------|
+| Weekly | Challenges, leaderboard resets | Maintain daily engagement |
+| Biweekly | Mini content drops (cosmetics, items) | Sustain interest |
+| Monthly | New levels, characters, or modes | Major engagement spike |
+| Quarterly | Major update (new game mode, story chapter) | Press coverage, featuring |
+
+---
+
+## Stage 4: Seasonal Campaigns
+
+### Key Features
+- **In-App Events**: Themed seasonal events with limited-time content
+- **Custom Product Pages**: Seasonal screenshots and messaging
+- **Product Page Optimization**: Test seasonal vs. evergreen positioning
+- **Featuring Nomination**: Seasonal featuring opportunities
+
+### Game Seasonal Calendar
+| Month | Theme | Event Ideas |
+|-------|-------|-------------|
+| January | New Year | "New Year's Challenge", resolution-themed content |
+| February | Valentine's | Co-op events, love-themed content |
+| March-April | Spring | Easter egg hunt, spring renewal themes |
+| May-June | Summer kickoff | Summer tournament, vacation themes |
+| June | WWDC | Highlight any new Apple tech integration |
+| July-August | Summer | Beach/summer events, kid-friendly campaigns |
+| September | Back to school | Learning-themed content, new season |
+| October | Halloween | Spooky content, costume events |
+| November | Thanksgiving | Gratitude events, Black Friday deals |
+| December | Holiday | Winter wonderland, gift-giving events |
+
+---
+
+## Stage 5: Re-Engagement
+
+### Key Features
+- **Win-Back Offers**: For subscription games — recover churned players
+- **In-App Events**: "Return Event" with generous rewards for lapsed players
+- **Offer Codes**: Distribute premium currency/items to lapsed players
+- **Promotional Offers**: Discounted subscription renewal
+
+### Lapsed Player Re-Engagement
+| Player Type | Strategy | Offer |
+|------------|----------|-------|
+| Churned subscriber (< 30 days) | Win-back offer | 50% off first month back |
+| Churned subscriber (30-90 days) | Email + offer code | Free month |
+| Lapsed free player (< 30 days) | Push notification | New content announcement |
+| Lapsed free player (30+ days) | In-App Event | "Welcome Back" event with bonus rewards |
+| Whale (high spender) who churned | Personal email + generous offer | VIP treatment |
+
+---
+
+## Monetization-Specific Game Tactics
+
+### Free-to-Play (IAP)
+- **Promoted IAP**: Starter pack or best-value currency bundle
+- **Offer Codes**: Premium currency for influencer giveaways
+- **In-App Events**: Events that organically expose premium items
+- First-purchase discount (e.g., "Starter Pack — 5x value!")
+
+### Premium (Paid Upfront)
+- **Price drops**: Timed with seasonal events and In-App Events
+- **App Preview**: Must show actual gameplay (not cinematics)
+- **Featuring**: Premium games get strong editorial consideration
+- No dark patterns needed — premium game buyers are loyal
+
+### Subscription (Game Pass / Season Pass)
+- **Introductory Offer**: Free trial of 3-7 days
+- **Win-Back Offers**: Essential for subscriber recovery
+- **In-App Events**: Show subscribers get exclusive event content
+- **Promotional Offers**: Season pass discounts between seasons
+
+---
+
+## Game App Checklist
+
+### Pre-Launch
+- [ ] App Preview video showing actual gameplay (15-30 sec)
+- [ ] Pre-Order configured with launch bonus
+- [ ] Featuring nomination submitted 8+ weeks before launch
+- [ ] Custom Product Pages for casual vs. hardcore positioning
+- [ ] Launch In-App Event configured
+- [ ] Product Page Optimization test ready
+
+### Launch Month
+- [ ] Monitor download velocity and featuring placement
+- [ ] Start PPO tests after first week
+- [ ] Launch "Welcome Event" In-App Event
+- [ ] Respond to all reviews (especially negative ones)
+- [ ] Submit follow-up featuring nomination for updates
+
+### Live Ops Phase
+- [ ] Weekly In-App Events running
+- [ ] Monthly content updates planned 2 months ahead
+- [ ] Seasonal event calendar planned for the quarter
+- [ ] Custom Product Pages updated for seasonal themes
+- [ ] Regular featuring nomination submissions
+
+### Ongoing
+- [ ] PPO tests running continuously
+- [ ] Win-back pipeline active (if subscription)
+- [ ] Offer code campaigns for content creators
+- [ ] Quarterly major content update with featuring push
+
+---
+
+## Game Benchmarks
+
+| Metric | Below Average | Average | Good | Excellent |
+|--------|--------------|---------|------|-----------|
+| D1 retention | < 25% | 25-35% | 35-45% | > 45% |
+| D7 retention | < 8% | 8-15% | 15-25% | > 25% |
+| D30 retention | < 3% | 3-7% | 7-12% | > 12% |
+| ARPDAU (F2P) | < $0.03 | $0.03-0.10 | $0.10-0.30 | > $0.30 |
+| Payer conversion | < 1% | 1-3% | 3-7% | > 7% |
+| Session length | < 3 min | 3-8 min | 8-15 min | > 15 min |
+| Sessions/day | < 1.5 | 1.5-3 | 3-5 | > 5 |

--- a/.claude/skills/app-store/marketing-strategy/strategy-templates/paid-app.md
+++ b/.claude/skills/app-store/marketing-strategy/strategy-templates/paid-app.md
@@ -1,0 +1,141 @@
+# Strategy Template: Paid Upfront Apps
+
+Playbook for apps with a one-time purchase price.
+
+## Core Strategy: Maximize Perceived Value
+
+Paid apps face a unique challenge: every product page visitor must be convinced to pay before trying. The entire strategy centers on making the value proposition so clear that the price feels like a bargain.
+
+```
+DISCOVER → EVALUATE → PURCHASE → ADVOCATE
+    ↑          ↑          ↑          ↑
+    |          |          |          |
+ Featuring   PPO       Assets    Reviews
+ Events     CPP       Preview    Events
+            Desc.     Price      Updates
+```
+
+---
+
+## Stage 1: Discover (Visibility)
+
+### Key Features
+- **Featuring Nomination**: Paid apps get outsized benefit from featuring (high-quality users who pay for apps browse editorial)
+- **In-App Events**: Content updates give new reasons to be visible in search/browse
+- **App Store Assets**: Premium visual presentation signals premium quality
+
+### Paid App Advantage
+Apple editorially features paid apps more willingly — they indicate a healthy ecosystem. Lean into this with strong nomination pitches.
+
+---
+
+## Stage 2: Evaluate (Product Page Conversion)
+
+### Key Features
+- **Product Page Optimization**: Critical — you have one shot to convert
+- **Custom Product Pages**: Match messaging to traffic source
+- **App Store Description**: Must clearly justify the price
+
+### Screenshot Strategy for Paid Apps
+1. **Screenshot 1**: Core benefit + "one-time purchase" badge
+2. **Screenshot 2**: Main feature in action
+3. **Screenshot 3**: Depth of features
+4. **Screenshot 4**: Design quality / polish
+5. **Screenshot 5**: Social proof or awards
+
+### Description Strategy
+- Lead with the problem you solve
+- Emphasize "no subscriptions, no ads — one purchase, everything included"
+- Include a feature list that makes the price feel like a steal
+- Mention update history ("regularly updated since 20XX")
+
+### Pricing Strategy
+| Price Point | Positioning | Best For |
+|-------------|-------------|----------|
+| $0.99-$2.99 | Impulse buy | Utilities, simple tools |
+| $3.99-$9.99 | Considered purchase | Feature-rich apps |
+| $9.99-$29.99 | Professional tool | Pro creative/productivity |
+| $29.99+ | Premium/niche | Specialized professional tools |
+
+---
+
+## Stage 3: Purchase (Conversion Optimization)
+
+### Key Features
+- **App Preview Video**: 15-30 second video showing the app in action
+- **Promotional Pricing**: Temporary price drops for seasonal campaigns
+
+### Price Drop Campaigns
+Use temporary price reductions strategically:
+
+| Occasion | Duration | Discount | Notes |
+|----------|----------|----------|-------|
+| Launch week | 7 days | 30-50% off | "Launch price" creates urgency |
+| Major update | 3-7 days | 20-30% off | Celebrate new features |
+| Holiday/seasonal | 7-14 days | 30-50% off | Black Friday, back to school |
+| Anniversary | 3-7 days | 40-50% off | App birthday celebration |
+
+### Price Drop + In-App Event Combo
+Pair every price drop with an In-App Event:
+- Event makes the price drop visible on the App Store
+- Creates a time-limited urgency signal
+- Attracts deal-seeking users browsing events
+
+---
+
+## Stage 4: Advocate (Post-Purchase)
+
+### Key Features
+- **In-App Events**: Regular updates justify the purchase and generate word-of-mouth
+- **Review Responses**: Professional responses build trust for potential buyers
+
+### Update Strategy for Paid Apps
+Regular updates serve double duty:
+1. Keep existing users happy (reduces refunds, generates positive reviews)
+2. Create new "What's New" visibility in the App Store
+
+### Encouraging Reviews
+- Prompt for review after a positive experience (not on first launch)
+- Time prompts after feature discovery moments
+- Use `SKStoreReviewController` at natural satisfaction points
+
+---
+
+## Paid App Checklist
+
+### Pre-Launch
+- [ ] Research competitor pricing in category
+- [ ] Prepare app preview video showing core value
+- [ ] Write description emphasizing "no subscription" advantage
+- [ ] Prepare at least 5 high-quality screenshots per device
+- [ ] Plan launch pricing strategy (intro price?)
+- [ ] Submit featuring nomination 6-8 weeks early
+
+### Launch
+- [ ] Start Product Page Optimization test immediately
+- [ ] Create launch In-App Event
+- [ ] Monitor conversion rate vs. category benchmark
+- [ ] Respond to all early reviews (positive and negative)
+
+### Growth
+- [ ] Quarterly featuring nomination submissions
+- [ ] Plan 3-4 price drop campaigns per year
+- [ ] Create Custom Product Pages for top search terms
+- [ ] Maintain regular update cadence (monthly or bimonthly)
+
+### Ongoing
+- [ ] Seasonal price drop calendar planned 3 months ahead
+- [ ] PPO tests running continuously
+- [ ] In-App Events for major updates
+- [ ] App Store assets refreshed annually
+
+---
+
+## Paid App Benchmarks
+
+| Metric | Below Average | Average | Good | Excellent |
+|--------|--------------|---------|------|-----------|
+| Page → Download | < 2% | 2-5% | 5-10% | > 10% |
+| Refund rate | > 10% | 5-10% | 2-5% | < 2% |
+| Average rating | < 3.5 | 3.5-4.0 | 4.0-4.5 | > 4.5 |
+| Review volume | < 10/mo | 10-50/mo | 50-200/mo | > 200/mo |

--- a/.claude/skills/app-store/marketing-strategy/strategy-templates/subscription-app.md
+++ b/.claude/skills/app-store/marketing-strategy/strategy-templates/subscription-app.md
@@ -1,0 +1,171 @@
+# Strategy Template: Subscription Apps
+
+Playbook for apps with auto-renewable subscriptions as the primary revenue model.
+
+## Core Strategy: The Subscription Funnel
+
+```
+ACQUIRE → TRIAL → CONVERT → RETAIN → WIN BACK
+   ↑         ↑        ↑         ↑         ↑
+   |         |        |         |         |
+  CPP    Intro     Paywall   Events    Win-back
+  PPO    Offer     Design    Content    Offers
+  ASA    Trial     Pricing   Updates    Offer Codes
+```
+
+Each stage has specific App Store features that optimize it.
+
+---
+
+## Stage 1: Acquire (Get Visitors to Product Page)
+
+### Key Features
+- **Product Page Optimization**: A/B test screenshots, descriptions, and icons
+- **Custom Product Pages**: Tailored pages per audience segment or ad campaign
+- **Featuring Nomination**: Editorial visibility → high-quality, low-cost installs
+- **App Store Assets**: Professional screenshots and app preview videos
+
+### Metrics to Track
+- Impressions → Product page views (conversion rate)
+- Product page views → Downloads (tap-through rate)
+- Source attribution (organic vs. search vs. browse)
+
+### Quick Wins
+1. Optimize first 3 screenshots (most users don't scroll)
+2. Make subtitle benefit-focused, not feature-focused
+3. Add app preview video showing core value in first 5 seconds
+
+---
+
+## Stage 2: Trial (Convert Downloads to Trial Starts)
+
+### Key Features
+- **Introductory Offers**: Free trial (3, 7, or 14 days) or discounted first period
+- **Promoted IAP**: Show subscription directly on the product page
+
+### Trial Duration Decision
+| App Usage Pattern | Recommended Trial | Reason |
+|-------------------|-------------------|--------|
+| Daily use (habit) | 7 days | One week to build habit |
+| Weekly use | 14 days | Two cycles to see value |
+| Infrequent/project-based | 7 days | Quick value demonstration |
+| Complex/onboarding-heavy | 14-30 days | Time to learn and integrate |
+
+### Onboarding During Trial
+- Guide users to premium features immediately (not free features)
+- Show progress/value metrics ("You've completed 5 sessions this week")
+- Trigger contextual upsell at natural upgrade moments
+
+---
+
+## Stage 3: Convert (Trial → Paid Subscriber)
+
+### Key Features
+- **Paywall Design**: Use `generators/paywall-generator` for StoreKit 2 implementation
+- **Pricing Psychology**: Annual-first presentation, anchor pricing
+- **Promotional Offers**: Discounted rate for users who didn't convert from trial
+
+### Conversion Tactics
+1. **Trial ending notification** 2-3 days before expiry
+2. **Value summary** showing what they'll lose ("You tracked 12 workouts")
+3. **Annual offer** presented as "save X%" vs. monthly
+4. **Promotional offer** 7-14 days after trial expires if not converted
+
+### Price Testing Approach
+1. Start with category benchmark pricing
+2. Run 90-day A/B test on pricing page layout
+3. Test annual vs. monthly prominence
+4. Never test price directly (App Store doesn't support price A/B)
+
+---
+
+## Stage 4: Retain (Keep Subscribers Active)
+
+### Key Features
+- **In-App Events**: Regular content/challenges to maintain engagement
+- **Promotional Offers**: Loyalty discounts at renewal risk points
+
+### Retention Event Calendar
+| Timing | Event Type | Goal |
+|--------|-----------|------|
+| Monthly | Feature spotlight or challenge | Remind of value |
+| Quarterly | Major content update event | Re-engage dormant users |
+| Seasonal | Themed campaign (New Year, etc.) | Capitalize on motivation spikes |
+| Anniversary | Personal milestone celebration | Emotional connection |
+
+### Churn Prevention Signals
+Watch for these and trigger Promotional Offers:
+- Usage drops significantly (< 50% of normal)
+- User hasn't opened app in 14+ days
+- User downgrades from premium features
+- User contacts support with complaints
+
+---
+
+## Stage 5: Win Back (Recover Churned Subscribers)
+
+### Key Features
+- **Win-Back Offers**: StoreKit 2 win-back flow for lapsed subscribers
+- **Offer Codes**: Distribute via email campaigns to churned users
+- **In-App Events**: Signal major updates to bring users back
+
+### Win-Back Timeline
+| Days Since Churn | Action | Offer |
+|------------------|--------|-------|
+| 7-14 | App Store win-back offer | 25-50% off first period |
+| 30 | Email with offer code | Free month |
+| 60-90 | In-App Event notification | Major update announcement |
+| 90+ | Aggressive win-back offer | 60%+ off or extended trial |
+
+### Win-Back Messaging
+- Focus on what's new since they left
+- Acknowledge time away ("We've been busy while you were gone")
+- Lead with the single most compelling new feature
+- Make the offer time-limited to create urgency
+
+---
+
+## Subscription App Checklist
+
+### Pre-Launch
+- [ ] Configure subscription products in App Store Connect
+- [ ] Set up introductory offer (free trial recommended)
+- [ ] Implement StoreKit 2 with `paywall-generator` skill
+- [ ] Prepare 3+ screenshot variations for PPO testing
+- [ ] Write benefit-focused description and subtitle
+- [ ] Plan launch In-App Event
+
+### Launch Month
+- [ ] Submit featuring nomination (if not done pre-launch)
+- [ ] Start Product Page Optimization test
+- [ ] Monitor trial-to-paid conversion rate
+- [ ] Set up promotional offer for trial non-converters
+- [ ] Configure promoted IAP
+
+### Growth Phase (Month 2-6)
+- [ ] Create Custom Product Pages for top audience segments
+- [ ] Establish monthly In-App Event cadence
+- [ ] Set up win-back offer for first churned cohort
+- [ ] Distribute offer codes to partners/influencers
+- [ ] Iterate on paywall design based on conversion data
+
+### Mature Phase (Month 6+)
+- [ ] Full win-back offer pipeline active
+- [ ] Quarterly featuring nomination submissions
+- [ ] Seasonal event calendar planned 3 months ahead
+- [ ] Regular PPO tests running
+- [ ] Offer code campaigns for email list
+
+---
+
+## Revenue Benchmarks (Subscription Apps)
+
+| Metric | Below Average | Average | Good | Excellent |
+|--------|--------------|---------|------|-----------|
+| Trial start rate | < 5% | 5-10% | 10-20% | > 20% |
+| Trial → Paid | < 30% | 30-50% | 50-65% | > 65% |
+| Monthly churn | > 10% | 5-10% | 3-5% | < 3% |
+| Annual plan mix | < 30% | 30-50% | 50-70% | > 70% |
+| D30 retention | < 15% | 15-25% | 25-40% | > 40% |
+
+Use these benchmarks to identify which funnel stage needs the most attention.

--- a/.claude/skills/app-store/rejection-handler/SKILL.md
+++ b/.claude/skills/app-store/rejection-handler/SKILL.md
@@ -1,0 +1,402 @@
+---
+name: rejection-handler
+description: Handle App Store rejections, prepare submissions to avoid common rejection reasons, write Resolution Center responses, and navigate the appeal process. Use when user's app was rejected, is preparing for submission, or needs help with App Review.
+allowed-tools: [Read, Glob, Grep, AskUserQuestion]
+---
+
+# App Store Rejection Handler
+
+Guide developers through handling App Store rejections — from understanding why the rejection happened, to crafting effective responses, to escalating when appropriate.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Says their app was rejected by App Review
+- Asks for help understanding a rejection notice
+- Wants to prepare a submission to minimize rejection risk
+- Needs help writing a response in Resolution Center
+- Wants to appeal a rejection decision
+- Asks about common App Store rejection reasons
+- Mentions "App Review", "guideline violation", or "rejection"
+- Wants a pre-submission audit for guideline compliance
+
+## Reference Files
+
+Before handling a rejection, load:
+
+| File | Purpose |
+|------|---------|
+| **common-rejections.md** | Top 20 rejection reasons with fixes and response templates |
+
+## Pre-Submission Audit Checklist
+
+Run through this before submitting to avoid the most common rejections. Each item maps to a specific App Store Review Guideline.
+
+### App Completeness (Guideline 2.1)
+
+- [ ] App launches without crashing on all supported devices
+- [ ] All features described in metadata are functional
+- [ ] No placeholder content (lorem ipsum, test data, TODO screens)
+- [ ] No broken links or dead-end navigation
+- [ ] All buttons and interactive elements work
+- [ ] Demo/test accounts provided in App Review notes if login is required
+- [ ] Beta or test labels removed from UI and metadata
+
+### Accurate Metadata (Guideline 2.3)
+
+- [ ] App name matches what the app actually does
+- [ ] Screenshots show the actual current app UI
+- [ ] Description accurately represents functionality
+- [ ] Category selection is appropriate
+- [ ] No misleading claims ("best", "#1") without substantiation
+- [ ] Age rating reflects actual content
+- [ ] What's New text describes actual changes (not marketing copy)
+- [ ] Keywords do not include competitor names or misleading terms
+
+### Software Requirements (Guideline 2.5)
+
+- [ ] App uses only public APIs (no private frameworks)
+- [ ] No deprecated APIs that are marked for removal
+- [ ] App works on the oldest supported iOS/macOS version claimed
+- [ ] No remote code execution (no downloading and running code)
+- [ ] IPv6 networking compatibility
+
+### In-App Purchase Compliance (Guideline 3.1)
+
+- [ ] All digital content/features use Apple's IAP (not Stripe, PayPal, etc.)
+- [ ] Physical goods/services CAN use external payment
+- [ ] Subscription terms are clear before purchase
+- [ ] "Restore Purchases" button exists and works
+- [ ] Subscription management is accessible within the app
+- [ ] No language directing users to purchase outside the app
+- [ ] Free trial terms are clearly stated
+
+### Design Quality (Guideline 4.0)
+
+- [ ] App uses native UI components (not a web wrapper for existing website)
+- [ ] Supports current device screen sizes
+- [ ] No empty states without guidance
+- [ ] Error messages are user-friendly
+- [ ] Loading states exist for async operations
+- [ ] App provides meaningful functionality (not a glorified bookmark)
+
+### Privacy Compliance (Guideline 5.1)
+
+- [ ] Privacy policy URL is provided and accessible
+- [ ] Privacy policy accurately describes data collection
+- [ ] App Tracking Transparency prompt shown before tracking (if applicable)
+- [ ] Privacy Nutrition Labels in App Store Connect match actual behavior
+- [ ] Data minimization — only collect what you need
+- [ ] User data deletion mechanism exists (if data is collected)
+- [ ] Privacy manifest included (required for certain APIs, iOS 17+)
+
+### Legal Requirements (Guideline 5.2)
+
+- [ ] App complies with local laws in all territories where distributed
+- [ ] Required age gates for restricted content
+- [ ] Health/medical disclaimers if applicable
+- [ ] Financial disclaimers if applicable
+
+### App Review Notes (Submission)
+
+- [ ] Demo account credentials provided (if login required)
+- [ ] Special hardware instructions noted (if needed)
+- [ ] Backend requirements explained (if features need server access)
+- [ ] Explain non-obvious features or flows
+- [ ] Mention any entitlements and why they're needed
+
+## Rejection Handling Process
+
+### Step 1: Read the Rejection Notice Carefully
+
+When a user reports a rejection, gather:
+
+1. **The exact guideline cited** (e.g., "Guideline 4.2 - Design - Minimum Functionality")
+2. **The full rejection message text** (Apple provides specific details)
+3. **Any screenshots or annotations** Apple included
+4. **Whether this is a first submission or re-submission**
+
+Ask via AskUserQuestion:
+- "Can you paste the full rejection message from App Store Connect?"
+- "Which guideline number was cited?"
+- "Is this the first time this app has been submitted?"
+- "Have you made changes since a previous rejection?"
+
+### Step 2: Identify the Rejection Category
+
+Read **common-rejections.md** and match the cited guideline to the detailed breakdown. Determine:
+
+- Is the rejection objectively correct? (crash, privacy violation, missing IAP)
+- Is the rejection subjective? (minimum functionality, design quality)
+- Is the rejection possibly in error? (reviewer misunderstood the app)
+
+### Step 3: Determine Response Strategy
+
+```
+Is the rejection objectively correct?
+├── YES → Fix the issue and resubmit (Phase A)
+└── NO → Did the reviewer misunderstand?
+    ├── YES → Clarify with evidence (Phase B)
+    └── NO → Is it a subjective judgment call?
+        ├── YES → Evaluate: fix or push back? (Phase C)
+        └── NO → Appeal (Phase D)
+```
+
+### Phase A: Fix and Resubmit
+
+For clear violations (crashes, missing privacy policy, private API usage):
+
+1. Fix the specific issue cited
+2. Test thoroughly on the device types Apple may have tested on
+3. In the Resolution Center reply, briefly state what was fixed
+4. Resubmit the binary
+
+**Response template (Fix and Resubmit):**
+```
+Thank you for the review.
+
+We've addressed the issue cited in Guideline [X.X]:
+
+- [Specific change made]
+- [How it was verified]
+
+The updated build ([version] [build number]) has been submitted
+for review.
+
+Please let us know if you have any further questions.
+```
+
+### Phase B: Clarify with Evidence
+
+For rejections based on misunderstanding:
+
+1. Do NOT be defensive or argumentative
+2. Explain clearly what the app does and why it doesn't violate the guideline
+3. Provide screenshots, video, or step-by-step instructions
+4. Reference the specific guideline language and explain how you comply
+
+**Response template (Clarification):**
+```
+Thank you for reviewing our app.
+
+We'd like to provide additional context regarding Guideline [X.X].
+
+[Clear explanation of how the feature/app works]
+
+To demonstrate this:
+1. [Step-by-step instructions to see the relevant feature]
+2. [Step-by-step instructions continued]
+
+[Optional: screenshot or video link]
+
+We believe this addresses the concern raised. We're happy to
+provide any additional information or make a call to discuss
+further.
+```
+
+### Phase C: Evaluate Subjective Rejections
+
+For "minimum functionality" (4.2), "spam" (4.3), or "design" (4.0) rejections, decide:
+
+**When to fix (usually the better path):**
+- If you honestly agree the app could be more substantial
+- If adding 2-3 features would make a meaningful difference
+- If the reviewer's feedback, while harsh, has a point
+- If you're early in development and can improve quickly
+
+**When to push back:**
+- If the app intentionally does one thing well (it's a focused tool, not incomplete)
+- If similar apps exist on the App Store with less functionality
+- If the reviewer appears to have missed core features
+- If you have user testimonials or metrics showing the app delivers value
+
+**Response template (Pushing Back on Subjective Rejection):**
+```
+Thank you for your feedback on our app.
+
+We respectfully believe [App Name] provides meaningful
+functionality as outlined in Guideline [X.X]:
+
+1. [Core value proposition]
+2. [Specific features that demonstrate depth]
+3. [User benefit that differentiates from a simple website]
+
+[App Name] is designed as a focused [type of app] that excels
+at [specific purpose]. This intentional focus is a design
+decision, not a limitation.
+
+[Optional: "Similar apps like [X] and [Y] are available on the
+App Store with comparable scope."]
+
+We'd welcome the opportunity to discuss this further or
+demonstrate the app's functionality in detail.
+```
+
+### Phase D: Formal Appeal
+
+If Resolution Center responses don't resolve the issue, escalate.
+
+## Appeal Escalation Path
+
+### Level 1: Resolution Center Reply (First Response)
+
+- Reply directly in Resolution Center
+- Be professional, concise, and evidence-based
+- Include demo video if helpful
+- Response time: 1-3 business days typically
+
+### Level 2: Request a Phone Call
+
+If the Resolution Center reply doesn't resolve it:
+
+- In Resolution Center, explicitly request: "We'd appreciate the opportunity to discuss this via phone call with the App Review team."
+- Apple sometimes offers this for complex cases
+- Prepare a clear, concise verbal explanation
+- Have the app ready to demo live
+- Response time: 3-7 business days
+
+### Level 3: App Review Board Appeal
+
+If Level 1 and Level 2 fail:
+
+- Submit a formal appeal at https://developer.apple.com/contact/app-store/
+- Choose "App Review" and then "Appeal"
+- This goes to a separate board, not the same reviewer
+- One appeal per rejection — make it count
+- Response time: 5-14 business days
+
+**Appeal writing tips:**
+- Lead with facts, not emotions
+- Reference specific guideline language
+- Explain why the rejection criteria don't apply or are being misapplied
+- Mention comparable apps on the App Store (carefully — don't name-shame, but establish precedent)
+- Keep it under 500 words
+- Include a demo video link if the issue is about functionality
+
+### When to Change Approach vs. Push Back
+
+**Apple is usually right about:**
+- Crashes and bugs (fix them)
+- Privacy violations (fix them)
+- Missing IAP for digital goods (implement IAP)
+- Misleading metadata (fix it)
+- Private API usage (use public APIs)
+
+**Apple is sometimes wrong about:**
+- "Minimum functionality" for intentionally focused apps
+- "Spam" for apps that serve distinct user segments
+- "Could be a website" for apps with native features (widgets, notifications, offline)
+- "Not enough native UI" for apps with legitimate custom interfaces
+- Feature misunderstandings when reviewers don't find non-obvious functionality
+
+**Rule of thumb:** If 3 people independently look at the rejection and all say "Apple has a point," fix the issue. If they all say "this seems wrong," push back with evidence.
+
+## Timeline Expectations
+
+### Typical Review Times
+
+| Scenario | Expected Timeline |
+|----------|------------------|
+| Initial submission | 1-3 days (24-48 hours typical) |
+| Resubmission after rejection | 1-3 days |
+| Expedited review request | Same day to 1 day |
+| Resolution Center reply | 1-3 business days |
+| Phone call request | 3-7 business days |
+| App Review Board appeal | 5-14 business days |
+
+### When to Request Expedited Review
+
+Apple allows expedited review requests for:
+- Critical bug fixes for live apps
+- Time-sensitive events (conference launch, holiday tie-in)
+- Security patches
+
+Do NOT request expedited review for:
+- Initial submissions (no urgency justification)
+- Feature updates (plan ahead)
+- Rejected apps (use Resolution Center instead)
+
+### Seasonal Considerations
+
+- **WWDC (June)**: Slight delays as team focuses on new OS reviews
+- **September-October**: iPhone launch creates surge, slightly longer times
+- **December holidays**: Reduced staff, plan submissions before mid-December
+- **App Store freeze**: Typically Dec 23-27, no new submissions processed
+
+## Resolution Center Best Practices
+
+### Tone
+
+- Professional and respectful, always
+- Concise — reviewers handle hundreds of cases
+- Evidence-based — screenshots, videos, step-by-step instructions
+- Solution-oriented — "here's what we changed" or "here's why this complies"
+
+### What to Include
+
+- Reference the specific guideline number
+- Quote the specific language from the rejection
+- Provide clear evidence (screenshots, demo video, step-by-step reproduction)
+- If you fixed something, state exactly what changed and in which build
+- If you're clarifying, provide a walkthrough of the misunderstood feature
+
+### What to Avoid
+
+- Emotional language ("this is unfair", "we worked so hard")
+- Threats (legal action, press coverage, social media complaints)
+- Comparing to competitor apps in a negative way
+- Long, rambling responses (keep under 300 words for replies)
+- Multiple replies in quick succession (wait for a response)
+
+### Response Length
+
+- First reply: 100-200 words
+- Clarification with evidence: 200-300 words
+- Appeal: 300-500 words
+
+## Output Format
+
+When handling a rejection, produce this assessment:
+
+```markdown
+# Rejection Analysis: [App Name]
+
+## Rejection Details
+- **Guideline**: [X.X] - [Guideline Name]
+- **Submission type**: Initial / Resubmission
+- **Rejection message**: [Quoted text]
+
+## Assessment
+- **Category**: Objective violation / Subjective judgment / Possible error
+- **Validity**: [Is Apple right? Partially right? Wrong?]
+- **Recommended strategy**: Fix and resubmit / Clarify / Push back / Appeal
+
+## Recommended Response
+
+[Draft Resolution Center response]
+
+## If Fixing: Action Items
+1. [Specific change needed]
+2. [Specific change needed]
+3. [Verification step before resubmitting]
+
+## If Appealing: Evidence to Prepare
+- [Screenshot/video needed]
+- [Comparable App Store precedent]
+- [Guideline language to reference]
+
+## Pre-Resubmission Checklist
+- [ ] Issue addressed
+- [ ] Tested on [device types]
+- [ ] App Review notes updated
+- [ ] Demo account credentials current
+- [ ] Resolution Center response sent
+```
+
+## Related Skills
+
+- **common-rejections.md** — Detailed breakdown of top 20 rejection reasons with fix guides
+- Related: `release-review` — Pre-release audit that catches rejection-causing issues
+- Related: `security/privacy-manifests` — Privacy manifest compliance
+- Related: `app-store/app-description-writer` — Metadata accuracy (prevents Guideline 2.3 rejections)
+- Related: `monetization` — IAP compliance guidance (prevents Guideline 3.1 rejections)

--- a/.claude/skills/app-store/rejection-handler/common-rejections.md
+++ b/.claude/skills/app-store/rejection-handler/common-rejections.md
@@ -1,0 +1,471 @@
+# Common App Store Rejections
+
+The top 20 App Store rejection reasons, organized by guideline. For each: what triggers it, example rejection message, how to fix, and a response template snippet.
+
+## Guideline 2.1: App Completeness
+
+### 2.1 — Crashes
+
+**What triggers it:** App crashes during review, on launch, or during core flows. Apple tests on current-generation devices with the latest OS.
+
+**Example rejection message:**
+> We discovered one or more bugs in your app. Specifically, the app crashed when we tapped on the "Export" button on iPhone 15 Pro running iOS 18.2.
+
+**How to fix:**
+- Reproduce on the exact device/OS cited (use Xcode Simulator or physical device)
+- Check crash logs in App Store Connect → App Analytics → Crashes
+- Test all core flows on the latest OS release
+- Pay special attention to edge cases: no network, empty data, permissions denied
+
+**Response template:**
+```
+We've identified and resolved the crash in the export flow.
+The issue was caused by [root cause]. Build [X.X (XX)] includes
+the fix, verified on iPhone 15 Pro / iOS 18.2.
+```
+
+### 2.1 — Broken Links or Placeholder Content
+
+**What triggers it:** Links that 404, screens that say "Coming Soon", lorem ipsum text, test data visible in the UI.
+
+**Example rejection message:**
+> Your app includes placeholder content. Specifically, the "Community" tab displays "Coming Soon" text without functional content.
+
+**How to fix:**
+- Remove or hide any unfinished features entirely
+- Replace placeholder text with real content
+- Ensure all URLs (privacy policy, support, terms) resolve to live pages
+- Remove any "beta" or "test" labels
+
+**Response template:**
+```
+We've removed the placeholder content from the Community tab.
+This feature has been removed from the current release and will
+be included in a future update when fully implemented.
+```
+
+### 2.1 — Missing Demo Account
+
+**What triggers it:** App requires login but no test credentials were provided in App Review Notes.
+
+**Example rejection message:**
+> We were unable to review your app as it requires a login but no demo account was provided.
+
+**How to fix:**
+- Provide a valid demo account in App Store Connect → App Review Information → Notes
+- Ensure the demo account has access to all features
+- Don't use an account that might be rate-limited or expire
+- Format: "Demo account: user@example.com / password123"
+
+**Response template:**
+```
+We apologize for the oversight. Demo credentials have been added
+to the App Review notes: [email] / [password]. This account has
+full access to all app features.
+```
+
+## Guideline 2.3: Accurate Metadata
+
+### 2.3 — Misleading Description or Screenshots
+
+**What triggers it:** Screenshots don't match the current app UI, description promises features that don't exist, or marketing overstates capabilities.
+
+**Example rejection message:**
+> Your app's screenshots do not accurately reflect the app in use. Specifically, screenshot 3 shows a feature that is not present in the current version.
+
+**How to fix:**
+- Retake all screenshots from the current build
+- Ensure every feature mentioned in the description exists in the app
+- Remove any claims that can't be substantiated
+- Match What's New text to actual changes in this version
+
+**Response template:**
+```
+We've updated all screenshots to reflect the current app UI.
+Screenshot 3 has been replaced with an accurate representation
+of the [feature name] screen as it appears in this build.
+```
+
+### 2.3 — Keyword Stuffing or Misleading Keywords
+
+**What triggers it:** Irrelevant keywords in the keyword field, competitor names, category names, or misleading terms.
+
+**Example rejection message:**
+> Your app's metadata includes misleading content. Specifically, the keyword field contains competitor app names.
+
+**How to fix:**
+- Remove all competitor brand names from keywords
+- Remove category names (already indexed automatically)
+- Remove irrelevant terms that don't describe your app
+- Use only keywords directly relevant to your app's functionality
+
+**Response template:**
+```
+We've updated the keyword field to remove all third-party brand
+names and irrelevant terms. Keywords now accurately reflect our
+app's features and functionality.
+```
+
+## Guideline 2.5.1: Software Requirements
+
+### 2.5.1 — Private API Usage
+
+**What triggers it:** App calls private Apple frameworks or undocumented APIs. Apple's static analysis detects these automatically.
+
+**Example rejection message:**
+> Your app uses non-public API/framework: UIWebDocumentView. This is not permitted on the App Store.
+
+**How to fix:**
+- Search your codebase for the cited API name
+- Check third-party SDKs and libraries — they often contain private API calls
+- Replace with public alternatives
+- Update any outdated libraries that may use deprecated private APIs
+- Use `nm` or `otool` on your binary to check for private symbols
+
+**Response template:**
+```
+We've removed the non-public API usage. The reference to
+[API name] was in [library name], which has been updated to
+version [X.X] that uses only public APIs.
+```
+
+## Guideline 3.1.1: In-App Purchase
+
+### 3.1.1 — Digital Goods Not Using IAP
+
+**What triggers it:** App sells digital content, features, or subscriptions through external payment processors (Stripe, PayPal, etc.) instead of Apple's In-App Purchase.
+
+**Example rejection message:**
+> Your app offers digital content for purchase but does not use the In-App Purchase API. Specifically, the premium themes are available for purchase via an external payment system.
+
+**How to fix:**
+- Implement StoreKit 2 for all digital content purchases
+- Remove external payment links/buttons for digital goods
+- Physical goods and services CAN use external payment
+- Reader apps have specific exemptions (Guideline 3.1.3)
+
+**Response template:**
+```
+We've migrated all digital content purchases to Apple's In-App
+Purchase system. Premium themes are now available as non-consumable
+IAPs through StoreKit 2. External payment references have been
+removed.
+```
+
+### 3.1.1 — Directing Users to External Purchase
+
+**What triggers it:** App includes language, buttons, or links encouraging users to purchase outside the app (even if IAP is also offered).
+
+**Example rejection message:**
+> Your app includes a button or link that directs users to an external payment mechanism for items that are required to be purchased through In-App Purchase.
+
+**How to fix:**
+- Remove all "buy on our website" buttons or text for digital goods
+- Remove pricing pages that link to external checkout
+- Don't mention that content is cheaper on your website
+- Reader app entitlement allows linking out for account management only
+
+**Response template:**
+```
+We've removed all references to external purchasing for digital
+content. The "Buy on Web" button and associated links have been
+removed. All digital purchases now go through IAP exclusively.
+```
+
+## Guideline 3.1.2: Subscriptions
+
+### 3.1.2 — Subscription Requirements
+
+**What triggers it:** Subscription doesn't provide ongoing value, unclear pricing terms, no way to manage subscription in-app, or auto-renewal terms not clearly communicated.
+
+**Example rejection message:**
+> Your app's subscription does not provide ongoing value to the user. The content available through the subscription is static and does not justify a recurring charge.
+
+**How to fix:**
+- Ensure subscription includes regularly updated content or ongoing service
+- Add clear subscription terms on the paywall (price, duration, renewal terms)
+- Include in-app access to subscription management
+- Link to Apple's subscription management page
+- Show what users get for their ongoing payment
+
+**Response template:**
+```
+Our subscription provides ongoing value through [specific
+ongoing benefits: weekly content updates, cloud sync, continuous
+AI processing, etc.]. We've also added clearer subscription
+terms on the purchase screen and a direct link to subscription
+management.
+```
+
+## Guideline 4.0: Design
+
+### 4.0 — Not Enough Native UI / Web Wrapper
+
+**What triggers it:** App is primarily a web view wrapping an existing website without meaningful native functionality.
+
+**Example rejection message:**
+> Your app is primarily a web-based experience and does not provide enough native iOS functionality. We encourage you to consider building a native app that takes advantage of iOS features.
+
+**How to fix (if web-based is intentional):**
+- Add meaningful native features: push notifications, widgets, Shortcuts/Siri
+- Use native navigation (NavigationStack, TabView) instead of web navigation
+- Implement offline functionality
+- Add native sharing, haptics, or device-specific features
+- If the app truly should be a website, consider not submitting it
+
+**Response template:**
+```
+While [App Name] does use web views for [specific content],
+it provides significant native functionality including:
+- Push notifications for [purpose]
+- Home screen widget showing [content]
+- Offline access to [feature]
+- Native [iOS feature] integration
+
+These features require a native app and cannot be delivered
+through a website alone.
+```
+
+### 4.0 — Poor UI Quality
+
+**What triggers it:** App has obviously unfinished UI, uses no standard iOS patterns, has layout issues, or looks unprofessional.
+
+**Example rejection message:**
+> Your app does not comply with the design guidelines for iOS apps. Specifically, the app includes UI elements that are inconsistent with standard iOS design patterns.
+
+**How to fix:**
+- Use system components (SwiftUI standard views, UIKit standard controls)
+- Follow Human Interface Guidelines for spacing, typography, and color
+- Support Dynamic Type for accessibility
+- Support Dark Mode
+- Ensure layouts work on all supported screen sizes
+
+**Response template:**
+```
+We've updated the app's design to align with iOS Human Interface
+Guidelines. Changes include [specific UI improvements]. The app
+now uses standard iOS components for [navigation/buttons/lists]
+and supports Dynamic Type and Dark Mode.
+```
+
+## Guideline 4.2: Minimum Functionality
+
+### 4.2 — App Is Too Simple
+
+**What triggers it:** App provides functionality that could be achieved with a bookmark, a simple website, or is too basic for the App Store.
+
+**Example rejection message:**
+> We found that the usefulness of your app is limited by the minimal amount of content or features it includes. We encourage you to review your app concept and incorporate additional features and content.
+
+**How to fix (if you agree it's too simple):**
+- Add 2-3 meaningful features beyond the core function
+- Include settings, customization, or personalization
+- Add data visualization, history, or insights
+- Implement native features: widgets, notifications, Siri Shortcuts
+- Consider whether a more comprehensive app would serve users better
+
+**How to push back (if your app is intentionally focused):**
+- Explain the design philosophy of focused simplicity
+- Reference comparable apps on the App Store
+- Highlight native features that justify app vs. website
+- Provide user testimonials or usage data if available
+
+**Response template (fixing):**
+```
+We've added substantial functionality to the app:
+- [New feature 1]
+- [New feature 2]
+- [New feature 3]
+Build [X.X (XX)] includes these improvements.
+```
+
+**Response template (pushing back):**
+```
+[App Name] is intentionally designed as a focused [type] tool.
+Despite its streamlined interface, it provides meaningful
+functionality that requires a native app:
+- [Native feature 1: widgets, notifications, etc.]
+- [Native feature 2]
+- [Unique value proposition]
+
+The app has [X users / X positive reviews / serves a specific
+use case] that demonstrates its value to users.
+```
+
+## Guideline 4.3: Spam
+
+### 4.3 — Duplicate or Template Apps
+
+**What triggers it:** App is substantially similar to other apps you've submitted, appears to be generated from a template without meaningful customization, or copies another developer's app.
+
+**Example rejection message:**
+> Your app duplicates the content and functionality of other apps currently available on the App Store, which is considered spam.
+
+**How to fix:**
+- Differentiate your app with unique features, content, or design
+- If you have multiple similar apps, consider consolidating into one
+- Remove template boilerplate and customize the experience
+- Add unique content that distinguishes your app
+
+**Response template:**
+```
+[App Name] is distinct from [other app] in the following ways:
+- [Unique feature or audience 1]
+- [Different content or purpose 2]
+- [Technical differentiation 3]
+
+These apps serve different user segments: [App 1] targets
+[audience A] while [App 2] targets [audience B].
+```
+
+## Guideline 5.1.1: Data Collection and Storage
+
+### 5.1.1 — Missing Privacy Policy
+
+**What triggers it:** App collects any user data but doesn't provide a privacy policy URL, or the URL leads to a dead page.
+
+**Example rejection message:**
+> Your app collects user data but does not include a privacy policy URL in App Store Connect.
+
+**How to fix:**
+- Create a privacy policy covering all data your app collects
+- Host it at a stable URL (your website, GitHub Pages, or a service like Termly)
+- Add the URL in App Store Connect → App Information → Privacy Policy URL
+- Ensure the page loads correctly on mobile
+
+**Response template:**
+```
+We've added our privacy policy at [URL]. It covers all data
+collection, usage, and sharing practices in the app. The URL
+has been added to App Store Connect.
+```
+
+### 5.1.1 — Excessive Data Collection
+
+**What triggers it:** App collects data that isn't necessary for its core functionality, or collects data without clear user consent.
+
+**Example rejection message:**
+> Your app collects user data that is not necessary for the app's core functionality. Specifically, the app requests access to Contacts, which does not appear to be needed.
+
+**How to fix:**
+- Remove permissions requests for data you don't strictly need
+- Add clear usage descriptions for all permission requests (NSUsageDescription)
+- Request permissions in context (when the user triggers the relevant feature)
+- Don't request all permissions at launch
+
+**Response template:**
+```
+We've removed the Contacts permission request as it is not
+essential to the app's core functionality. The app now only
+requests [remaining permissions] which are required for
+[specific features].
+```
+
+## Guideline 5.1.2: Data Use and Sharing
+
+### 5.1.2 — App Tracking Transparency
+
+**What triggers it:** App tracks users across apps/websites without presenting the ATT prompt first, or collects IDFA without the ATT framework.
+
+**Example rejection message:**
+> Your app uses the AppTrackingTransparency framework but does not present the tracking permission request to the user before collecting data used to track them.
+
+**How to fix:**
+- Present ATT prompt before any tracking begins
+- Don't track if user denies permission
+- Ensure ATT prompt has a clear purpose string (NSUserTrackingUsageDescription)
+- Don't incentivize users to allow tracking
+- Check that all third-party SDKs (analytics, ad networks) respect ATT status
+
+**Response template:**
+```
+We've updated the app to present the ATT permission prompt
+before any tracking occurs. Third-party SDKs have been
+configured to respect the user's tracking preference. No data
+is collected for tracking purposes until explicit consent is
+granted.
+```
+
+### 5.1.2 — Privacy Nutrition Label Mismatch
+
+**What triggers it:** The privacy labels declared in App Store Connect don't match the app's actual data collection practices.
+
+**Example rejection message:**
+> Your app's privacy information does not accurately reflect the app's data collection practices. The app collects [data type] which is not declared in the privacy nutrition labels.
+
+**How to fix:**
+- Audit all data collection in your app AND third-party SDKs
+- Update App Store Connect privacy labels to match actual behavior
+- Use Apple's privacy manifest to document API usage (iOS 17+)
+- Check SDK documentation for their data collection disclosures
+
+**Response template:**
+```
+We've updated the privacy nutrition labels in App Store Connect
+to accurately reflect all data collection. Specifically, we've
+added [data type] under [category]. We've also audited all
+third-party SDKs to ensure complete disclosure.
+```
+
+## Guideline 5.2.1: Legal Requirements
+
+### 5.2.1 — Local Law Compliance
+
+**What triggers it:** App content or functionality violates laws in specific territories (gambling, health claims, age restrictions, financial regulations).
+
+**Example rejection message:**
+> Your app includes [feature] that may not comply with local laws in [territory]. Please ensure your app complies with all applicable laws.
+
+**How to fix:**
+- Research laws in all territories where your app is available
+- Restrict distribution to compliant territories using App Store Connect
+- Add required disclaimers for health, financial, or legal content
+- Implement age gates where required
+- Consult legal counsel for regulated industries
+
+**Response template:**
+```
+We've addressed the compliance concern by [specific action:
+adding age gate / restricting distribution / adding disclaimer].
+The app is now limited to territories where [feature] is
+permitted and includes appropriate [disclaimers/restrictions].
+```
+
+## Quick Reference: Rejection to Fix Mapping
+
+| Guideline | Common Cause | Typical Fix Time | Difficulty |
+|-----------|-------------|-----------------|------------|
+| 2.1 Crashes | Untested edge case | 1-3 days | Low-Medium |
+| 2.1 Placeholder | Incomplete feature | 1-2 days | Low |
+| 2.1 Demo account | Missing review notes | 10 minutes | Low |
+| 2.3 Screenshots | Outdated assets | 1-2 hours | Low |
+| 2.3 Keywords | Competitor names | 10 minutes | Low |
+| 2.5.1 Private API | Third-party SDK | 1-3 days | Medium |
+| 3.1.1 IAP | External payment | 3-7 days | High |
+| 3.1.2 Subscription | Missing terms | 1-2 days | Medium |
+| 4.0 Web wrapper | Insufficient native | 1-2 weeks | High |
+| 4.0 Poor UI | Design quality | 3-7 days | Medium |
+| 4.2 Too simple | Insufficient features | 1-2 weeks | High |
+| 4.3 Spam | Duplicate apps | Varies | High |
+| 5.1.1 Privacy policy | Missing URL | 1-2 hours | Low |
+| 5.1.1 Data collection | Excess permissions | 1-2 days | Low-Medium |
+| 5.1.2 ATT | Missing prompt | 1-2 days | Medium |
+| 5.1.2 Nutrition labels | Inaccurate labels | 1-2 hours | Low |
+| 5.2.1 Legal | Territory laws | Varies | High |
+
+## When Each Strategy Applies
+
+| Rejection Type | Fix | Clarify | Push Back | Appeal |
+|---------------|-----|---------|-----------|--------|
+| 2.1 Crashes | ✅ | | | |
+| 2.1 Placeholder | ✅ | | | |
+| 2.3 Metadata | ✅ | | | |
+| 2.5.1 Private API | ✅ | | | |
+| 3.1.1 IAP | ✅ | Sometimes | | |
+| 3.1.2 Subscriptions | ✅ | Sometimes | | |
+| 4.0 Design | ✅ | Sometimes | Sometimes | |
+| 4.2 Minimum functionality | Sometimes | ✅ | ✅ | ✅ |
+| 4.3 Spam | ✅ | ✅ | Sometimes | Sometimes |
+| 5.1.1 Privacy | ✅ | | | |
+| 5.1.2 Tracking | ✅ | | | |
+| 5.2.1 Legal | ✅ | | | |

--- a/.claude/skills/app-store/review-response-writer/SKILL.md
+++ b/.claude/skills/app-store/review-response-writer/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: review-response-writer
+description: Write professional, empathetic responses to App Store reviews that build trust and turn critics into fans. Use when responding to negative reviews, drafting templates for common review types, or improving review management strategy.
+allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# Review Response Writer
+
+Write professional, empathetic responses to App Store reviews that build trust and turn critics into fans.
+
+## When This Skill Activates
+
+- User needs to respond to negative reviews
+- User wants templates for common review types
+- User asks about review management strategy
+- User wants to improve customer relationships
+
+## Response Philosophy
+
+### Why Respond?
+
+1. **Shows you care** - Active developer = trustworthy app
+2. **Helps others** - Future users read responses
+3. **Converts critics** - Can change rating with good response
+4. **Provides feedback** - Reviews reveal real issues
+5. **Builds community** - Creates loyal users
+
+### When to Respond
+
+| Review Type | Respond? | Priority |
+|-------------|----------|----------|
+| 1-2 stars with feedback | **Yes** | High |
+| 3 stars with suggestions | Yes | Medium |
+| Bug reports (any rating) | **Yes** | High |
+| 4-5 stars with content | Yes | Low |
+| 4-5 stars generic praise | Optional | Low |
+| Abusive/inappropriate | Report, don't respond | - |
+| Competitor spam | Report, don't respond | - |
+
+### Response Timing
+
+- **Negative reviews:** Within 24-48 hours
+- **Bug reports:** ASAP (shows responsiveness)
+- **Positive reviews:** Weekly batch is fine
+- **After fixing issues:** Follow up to notify
+
+## Response Framework
+
+### The A.C.T. Formula
+
+```
+A - Acknowledge their experience
+C - Clarify or provide solution
+T - Thank them and invite continued feedback
+```
+
+### Template Structure
+
+```
+[Greeting - use their name if signed]
+
+[Acknowledge their frustration/praise]
+
+[Address specific points they raised]
+
+[Provide solution, workaround, or update info]
+
+[Thank + future-focused closing]
+
+[Sign-off with name/team]
+```
+
+## Response Templates
+
+### Negative Review: Bug Report
+
+**Review:** "App crashes every time I try to export. Waste of money. 1 star."
+
+**Response:**
+```
+Hi [Name],
+
+I'm really sorry about the export crashes — that's frustrating,
+especially when you're trying to get work done.
+
+We identified this issue and it's fixed in version X.X, which is
+now available. If you update and still experience problems, please
+reach out to support@yourapp.com and we'll help you directly.
+
+Thank you for taking the time to report this. It helps us improve.
+
+— [Your Name], [App] Team
+```
+
+### Negative Review: Missing Feature
+
+**Review:** "No dark mode? In 2024? Uninstalled."
+
+**Response:**
+```
+Hi there,
+
+You're absolutely right — dark mode is important, and we hear you.
+
+Good news: dark mode is in active development and planned for our
+next major update. If you'd like to be notified when it's ready,
+drop us a note at support@yourapp.com.
+
+Thanks for the feedback. We hope to welcome you back soon!
+
+— [Your Name], [App] Team
+```
+
+### Negative Review: User Error (Diplomatic)
+
+**Review:** "Can't figure out how to do X. Bad design."
+
+**Response:**
+```
+Hi [Name],
+
+Thanks for reaching out. I can see how [X] might not be obvious
+at first — we could definitely make it clearer.
+
+Quick tip: you can access [X] by [simple instructions]. We're also
+adding an in-app tutorial in our next update to help with this.
+
+If you're still stuck, email us at support@yourapp.com and we'll
+walk you through it.
+
+— [Your Name], [App] Team
+```
+
+### Negative Review: Pricing Complaint
+
+**Review:** "Too expensive for what it does."
+
+**Response:**
+```
+Hi [Name],
+
+Thanks for sharing your thoughts on pricing. I understand — value
+is important.
+
+A few things that might help:
+• We offer a free trial so you can test before committing
+• The subscription includes [key benefits]
+• We regularly run promotions — follow us @handle for updates
+
+We're always working to add more value. If there's a specific
+feature you'd find worth the price, we'd love to hear about it.
+
+— [Your Name], [App] Team
+```
+
+### Negative Review: Generic/Vague
+
+**Review:** "Doesn't work. Terrible app."
+
+**Response:**
+```
+Hi there,
+
+I'm sorry to hear you're having trouble. We'd really like to help,
+but need a bit more info to figure out what's going wrong.
+
+Could you email us at support@yourapp.com with:
+• What you were trying to do
+• What happened instead
+• Your device and iOS version
+
+We respond quickly and will do our best to get you sorted.
+
+— [Your Name], [App] Team
+```
+
+### Positive Review: With Feature Request
+
+**Review:** "Love this app! Would be perfect if it had X."
+
+**Response:**
+```
+Thank you so much for the kind words! 🙏
+
+Great suggestion on [X] — you're not the first to ask, and it's
+on our roadmap. Can't promise exact timing, but it's coming.
+
+If you have other ideas, we're all ears at feedback@yourapp.com.
+
+Thanks for being a [App] user!
+
+— [Your Name]
+```
+
+### Positive Review: Simple Thanks
+
+**Review:** "Great app, use it every day. 5 stars!"
+
+**Response:**
+```
+Thank you! Reviews like this make our day. We're glad [App] is
+helping you. If you ever need anything, we're here!
+
+— The [App] Team
+```
+
+### After Fixing a Bug
+
+**Review:** [Previously reported bug]
+
+**Follow-up Response:**
+```
+Hi [Name],
+
+Quick update: the [issue] you reported has been fixed in version
+X.X, now available in the App Store.
+
+Thank you again for letting us know — you helped us make [App]
+better for everyone.
+
+If you get a chance to try the update, we'd love to know if it
+resolved things for you.
+
+— [Your Name], [App] Team
+```
+
+## Tone Guidelines
+
+### Always
+
+- Be genuinely helpful
+- Stay professional but warm
+- Take responsibility (never blame user)
+- Be specific (not generic)
+- Keep it concise
+
+### Never
+
+- Be defensive or argumentative
+- Make excuses
+- Ignore valid criticism
+- Use corporate jargon
+- Copy-paste identical responses
+- Promise specific timelines you can't keep
+
+### Tone by Situation
+
+| Situation | Tone |
+|-----------|------|
+| Bug report | Apologetic, solution-focused |
+| Feature request | Appreciative, forward-looking |
+| Confusion | Helpful, educational |
+| Angry review | Calm, empathetic |
+| Positive review | Grateful, personable |
+
+## Difficult Situations
+
+### Abusive Reviews
+
+**Don't respond.** Report to Apple if it:
+- Contains profanity/hate speech
+- Includes personal attacks
+- Is clearly spam
+- Violates App Store guidelines
+
+### Competitor Attacks
+
+Signs of competitor spam:
+- Multiple similar reviews at once
+- No specific details
+- Account has reviewed many competing apps
+- Unrealistic claims
+
+**Action:** Report to Apple, don't engage.
+
+### Impossible to Satisfy
+
+Some users can't be pleased. After one genuine attempt:
+- Don't keep responding
+- Document for your records
+- Move on
+
+### Legal Threats
+
+If a review contains legal threats:
+- Don't respond publicly
+- Consult with legal
+- Document everything
+
+## Metrics to Track
+
+### Response Metrics
+- Response rate (aim for 100% of actionable)
+- Response time (aim for <48 hours)
+- Follow-up conversion (ratings changed after response)
+
+### Review Health
+- Average rating trend
+- Review volume
+- Sentiment analysis
+- Common themes
+
+## Workflow
+
+### Daily (5 minutes)
+1. Check for new reviews
+2. Flag urgent issues (bugs, crashes)
+3. Respond to critical reviews
+
+### Weekly (15 minutes)
+1. Respond to remaining reviews
+2. Track themes and patterns
+3. Share feedback with team
+
+### Monthly (30 minutes)
+1. Analyze rating trends
+2. Update response templates if needed
+3. Report key feedback to product team
+
+## Quick Reference
+
+### Response Length
+- **Ideal:** 50-100 words
+- **Maximum:** 150 words
+- **Never:** Wall of text
+
+### Sign-off Options
+- "— The [App] Team"
+- "— [Name], [App] Support"
+- "— [Name], Founder of [App]"
+
+### Contact Options to Offer
+- support@yourapp.com
+- In-app support chat
+- @TwitterHandle
+- yourapp.com/help

--- a/.claude/skills/app-store/screenshot-planner/SKILL.md
+++ b/.claude/skills/app-store/screenshot-planner/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: screenshot-planner
+description: Plan compelling App Store screenshot sequences that showcase your app's value. Use when preparing App Store assets, improving screenshot conversion, or drafting screenshot captions for a launch or major update.
+allowed-tools: [Read, Write, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# Screenshot Planner
+
+Plan compelling App Store screenshot sequences that showcase your app's value.
+
+## When This Skill Activates
+
+- User is preparing App Store assets
+- User wants to improve screenshot conversion
+- User asks about screenshot strategy or captions
+- User is launching a new app or major update
+
+## Information Gathering
+
+Before planning, ask about:
+
+1. **App Type**
+   - What category? (Productivity, Games, Lifestyle, etc.)
+   - Primary use case?
+   - Visual style of the app?
+
+2. **Key Selling Points**
+   - What makes users choose this app?
+   - Most impressive features visually?
+   - Any unique UI elements?
+
+3. **Target Audience**
+   - Who downloads this app?
+   - What problem are they trying to solve?
+   - What matters most to them?
+
+4. **Competitors**
+   - What do competitor screenshots show?
+   - How can you differentiate?
+
+## Screenshot Strategy
+
+### The 5-Screenshot Framework
+
+Most users only see the first 2-3 screenshots. Order matters!
+
+| Position | Purpose | Content |
+|----------|---------|---------|
+| **1** | Hero Shot | Value proposition + best visual |
+| **2** | Core Feature | Primary use case in action |
+| **3** | Key Differentiator | What makes you unique |
+| **4** | Secondary Feature | Another compelling feature |
+| **5** | Social Proof/CTA | Reviews, awards, or final push |
+
+### Extended (10 Screenshots)
+
+| Position | Purpose |
+|----------|---------|
+| 6 | Additional feature |
+| 7 | Customization/settings |
+| 8 | Integration/ecosystem |
+| 9 | Before/after or workflow |
+| 10 | Final CTA with app icon |
+
+## Caption Writing
+
+### Caption Formula
+
+```
+[Action Verb] + [Benefit] + [Optional Detail]
+```
+
+### Examples by Category
+
+**Productivity:**
+- "Capture ideas instantly"
+- "Never miss a deadline"
+- "Your tasks, beautifully organized"
+
+**Health & Fitness:**
+- "Track every workout"
+- "See your progress over time"
+- "Personalized plans that work"
+
+**Photo & Video:**
+- "Edit like a pro in seconds"
+- "Filters that actually look good"
+- "Share anywhere with one tap"
+
+**Finance:**
+- "Know where your money goes"
+- "Budget without the stress"
+- "Insights that save you money"
+
+### Caption Rules
+
+✅ **Do:**
+- Keep under 8 words
+- Start with action verbs
+- Focus on user benefits
+- Match the visual exactly
+- Use sentence case
+
+❌ **Don't:**
+- Use technical jargon
+- Include version numbers
+- Mention prices
+- Use "Our app does..."
+- Write full sentences
+
+## Visual Best Practices
+
+### Device Frames
+
+| Approach | When to Use |
+|----------|-------------|
+| **With frames** | When device context matters, lifestyle apps |
+| **Without frames** | Maximizing screen real estate, content apps |
+| **3D angles** | Standing out, premium feel |
+| **Flat/straight** | Clean, professional, enterprise |
+
+### Backgrounds
+
+- **Solid colors:** Clean, professional, fast loading
+- **Gradients:** Modern, dynamic, attention-grabbing
+- **Lifestyle photos:** Context, emotion, aspiration
+- **Abstract patterns:** Creative, unique, memorable
+
+### Typography
+
+- Use 2 fonts max (headline + body)
+- Minimum 60pt for headlines (iPhone)
+- Ensure readability on small thumbnails
+- Match your app's brand fonts if possible
+
+## Screenshot Storyboard Template
+
+```
+SCREENSHOT 1: HERO
+━━━━━━━━━━━━━━━━━━
+Caption: [Value proposition - max 6 words]
+Visual: [Key screen showing main feature]
+Background: [Color/gradient that pops]
+Notes: [This is first impression - make it count]
+
+SCREENSHOT 2: CORE FEATURE
+━━━━━━━━━━━━━━━━━━━━━━━━━━
+Caption: [What can user do?]
+Visual: [App in action, primary workflow]
+Background: [Consistent with #1]
+Notes: [Show the "aha" moment]
+
+SCREENSHOT 3: DIFFERENTIATOR
+━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Caption: [What makes you unique?]
+Visual: [Feature competitors don't have]
+Background: [Can vary slightly]
+Notes: [Answer "why this app?"]
+
+SCREENSHOT 4: SECONDARY FEATURE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Caption: [Another key benefit]
+Visual: [Compelling secondary feature]
+Background: [Consistent theme]
+Notes: [Add depth to value proposition]
+
+SCREENSHOT 5: TRUST/CTA
+━━━━━━━━━━━━━━━━━━━━━━
+Caption: [Social proof or call to action]
+Visual: [Reviews, stats, or final screen]
+Background: [Strong finish]
+Notes: [Close the deal]
+```
+
+## Size Requirements
+
+### iPhone (Required)
+| Size | Device | Dimensions |
+|------|--------|------------|
+| 6.7" | iPhone 15 Pro Max | 1290 × 2796 |
+| 6.5" | iPhone 11 Pro Max | 1284 × 2778 |
+| 5.5" | iPhone 8 Plus | 1242 × 2208 |
+
+### iPad (If Universal)
+| Size | Device | Dimensions |
+|------|--------|------------|
+| 12.9" | iPad Pro | 2048 × 2732 |
+
+### macOS
+| Display | Dimensions |
+|---------|------------|
+| Standard | 1280 × 800 (min) |
+| Retina | 2880 × 1800 |
+
+## App Preview Video
+
+### When to Include
+- Complex apps that need demonstration
+- Games (almost always)
+- Apps with unique interactions
+- When screenshots can't show the experience
+
+### Video Specs
+- 15-30 seconds optimal
+- First 3 seconds = hook
+- No audio required (most watch muted)
+- Show actual app (no external footage first 3s)
+- 1080p or higher
+
+### Video Storyboard
+```
+0:00-0:03  Hook - Most impressive moment
+0:03-0:10  Core workflow demonstration
+0:10-0:20  Key features montage
+0:20-0:30  Final CTA with value prop
+```
+
+## Localization
+
+### Considerations
+- Captions must be localized
+- Screenshots may need localization if they show text
+- Consider using minimal in-app text in screenshots
+- Some markets prefer different visual styles
+
+### Priority Markets
+1. English (US)
+2. Chinese (Simplified)
+3. Japanese
+4. German
+5. French
+6. Spanish
+
+## Tools
+
+### Design Tools
+- **Figma** - Free, collaborative
+- **Sketch** - Mac-native, templates available
+- **Photoshop** - Full control
+
+### Screenshot Generators
+- **Screenshots.pro** - Templates with device frames
+- **Previewed** - 3D mockups
+- **AppLaunchpad** - Quick and easy
+- **Studio** - Mac app with templates
+
+### Capture Tools
+- **Xcode Simulator** - File → Screenshot
+- **QuickTime** - Screen recording for video
+- **ScreenFloat** - Organize captures
+
+## Competitive Analysis
+
+Before finalizing, check competitors:
+
+1. Search your main keyword
+2. Screenshot top 5 apps
+3. Note patterns:
+   - Frame style used
+   - Caption placement
+   - Color schemes
+   - Number of screenshots
+4. Differentiate while meeting expectations

--- a/.claude/skills/macos-development/SKILL.md
+++ b/.claude/skills/macos-development/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: macos-development
+description: Comprehensive macOS development guidance including Swift 6+, SwiftUI, SwiftData, architecture patterns, AppKit bridging, and macOS 26 Tahoe APIs. Use for macOS code review, best practices, UI review, or platform-specific features.
+allowed-tools: [Read, Glob, Grep, WebFetch]
+---
+
+# macOS Development Expert
+
+Comprehensive guidance for macOS app development. This skill aggregates specialized modules for different aspects of macOS development.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Asks about macOS development best practices
+- Wants code review for macOS/Swift projects
+- Needs help with SwiftUI, SwiftData, or AppKit
+- Is implementing macOS 26 (Tahoe) features
+- Wants UI/UX review against HIG
+- Needs architecture guidance for macOS apps
+
+## Available Modules
+
+Read relevant module files based on the user's needs:
+
+### coding-best-practices/
+Swift 6+ code quality and modern idioms.
+- `swift-language.md` - Modern Swift patterns
+- `modern-concurrency.md` - async/await, actors, Sendable
+- `data-persistence.md` - SwiftData, UserDefaults, Keychain
+- `code-organization.md` - Project structure and modularity
+- `architecture-principles.md` - Clean architecture patterns
+
+### architecture-patterns/
+Software design and architecture.
+- `solid-detailed.md` - SOLID principles with Swift examples
+- `design-patterns.md` - Common design patterns
+- `modular-design.md` - Modular architecture approaches
+
+### swiftdata-architecture/
+SwiftData deep dive.
+- `schema-design.md` - Model design and relationships
+- `query-patterns.md` - Efficient queries and predicates
+- `performance.md` - Optimization techniques
+
+### macos-tahoe-apis/
+macOS 26 specific features.
+- `tahoe-features.md` - New macOS 26 capabilities
+- `apple-intelligence.md` - AI/ML integration
+- `mlx-framework.md` - On-device ML with MLX
+- `continuity.md` - Cross-device features
+- `xcode16.md` - Xcode 16 tools and features
+
+### macos-capabilities/
+Platform integration.
+- `sandboxing.md` - App Sandbox and entitlements
+- System integration features
+
+### appkit-swiftui-bridge/
+Hybrid development.
+- `nsviewrepresentable.md` - Wrapping AppKit views
+- State management between frameworks
+
+### ui-review-tahoe/
+UI/UX review for macOS 26.
+- Liquid Glass design system
+- HIG compliance checking
+- Accessibility review
+
+### app-planner/
+Project planning and analysis.
+- New app architecture planning
+- Existing app audits
+
+## How to Use
+
+1. Identify user's need from their question
+2. Read relevant module files from subdirectories
+3. Apply the guidance to their specific context
+4. Reference Apple documentation when needed
+
+## Example Workflow
+
+**User asks about SwiftData performance:**
+1. Read `swiftdata-architecture/performance.md`
+2. Read `swiftdata-architecture/query-patterns.md` if relevant
+3. Apply recommendations to their code

--- a/.claude/skills/macos-development/app-planner/existing-app-analysis.md
+++ b/.claude/skills/macos-development/app-planner/existing-app-analysis.md
@@ -1,0 +1,70 @@
+# Existing macOS App Analysis
+
+Create 10 comprehensive analysis documents for existing apps.
+
+## 1. Current Architecture Audit
+
+- Current tech stack
+- Architecture pattern used
+- Code organization
+- Dependencies
+
+## 2. Code Quality Assessment
+
+- SOLID compliance
+- DRY violations
+- Code duplication
+- Design patterns used
+
+## 3. UI/UX Tahoe Compatibility
+
+- Liquid Glass adoption
+- HIG compliance
+- macOS 26 features used
+- Accessibility status
+
+## 4. Data Layer Analysis
+
+- Current persistence (Core Data, etc.)
+- SwiftData migration potential
+- Data model review
+
+## 5. Performance Profiling
+
+- Bottlenecks identified
+- Memory usage
+- Launch time
+- Optimization opportunities
+
+## 6. Accessibility Audit
+
+- VoiceOver support
+- Keyboard navigation
+- Dynamic Type
+- Color contrast
+
+## 7. Security and Sandboxing
+
+- Current entitlements
+- Security vulnerabilities
+- Sandbox compatibility
+
+## 8. Dependency Analysis
+
+- Third-party dependencies
+- Version currency
+- Security audits
+
+## 9. Test Coverage Report
+
+- Current test coverage
+- Missing tests
+- Quality metrics
+
+## 10. Modernization Roadmap
+
+- Intel → Apple Silicon
+- Core Data → SwiftData
+- Objective-C → Swift
+- Liquid Glass adoption
+- Priority timeline

--- a/.claude/skills/macos-development/app-planner/new-app-planning.md
+++ b/.claude/skills/macos-development/app-planner/new-app-planning.md
@@ -1,0 +1,63 @@
+# New macOS App Planning
+
+Create 8 comprehensive planning documents for new macOS projects.
+
+## 1. Feature Specification
+
+- Core features list
+- User stories
+- Feature prioritization (MVP vs future)
+- Target audience
+- Success criteria
+
+## 2. Architecture Decision
+
+- SwiftUI vs AppKit vs Hybrid
+- MVVM architecture
+- Modular design approach
+- SwiftData for persistence
+- Dependency injection strategy
+
+## 3. Data Model Design
+
+- SwiftData models and relationships
+- Schema design
+- Migration strategy
+- CloudKit sync (if needed)
+
+## 4. UI/UX Wireframes
+
+- Window structure
+- Navigation pattern (sidebar, tabs)
+- Liquid Glass design integration
+- Accessibility considerations
+- Responsive layouts
+
+## 5. Technology Stack
+
+- Swift 6
+- SwiftUI/AppKit
+- SwiftData
+- Frameworks needed
+- Third-party dependencies
+
+## 6. Project Structure
+
+- Feature-based modules
+- Swift Package organization
+- File structure
+- Testing strategy
+
+## 7. Testing Strategy
+
+- Unit tests
+- UI tests
+- Integration tests
+- Test coverage goals
+
+## 8. Distribution Plan
+
+- Mac App Store vs direct
+- Code signing
+- Notarization
+- Update mechanism

--- a/.claude/skills/macos-development/app-planner/skill.md
+++ b/.claude/skills/macos-development/app-planner/skill.md
@@ -1,0 +1,41 @@
+---
+name: app-planner
+description: Plans new macOS apps or analyzes existing projects. Creates comprehensive planning documents covering architecture, features, UI/UX, and tech stack. Use when planning a new macOS app or auditing an existing one.
+allowed-tools: [Read, Write, Glob, Grep, AskUserQuestion]
+---
+
+# App Planner for macOS
+
+You are a macOS app architect specializing in project planning and analysis.
+
+## When This Skill Activates
+
+- User wants to plan a new macOS app
+- User wants to analyze or audit an existing macOS project
+- User asks to architect a macOS app
+- User wants planning documents for their macOS app
+- User asks to review project structure for a macOS app
+
+## Your Role
+
+Create comprehensive planning documents for new macOS apps or analyze existing projects.
+
+## Core Functions
+
+1. **New App Planning** - Create 8 planning documents for new projects
+2. **Existing App Analysis** - Create 10 analysis documents for existing apps
+
+## Module References
+
+1. **New App Planning**: `skills/app-planner/new-app-planning.md`
+2. **Existing App Analysis**: `skills/app-planner/existing-app-analysis.md`
+
+## Approach
+
+- Ask detailed questions about requirements
+- Consider macOS 26 Tahoe features
+- Recommend SwiftData, SwiftUI where appropriate
+- Plan for SOLID/DRY principles
+- Consider accessibility and performance
+
+Begin by asking whether this is a new app or existing app analysis.

--- a/.claude/skills/macos-development/appkit-swiftui-bridge/hosting-controllers.md
+++ b/.claude/skills/macos-development/appkit-swiftui-bridge/hosting-controllers.md
@@ -1,0 +1,228 @@
+# Hosting Controllers
+
+Embedding SwiftUI views inside AppKit applications using NSHostingView and NSHostingController. This is the primary pattern for incrementally adopting SwiftUI in existing AppKit apps.
+
+## NSHostingView
+
+Wraps a SwiftUI view as an NSView. Use when you need to embed SwiftUI in an existing NSView hierarchy.
+
+### Basic Usage
+
+```swift
+import SwiftUI
+
+let swiftUIView = MySwiftUIView(viewModel: viewModel)
+let hostingView = NSHostingView(rootView: swiftUIView)
+
+// Add to existing view hierarchy
+parentView.addSubview(hostingView)
+
+// With Auto Layout
+hostingView.translatesAutoresizingMaskIntoConstraints = false
+NSLayoutConstraint.activate([
+    hostingView.leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+    hostingView.trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+    hostingView.topAnchor.constraint(equalTo: parentView.topAnchor),
+    hostingView.bottomAnchor.constraint(equalTo: parentView.bottomAnchor)
+])
+```
+
+### Sizing Behavior
+
+NSHostingView calculates its `intrinsicContentSize` from the SwiftUI view. Control this with `sizingOptions` (macOS 13+):
+
+```swift
+let hostingView = NSHostingView(rootView: myView)
+
+// Default: hosting view has intrinsic size from SwiftUI content
+hostingView.sizingOptions = .intrinsicContentSize
+
+// Prefer minimal size (useful for fixed-size badges, indicators)
+hostingView.sizingOptions = .minSize
+
+// Both (most flexible)
+hostingView.sizingOptions = [.intrinsicContentSize, .minSize]
+```
+
+### Updating the Root View
+
+When your data model changes, update the hosted view:
+
+```swift
+// With @Observable (macOS 14+) - automatic updates, no manual refresh needed
+@Observable class ViewModel {
+    var title = "Hello"
+}
+
+let viewModel = ViewModel()
+let hostingView = NSHostingView(rootView: ContentView(viewModel: viewModel))
+// Changes to viewModel.title automatically update the hosted SwiftUI view
+
+// Without @Observable - manually update rootView
+hostingView.rootView = MySwiftUIView(updatedData: newData)
+```
+
+## NSHostingController
+
+Wraps a SwiftUI view as an NSViewController. Use when you need a full view controller (e.g., in NSSplitViewController, tab views, sheets).
+
+### Basic Usage
+
+```swift
+let hostingController = NSHostingController(rootView: SettingsView())
+
+// Present as sheet
+parentViewController.presentAsSheet(hostingController)
+
+// Add as child view controller
+parentVC.addChild(hostingController)
+parentVC.view.addSubview(hostingController.view)
+hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+NSLayoutConstraint.activate([
+    hostingController.view.leadingAnchor.constraint(equalTo: parentVC.view.leadingAnchor),
+    hostingController.view.trailingAnchor.constraint(equalTo: parentVC.view.trailingAnchor),
+    hostingController.view.topAnchor.constraint(equalTo: parentVC.view.topAnchor),
+    hostingController.view.bottomAnchor.constraint(equalTo: parentVC.view.bottomAnchor)
+])
+```
+
+### Window Management
+
+Create a new window with SwiftUI content:
+
+```swift
+func showSwiftUIWindow() {
+    let hostingController = NSHostingController(rootView: DetailView())
+
+    let window = NSWindow(contentViewController: hostingController)
+    window.title = "Detail"
+    window.setContentSize(NSSize(width: 600, height: 400))
+    window.styleMask = [.titled, .closable, .resizable, .miniaturizable]
+    window.center()
+    window.makeKeyAndOrderFront(nil)
+
+    // Retain the window controller
+    let windowController = NSWindowController(window: window)
+    windowController.showWindow(nil)
+}
+```
+
+### In NSSplitViewController
+
+```swift
+class MainSplitViewController: NSSplitViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Sidebar in SwiftUI
+        let sidebarItem = NSSplitViewItem(
+            sidebarWithViewController: NSHostingController(rootView: SidebarView())
+        )
+        sidebarItem.minimumThickness = 200
+        sidebarItem.canCollapse = true
+
+        // Content in SwiftUI
+        let contentItem = NSSplitViewItem(
+            viewController: NSHostingController(rootView: ContentView())
+        )
+        contentItem.minimumThickness = 300
+
+        addSplitViewItem(sidebarItem)
+        addSplitViewItem(contentItem)
+    }
+}
+```
+
+## Incremental Adoption Strategy
+
+### Phase 1: Leaf Views
+Start by replacing simple, self-contained views:
+- Settings panels
+- Detail views
+- Empty states
+- Status indicators
+
+```swift
+// Replace an AppKit detail view with SwiftUI
+class DetailViewController: NSViewController {
+    private var hostingView: NSHostingView<DetailSwiftUIView>!
+
+    override func loadView() {
+        let swiftUIView = DetailSwiftUIView(item: item)
+        hostingView = NSHostingView(rootView: swiftUIView)
+        self.view = hostingView
+    }
+}
+```
+
+### Phase 2: Container Views
+Move to views that contain other views:
+- Tab containers
+- Split view panels
+- List/detail patterns
+
+### Phase 3: Window-Level
+Eventually host entire windows in SwiftUI:
+- New windows as SwiftUI `WindowGroup`
+- Settings via SwiftUI `Settings` scene
+- Menu bar with `MenuBarExtra`
+
+### Phase 4: Full Migration
+- Replace the App Delegate entry point with SwiftUI `@main App`
+- Use `NSApplicationDelegateAdaptor` for remaining AppKit lifecycle needs
+
+```swift
+@main
+struct MyApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        Settings {
+            SettingsView()
+        }
+    }
+}
+```
+
+## SwiftUI Environment in Hosted Views
+
+Hosted SwiftUI views have access to the full SwiftUI environment:
+
+```swift
+let hostingController = NSHostingController(
+    rootView: MyView()
+        .environment(\.managedObjectContext, persistentContainer.viewContext)
+        .environment(appState)
+)
+```
+
+## Toolbar Integration
+
+NSHostingController integrates with NSWindow toolbars. Use SwiftUI's `.toolbar` modifier:
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        MainContent()
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Add", systemImage: "plus") { }
+                }
+            }
+    }
+}
+// When hosted in NSHostingController, toolbar items appear in the window toolbar
+```
+
+## Best Practices
+
+1. **Use @Observable for shared state** - Automatic updates across the bridge (macOS 14+)
+2. **Set sizing options explicitly** - Don't rely on default sizing for complex layouts
+3. **Adopt incrementally** - Start with leaf views, work up to containers
+4. **Keep the bridge thin** - Don't build complex logic at the boundary
+5. **Use NSHostingController for view controller contexts** - Sheets, split views, tab views
+6. **Use NSHostingView for view-level embedding** - Cells, decorations, inline content
+7. **Test resizing behavior** - Verify hosted views respond correctly to window resizing

--- a/.claude/skills/macos-development/appkit-swiftui-bridge/nsviewrepresentable.md
+++ b/.claude/skills/macos-development/appkit-swiftui-bridge/nsviewrepresentable.md
@@ -1,0 +1,267 @@
+# NSViewRepresentable
+
+Wrapping AppKit views for use in SwiftUI. This is the primary mechanism for using AppKit views within a SwiftUI view hierarchy.
+
+## Protocol Requirements
+
+```swift
+struct MyAppKitView: NSViewRepresentable {
+    // 1. Create the AppKit view
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = NSTextField()
+        textField.delegate = context.coordinator
+        return textField
+    }
+
+    // 2. Update when SwiftUI state changes
+    func updateNSView(_ nsView: NSTextField, context: Context) {
+        nsView.stringValue = text
+    }
+
+    // 3. Optional: Provide a coordinator for delegation
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    // 4. Optional: Clean up resources
+    static func dismantleNSView(_ nsView: NSTextField, coordinator: Coordinator) {
+        // Remove observers, cancel timers, etc.
+    }
+
+    // 5. Optional: Control sizing (macOS 13+)
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSTextField, context: Context) -> CGSize? {
+        nsView.intrinsicContentSize
+    }
+}
+```
+
+## The Coordinator Pattern
+
+The coordinator is a long-lived object that survives SwiftUI view re-creation. Use it for:
+- **Delegation**: AppKit delegate callbacks
+- **Target-action**: Button targets, gesture recognizers
+- **Observation**: KVO, NotificationCenter
+
+```swift
+class Coordinator: NSObject, NSTextFieldDelegate {
+    var parent: MyAppKitView
+    var observation: NSKeyValueObservation?
+
+    init(_ parent: MyAppKitView) {
+        self.parent = parent
+    }
+
+    func controlTextDidChange(_ obj: Notification) {
+        guard let textField = obj.object as? NSTextField else { return }
+        parent.text = textField.stringValue
+    }
+}
+```
+
+### Updating the Parent Reference
+
+The coordinator's `parent` reference becomes stale when SwiftUI recreates the view struct. Update it in `updateNSView`:
+
+```swift
+func updateNSView(_ nsView: NSTextField, context: Context) {
+    context.coordinator.parent = self  // Keep parent reference fresh
+    nsView.stringValue = text
+}
+```
+
+## Wrapping Common AppKit Views
+
+### NSTextView (Rich Text Editing)
+
+```swift
+struct RichTextEditor: NSViewRepresentable {
+    @Binding var attributedText: NSAttributedString
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSTextView.scrollableTextView()
+        let textView = scrollView.documentView as! NSTextView
+        textView.isRichText = true
+        textView.allowsUndo = true
+        textView.delegate = context.coordinator
+        textView.textStorage?.setAttributedString(attributedText)
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        context.coordinator.parent = self
+        if textView.textStorage?.attributedString() != attributedText {
+            textView.textStorage?.setAttributedString(attributedText)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: RichTextEditor
+        init(_ parent: RichTextEditor) { self.parent = parent }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView,
+                  let storage = textView.textStorage else { return }
+            parent.attributedText = NSAttributedString(attributedString: storage)
+        }
+    }
+}
+```
+
+### NSTableView (High-Performance Lists)
+
+Use when `List` or `Table` performance is insufficient (100k+ rows):
+
+```swift
+struct HighPerformanceList: NSViewRepresentable {
+    let items: [ListItem]
+    var onSelect: (ListItem) -> Void
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let tableView = NSTableView()
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("main"))
+        column.title = "Items"
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.style = .plain
+        tableView.dataSource = context.coordinator
+        tableView.delegate = context.coordinator
+
+        scrollView.documentView = tableView
+        scrollView.hasVerticalScroller = true
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.parent = self
+        (scrollView.documentView as? NSTableView)?.reloadData()
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    class Coordinator: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+        var parent: HighPerformanceList
+        init(_ parent: HighPerformanceList) { self.parent = parent }
+
+        func numberOfRows(in tableView: NSTableView) -> Int {
+            parent.items.count
+        }
+
+        func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+            let cell = tableView.makeView(withIdentifier: tableColumn!.identifier, owner: nil) as? NSTextField
+                ?? NSTextField(labelWithString: "")
+            cell.identifier = tableColumn!.identifier
+            cell.stringValue = parent.items[row].title
+            return cell
+        }
+
+        func tableViewSelectionDidChange(_ notification: Notification) {
+            guard let tableView = notification.object as? NSTableView else { return }
+            let row = tableView.selectedRow
+            guard row >= 0 else { return }
+            parent.onSelect(parent.items[row])
+        }
+    }
+}
+```
+
+### Drag and Drop
+
+```swift
+struct DragDropView: NSViewRepresentable {
+    var onDrop: ([URL]) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = DropTargetView()
+        view.coordinator = context.coordinator
+        view.registerForDraggedTypes([.fileURL])
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.parent = self
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    class DropTargetView: NSView {
+        weak var coordinator: Coordinator?
+
+        override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation { .copy }
+
+        override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+            guard let urls = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
+                return false
+            }
+            coordinator?.parent.onDrop(urls)
+            return true
+        }
+    }
+
+    class Coordinator: NSObject {
+        var parent: DragDropView
+        init(_ parent: DragDropView) { self.parent = parent }
+    }
+}
+```
+
+## Layout Integration
+
+### sizeThatFits (macOS 13+)
+
+Control how the wrapped view participates in SwiftUI layout:
+
+```swift
+func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSTextField, context: Context) -> CGSize? {
+    // Return nil to use SwiftUI's default sizing
+    // Return a size to override
+
+    // Respect proposed width, calculate height
+    let width = proposal.width ?? nsView.intrinsicContentSize.width
+    let height = nsView.intrinsicContentSize.height
+    return CGSize(width: width, height: height)
+}
+```
+
+### Intrinsic Content Size
+
+For custom NSView subclasses, override `intrinsicContentSize`:
+
+```swift
+class CustomView: NSView {
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: 44)
+    }
+}
+```
+
+## Animation Context
+
+Access SwiftUI animation state in `updateNSView`:
+
+```swift
+func updateNSView(_ nsView: NSView, context: Context) {
+    if context.transaction.animation != nil {
+        NSAnimationContext.runAnimationGroup { animContext in
+            animContext.duration = 0.25
+            animContext.allowsImplicitAnimation = true
+            nsView.animator().alphaValue = isVisible ? 1.0 : 0.0
+        }
+    } else {
+        nsView.alphaValue = isVisible ? 1.0 : 0.0
+    }
+}
+```
+
+## Best Practices
+
+1. **Keep makeNSView minimal** - Only create and configure. Don't set data.
+2. **Guard against redundant updates** - Check if values actually changed in `updateNSView`
+3. **Always clean up in dismantleNSView** - Remove observers, invalidate timers, cancel tasks
+4. **Update coordinator.parent** - Refresh the parent reference in `updateNSView`
+5. **Use sizeThatFits for layout** - Don't set frames manually; let SwiftUI handle layout
+6. **Avoid storing state in the coordinator** - Use @Binding and @State in the parent

--- a/.claude/skills/macos-development/appkit-swiftui-bridge/skill.md
+++ b/.claude/skills/macos-development/appkit-swiftui-bridge/skill.md
@@ -1,0 +1,136 @@
+---
+name: appkit-swiftui-bridge
+description: Expert guidance for hybrid AppKit-SwiftUI development. Covers NSViewRepresentable, hosting controllers, and state management between frameworks. Use when bridging AppKit and SwiftUI.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# AppKit-SwiftUI Bridge Expert
+
+You are a macOS development expert specializing in hybrid AppKit-SwiftUI applications. You help developers incrementally adopt SwiftUI within existing AppKit apps and leverage AppKit capabilities from SwiftUI.
+
+## When This Skill Activates
+
+- User wants to bridge AppKit and SwiftUI
+- User asks about `NSViewRepresentable` or `NSHostingView`/`NSHostingController`
+- User wants to wrap an AppKit view for use in SwiftUI
+- User wants to host SwiftUI inside an existing AppKit app
+- User is migrating an AppKit app to SwiftUI incrementally
+
+## Your Role
+
+Guide developers through bridging AppKit and SwiftUI, choosing the right approach for each situation, and managing shared state between frameworks.
+
+## Core Focus Areas
+
+1. **NSViewRepresentable** - Wrapping AppKit views for use in SwiftUI
+2. **Hosting Controllers** - Embedding SwiftUI views in AppKit containers
+3. **State Management** - Bridging state between frameworks with @Observable and Combine
+
+## When to Bridge vs. Go Native
+
+### Use NSViewRepresentable when:
+- SwiftUI lacks a native equivalent (e.g., `NSTextView` rich text, `NSOpenGLView`)
+- You need fine-grained control over AppKit view lifecycle
+- Performance-critical views need AppKit optimization (e.g., `NSTableView` with 100k+ rows)
+
+### Use NSHostingView/Controller when:
+- Incrementally adopting SwiftUI in an existing AppKit app
+- A SwiftUI view is more concise for the job (e.g., complex layouts, animations)
+- Building new features in SwiftUI within an AppKit shell
+
+### Go pure SwiftUI when:
+- Starting a new project targeting macOS 14+
+- The feature has full SwiftUI API coverage
+- No AppKit-specific behavior is needed
+
+## How to Conduct Reviews
+
+### Step 1: Identify the Bridge Direction
+- Is AppKit hosting SwiftUI, or SwiftUI wrapping AppKit?
+- What's the minimum macOS deployment target?
+- Are there performance or lifecycle constraints?
+
+### Step 2: Review Against Module Guidelines
+- NSViewRepresentable usage (see nsviewrepresentable.md)
+- Hosting controllers (see hosting-controllers.md)
+- State management (see state-management.md)
+
+### Step 3: Provide Structured Feedback
+
+For each issue found:
+1. **Issue**: Describe the bridging problem
+2. **Impact**: Memory leak, state desync, layout glitch, etc.
+3. **Fix**: Concrete code showing the correct approach
+4. **Pattern**: Reference the applicable bridging pattern
+
+## Common Pitfalls
+
+### 1. Coordinator Lifecycle Mismanagement
+```swift
+// Wrong - creating new coordinator on every update
+func updateNSView(_ nsView: NSTextField, context: Context) {
+    let coordinator = Coordinator() // New instance each time!
+    nsView.delegate = coordinator
+}
+
+// Right - use the persistent coordinator
+func updateNSView(_ nsView: NSTextField, context: Context) {
+    nsView.delegate = context.coordinator // Reuses existing
+}
+```
+
+### 2. Missing Dismantling
+```swift
+// Wrong - observer never removed
+static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    // Empty - leaks observer!
+}
+
+// Right - clean up in dismantle
+static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+    coordinator.observation?.invalidate()
+    NotificationCenter.default.removeObserver(coordinator)
+}
+```
+
+### 3. Forcing Layout in Wrong Phase
+```swift
+// Wrong - layout during makeNSView
+func makeNSView(context: Context) -> NSView {
+    let view = NSView()
+    view.frame = CGRect(x: 0, y: 0, width: 200, height: 100) // Ignored by SwiftUI
+    return view
+}
+
+// Right - use sizeThatFits or intrinsicContentSize
+func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSView, context: Context) -> CGSize? {
+    CGSize(width: proposal.width ?? 200, height: 100)
+}
+```
+
+## Module References
+
+Load these modules as needed:
+
+1. **NSViewRepresentable**: `nsviewrepresentable.md`
+   - Full protocol implementation
+   - Coordinator pattern
+   - Layout integration with sizeThatFits
+
+2. **Hosting Controllers**: `hosting-controllers.md`
+   - NSHostingView and NSHostingController
+   - Window management
+   - Incremental SwiftUI adoption
+
+3. **State Management**: `state-management.md`
+   - @Observable bridging
+   - Combine pipelines
+   - Notification-based communication
+
+## Response Guidelines
+
+- Always specify the minimum macOS version for APIs used
+- Provide both AppKit and SwiftUI sides of the bridge
+- Highlight memory management and cleanup requirements
+- Prefer @Observable (macOS 14+) over ObservableObject when possible
+- Warn about common retain cycles in coordinators

--- a/.claude/skills/macos-development/appkit-swiftui-bridge/state-management.md
+++ b/.claude/skills/macos-development/appkit-swiftui-bridge/state-management.md
@@ -1,0 +1,311 @@
+# State Management Across Frameworks
+
+Bridging state between AppKit and SwiftUI. The key challenge is keeping both sides synchronized without retain cycles or stale data.
+
+## Approach 1: @Observable (Recommended, macOS 14+)
+
+The simplest and most modern approach. Both AppKit and SwiftUI can observe the same `@Observable` class.
+
+```swift
+@Observable
+class AppState {
+    var currentDocument: Document?
+    var isEditing = false
+    var statusMessage = ""
+}
+```
+
+### SwiftUI Side
+
+```swift
+struct ContentView: View {
+    var appState: AppState
+
+    var body: some View {
+        VStack {
+            if let doc = appState.currentDocument {
+                DocumentView(document: doc)
+            }
+            Text(appState.statusMessage)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+```
+
+### AppKit Side
+
+Use `withObservationTracking` to react to changes:
+
+```swift
+class AppKitController: NSViewController {
+    let appState: AppState
+    private var isObserving = true
+
+    init(appState: AppState) {
+        self.appState = appState
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        observeState()
+    }
+
+    private func observeState() {
+        guard isObserving else { return }
+        withObservationTracking {
+            // Access properties you want to observe
+            let message = appState.statusMessage
+            updateStatusBar(message)
+        } onChange: {
+            // Re-observe on next change (must re-register)
+            DispatchQueue.main.async { [weak self] in
+                self?.observeState()
+            }
+        }
+    }
+
+    deinit {
+        isObserving = false
+    }
+}
+```
+
+### Hosting with @Observable
+
+```swift
+let appState = AppState()
+
+// SwiftUI side - pass as environment
+let hostingView = NSHostingView(
+    rootView: ContentView()
+        .environment(appState)
+)
+
+// AppKit side - use the same instance
+let appKitController = AppKitController(appState: appState)
+
+// Changes from either side propagate automatically
+appState.statusMessage = "Updated from AppKit"  // SwiftUI view updates
+```
+
+## Approach 2: Combine (macOS 10.15+)
+
+Use Combine publishers for cross-framework communication when targeting older macOS versions.
+
+### Shared ViewModel with Combine
+
+```swift
+class SharedViewModel: ObservableObject {
+    @Published var items: [Item] = []
+    @Published var selectedItemID: UUID?
+    @Published var isLoading = false
+}
+```
+
+### SwiftUI Side
+
+```swift
+struct ItemListView: View {
+    @ObservedObject var viewModel: SharedViewModel
+
+    var body: some View {
+        List(viewModel.items, selection: $viewModel.selectedItemID) { item in
+            Text(item.name)
+        }
+    }
+}
+```
+
+### AppKit Side
+
+```swift
+class AppKitSidebarController: NSViewController {
+    let viewModel: SharedViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(viewModel: SharedViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        viewModel.$selectedItemID
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] selectedID in
+                self?.highlightItem(selectedID)
+            }
+            .store(in: &cancellables)
+
+        viewModel.$items
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] items in
+                self?.reloadTable(with: items)
+            }
+            .store(in: &cancellables)
+    }
+
+    func userSelectedItem(_ id: UUID) {
+        viewModel.selectedItemID = id  // SwiftUI view updates automatically
+    }
+}
+```
+
+## Approach 3: NotificationCenter
+
+Best for loosely coupled, fire-and-forget communication between distant parts of the app.
+
+```swift
+// Define notification names
+extension Notification.Name {
+    static let documentDidSave = Notification.Name("documentDidSave")
+    static let themeDidChange = Notification.Name("themeDidChange")
+}
+
+// AppKit posts
+NotificationCenter.default.post(
+    name: .documentDidSave,
+    object: nil,
+    userInfo: ["documentID": document.id]
+)
+
+// SwiftUI receives
+struct ContentView: View {
+    var body: some View {
+        Text("Content")
+            .onReceive(NotificationCenter.default.publisher(for: .documentDidSave)) { notification in
+                if let docID = notification.userInfo?["documentID"] as? UUID {
+                    handleSave(docID)
+                }
+            }
+    }
+}
+```
+
+## Approach 4: Shared UserDefaults / App Storage
+
+For simple preferences shared between both frameworks:
+
+```swift
+// SwiftUI side
+@AppStorage("sidebarWidth") private var sidebarWidth: Double = 250
+
+// AppKit side
+UserDefaults.standard.addObserver(self, forKeyPath: "sidebarWidth", context: nil)
+
+override func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                           change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+    if keyPath == "sidebarWidth" {
+        let width = UserDefaults.standard.double(forKey: "sidebarWidth")
+        updateSidebarWidth(width)
+    }
+}
+```
+
+## Approach 5: NSResponder Chain
+
+Pass actions up through the responder chain from SwiftUI to AppKit:
+
+```swift
+// SwiftUI sends an action up the responder chain
+struct ToolbarView: View {
+    var body: some View {
+        Button("Save") {
+            NSApp.sendAction(#selector(DocumentController.saveDocument(_:)), to: nil, from: nil)
+        }
+    }
+}
+
+// AppKit receives via responder chain
+class DocumentController: NSDocumentController {
+    @objc func saveDocument(_ sender: Any?) {
+        currentDocument?.save(nil)
+    }
+}
+```
+
+## Choosing the Right Approach
+
+| Approach | macOS Version | Coupling | Best For |
+|----------|--------------|----------|----------|
+| @Observable | 14+ | Tight | Shared view models, closely related views |
+| Combine | 10.15+ | Medium | Reactive data streams, async updates |
+| NotificationCenter | Any | Loose | Cross-module events, fire-and-forget |
+| UserDefaults | Any | Loose | Simple preferences, settings |
+| Responder Chain | Any | Loose | Menu actions, commands |
+
+## Common Mistakes
+
+### Retain Cycles
+
+```swift
+// Wrong - strong reference cycle
+class Coordinator: NSObject {
+    let viewModel: SharedViewModel
+    var cancellable: AnyCancellable?
+
+    init(viewModel: SharedViewModel) {
+        self.viewModel = viewModel
+        cancellable = viewModel.$items.sink { items in
+            self.update(items)  // Strong capture of self!
+        }
+    }
+}
+
+// Right - weak capture
+cancellable = viewModel.$items.sink { [weak self] items in
+    self?.update(items)
+}
+```
+
+### Thread Safety
+
+```swift
+// Wrong - updating UI from background thread
+viewModel.$data
+    .sink { data in
+        self.tableView.reloadData()  // May be on background thread!
+    }
+
+// Right - ensure main thread
+viewModel.$data
+    .receive(on: DispatchQueue.main)
+    .sink { [weak self] data in
+        self?.tableView.reloadData()
+    }
+```
+
+### Stale Coordinator References
+
+```swift
+// Wrong - coordinator captures old parent struct
+func makeCoordinator() -> Coordinator {
+    Coordinator(text: text)  // Captures current value, never updates
+}
+
+// Right - coordinator references parent, updated in updateNSView
+func makeCoordinator() -> Coordinator {
+    Coordinator(parent: self)
+}
+
+func updateNSView(_ nsView: NSView, context: Context) {
+    context.coordinator.parent = self  // Keep reference fresh
+}
+```
+
+## Best Practices
+
+1. **Use @Observable for macOS 14+** - Simplest approach, works automatically across both frameworks
+2. **Avoid mixing approaches** - Pick one primary mechanism per data flow
+3. **Always use weak self in closures** - Prevent retain cycles in Combine sinks and callbacks
+4. **Dispatch to main thread** - All UI updates must happen on the main thread
+5. **Clean up subscriptions** - Cancel Combine subscriptions and remove observers in deinit/dismantle
+6. **Keep shared state minimal** - Only share what both frameworks actually need
+7. **Test bidirectional updates** - Verify changes from either side propagate correctly

--- a/.claude/skills/macos-development/architecture-patterns/design-patterns.md
+++ b/.claude/skills/macos-development/architecture-patterns/design-patterns.md
@@ -1,0 +1,372 @@
+# Design Patterns for macOS
+
+Common design patterns implemented in modern Swift for macOS applications. Each pattern includes when to use it, implementation, and real-world examples.
+
+## MVVM (Model-View-ViewModel)
+
+The primary pattern for SwiftUI macOS apps. The ViewModel owns business logic and exposes state the View observes.
+
+### Implementation with @Observable (macOS 14+)
+
+```swift
+// Model
+struct Task: Identifiable, Codable {
+    let id: UUID
+    var title: String
+    var isCompleted: Bool
+    var dueDate: Date?
+}
+
+// ViewModel
+@Observable class TaskListViewModel {
+    private let repository: TaskRepository
+
+    var tasks: [Task] = []
+    var filterOption: FilterOption = .all
+    var errorMessage: String?
+
+    var filteredTasks: [Task] {
+        switch filterOption {
+        case .all: tasks
+        case .active: tasks.filter { !$0.isCompleted }
+        case .completed: tasks.filter { $0.isCompleted }
+        }
+    }
+
+    init(repository: TaskRepository) {
+        self.repository = repository
+    }
+
+    func loadTasks() async {
+        do {
+            tasks = try await repository.fetchAll()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleCompletion(_ task: Task) async {
+        guard var updated = tasks.first(where: { $0.id == task.id }) else { return }
+        updated.isCompleted.toggle()
+        do {
+            try await repository.save(updated)
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index] = updated
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+// View
+struct TaskListView: View {
+    @State private var viewModel: TaskListViewModel
+
+    init(repository: TaskRepository) {
+        _viewModel = State(initialValue: TaskListViewModel(repository: repository))
+    }
+
+    var body: some View {
+        List(viewModel.filteredTasks) { task in
+            TaskRow(task: task) {
+                Task { await viewModel.toggleCompletion(task) }
+            }
+        }
+        .task { await viewModel.loadTasks() }
+    }
+}
+```
+
+### When to Use MVVM
+- Any SwiftUI app with business logic beyond simple data display
+- When you need testable business logic separate from the view
+- When multiple views share the same state transformations
+
+## Repository Pattern
+
+Abstracts data access behind a protocol. The ViewModel doesn't know if data comes from a database, network, or cache.
+
+```swift
+protocol TaskRepository {
+    func fetchAll() async throws -> [Task]
+    func fetch(id: UUID) async throws -> Task?
+    func save(_ task: Task) async throws
+    func delete(_ task: Task) async throws
+}
+
+// SwiftData implementation
+struct SwiftDataTaskRepository: TaskRepository {
+    let modelContext: ModelContext
+
+    func fetchAll() async throws -> [Task] {
+        let descriptor = FetchDescriptor<TaskModel>(sortBy: [SortDescriptor(\.dueDate)])
+        return try modelContext.fetch(descriptor).map(\.toTask)
+    }
+
+    func save(_ task: Task) async throws {
+        if let existing = try await fetch(id: task.id) as? TaskModel {
+            existing.update(from: task)
+        } else {
+            modelContext.insert(TaskModel(from: task))
+        }
+        try modelContext.save()
+    }
+
+    func fetch(id: UUID) async throws -> Task? {
+        let descriptor = FetchDescriptor<TaskModel>(predicate: #Predicate { $0.id == id })
+        return try modelContext.fetch(descriptor).first?.toTask
+    }
+
+    func delete(_ task: Task) async throws {
+        let descriptor = FetchDescriptor<TaskModel>(predicate: #Predicate { $0.id == task.id })
+        if let model = try modelContext.fetch(descriptor).first {
+            modelContext.delete(model)
+            try modelContext.save()
+        }
+    }
+}
+
+// In-memory implementation for tests and previews
+struct InMemoryTaskRepository: TaskRepository {
+    var tasks: [Task] = []
+
+    func fetchAll() async throws -> [Task] { tasks }
+    func fetch(id: UUID) async throws -> Task? { tasks.first { $0.id == id } }
+    mutating func save(_ task: Task) async throws {
+        if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+            tasks[index] = task
+        } else {
+            tasks.append(task)
+        }
+    }
+    mutating func delete(_ task: Task) async throws {
+        tasks.removeAll { $0.id == task.id }
+    }
+}
+```
+
+### When to Use Repository
+- Apps with persistence (SwiftData, Core Data, files)
+- When you need to swap data sources (network vs. local)
+- When you want testable data access without real databases
+
+## Factory Pattern
+
+Creates objects without exposing creation logic. Useful for building complex objects with varying configurations.
+
+```swift
+// Protocol for the product
+protocol AlertPresenter {
+    func show(title: String, message: String)
+}
+
+// Factory
+enum AlertPresenterFactory {
+    static func make(for context: AlertContext) -> AlertPresenter {
+        switch context {
+        case .modal:
+            return ModalAlertPresenter()
+        case .notification:
+            return NotificationAlertPresenter()
+        case .statusBar:
+            return StatusBarAlertPresenter()
+        }
+    }
+}
+
+// More practical: ViewModel factory with dependencies
+enum ViewModelFactory {
+    static func makeTaskList(modelContext: ModelContext) -> TaskListViewModel {
+        let repository = SwiftDataTaskRepository(modelContext: modelContext)
+        return TaskListViewModel(repository: repository)
+    }
+
+    static func makeSettings(store: UserDefaults = .standard) -> SettingsViewModel {
+        let preferences = UserDefaultsPreferences(store: store)
+        return SettingsViewModel(preferences: preferences)
+    }
+}
+```
+
+### When to Use Factory
+- Complex object creation with multiple dependencies
+- When creation logic varies based on context or configuration
+- Centralizing dependency wiring
+
+## Observer Pattern
+
+Built into Swift via Combine, @Observable, and NotificationCenter. Choose the right mechanism for the coupling level.
+
+### @Observable (Tight Coupling, macOS 14+)
+
+```swift
+@Observable class DownloadManager {
+    var activeDownloads: [Download] = []
+    var totalProgress: Double = 0.0
+    var isDownloading: Bool { !activeDownloads.isEmpty }
+}
+
+// Views automatically observe accessed properties
+struct DownloadStatusView: View {
+    var manager: DownloadManager
+    var body: some View {
+        if manager.isDownloading {
+            ProgressView(value: manager.totalProgress)
+        }
+    }
+}
+```
+
+### Combine (Medium Coupling)
+
+```swift
+class FileWatcher {
+    let fileChanged = PassthroughSubject<URL, Never>()
+
+    func startWatching(_ directory: URL) {
+        // FSEvents or DispatchSource monitoring
+        // When file changes:
+        fileChanged.send(changedURL)
+    }
+}
+
+// Consumer
+class EditorController {
+    private var cancellables = Set<AnyCancellable>()
+
+    init(watcher: FileWatcher) {
+        watcher.fileChanged
+            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+            .sink { [weak self] url in
+                self?.reloadFile(at: url)
+            }
+            .store(in: &cancellables)
+    }
+}
+```
+
+### When to Use Which Observer Mechanism
+| Mechanism | Coupling | Use Case |
+|-----------|----------|----------|
+| @Observable | Tight | ViewModel-to-View data binding |
+| Combine | Medium | Async streams, data transformation pipelines |
+| NotificationCenter | Loose | App-wide events, system notifications |
+| AsyncSequence | Medium | Streaming data, server-sent events |
+
+## Coordinator Pattern
+
+Manages navigation flow, keeping ViewModels free of navigation logic. Most useful in large apps with complex flows.
+
+```swift
+@Observable class AppCoordinator {
+    var selectedTab: Tab = .documents
+    var navigationPath = NavigationPath()
+    var presentedSheet: SheetDestination?
+    var presentedAlert: AlertDestination?
+
+    func showDocument(_ document: Document) {
+        selectedTab = .documents
+        navigationPath.append(document)
+    }
+
+    func showSettings() {
+        presentedSheet = .settings
+    }
+
+    func showDeleteConfirmation(for document: Document) {
+        presentedAlert = .deleteConfirmation(document)
+    }
+
+    func handleDeepLink(_ url: URL) {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return }
+        switch components.host {
+        case "document":
+            if let id = components.queryItems?.first(where: { $0.name == "id" })?.value {
+                navigationPath.append(DocumentRoute(id: id))
+            }
+        case "settings":
+            showSettings()
+        default:
+            break
+        }
+    }
+}
+
+// Usage in the root view
+struct ContentView: View {
+    @State private var coordinator = AppCoordinator()
+
+    var body: some View {
+        TabView(selection: $coordinator.selectedTab) {
+            NavigationStack(path: $coordinator.navigationPath) {
+                DocumentListView()
+                    .navigationDestination(for: Document.self) { doc in
+                        DocumentDetailView(document: doc)
+                    }
+            }
+            .tag(Tab.documents)
+        }
+        .sheet(item: $coordinator.presentedSheet) { destination in
+            switch destination {
+            case .settings: SettingsView()
+            }
+        }
+        .environment(coordinator)
+    }
+}
+```
+
+### When to Use Coordinator
+- Apps with complex navigation flows (onboarding, multi-step forms)
+- Deep linking support
+- When navigation logic is cluttering ViewModels
+- Multi-window macOS apps
+
+## Service Locator (Lightweight DI)
+
+For small-to-medium apps where a full DI container is overkill.
+
+```swift
+@Observable class ServiceContainer {
+    lazy var taskRepository: TaskRepository = SwiftDataTaskRepository(modelContext: modelContext)
+    lazy var analytics: AnalyticsTracking = FirebaseTracker()
+    lazy var networkMonitor: NetworkMonitor = SystemNetworkMonitor()
+
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+}
+
+// Inject via SwiftUI environment
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(ServiceContainer(modelContext: modelContext))
+        }
+    }
+}
+
+// Consume in views
+struct TaskListView: View {
+    @Environment(ServiceContainer.self) private var services
+
+    var body: some View {
+        TaskListContent(repository: services.taskRepository)
+    }
+}
+```
+
+## Choosing the Right Pattern
+
+| Scenario | Recommended Patterns |
+|----------|---------------------|
+| Simple CRUD app | MVVM + Repository |
+| Multi-screen app with navigation | MVVM + Repository + Coordinator |
+| App with swappable backends | Repository + Factory |
+| Plugin/extension architecture | Factory + Observer |
+| Menu bar utility | MVVM (lightweight, single ViewModel) |

--- a/.claude/skills/macos-development/architecture-patterns/modular-design.md
+++ b/.claude/skills/macos-development/architecture-patterns/modular-design.md
@@ -1,0 +1,311 @@
+# Modular Design
+
+Swift Package Manager organization, feature modules, and code organization strategies for macOS applications.
+
+## Project Organization Strategies
+
+### Strategy 1: Group by Feature (Recommended for Most Apps)
+
+```
+MyApp/
+├── Features/
+│   ├── Documents/
+│   │   ├── DocumentListView.swift
+│   │   ├── DocumentDetailView.swift
+│   │   ├── DocumentViewModel.swift
+│   │   └── DocumentModel.swift
+│   ├── Settings/
+│   │   ├── SettingsView.swift
+│   │   ├── GeneralSettingsTab.swift
+│   │   ├── AppearanceSettingsTab.swift
+│   │   └── SettingsViewModel.swift
+│   └── Search/
+│       ├── SearchView.swift
+│       ├── SearchResultRow.swift
+│       └── SearchViewModel.swift
+├── Core/
+│   ├── Models/
+│   │   └── SharedModels.swift
+│   ├── Services/
+│   │   ├── PersistenceService.swift
+│   │   └── NetworkService.swift
+│   └── Extensions/
+│       └── Date+Formatting.swift
+├── App/
+│   ├── MyApp.swift
+│   ├── ContentView.swift
+│   └── AppState.swift
+└── Resources/
+    └── Assets.xcassets
+```
+
+**Pros**: Related files together, easy to find things, scales well
+**Cons**: Shared dependencies can create circular references
+
+### Strategy 2: Group by Layer
+
+```
+MyApp/
+├── Views/
+│   ├── DocumentListView.swift
+│   ├── DocumentDetailView.swift
+│   ├── SettingsView.swift
+│   └── SearchView.swift
+├── ViewModels/
+│   ├── DocumentViewModel.swift
+│   ├── SettingsViewModel.swift
+│   └── SearchViewModel.swift
+├── Models/
+│   ├── Document.swift
+│   ├── Settings.swift
+│   └── SearchResult.swift
+├── Services/
+│   ├── DocumentRepository.swift
+│   └── SearchService.swift
+└── App/
+    └── MyApp.swift
+```
+
+**Pros**: Clear separation of concerns, familiar to MVVM developers
+**Cons**: Related files scattered across folders, doesn't scale as well
+
+### Recommendation
+- **Small apps (< 15 files)**: Group by layer — simpler, less folder nesting
+- **Medium+ apps (15+ files)**: Group by feature — better discoverability and modularity
+
+## Swift Package Manager Modularization
+
+For large apps, extract code into local Swift packages for build isolation, clear API boundaries, and faster incremental builds.
+
+### Package Structure
+
+```
+MyApp/
+├── MyApp.xcodeproj
+├── MyApp/                          # App target (thin shell)
+│   ├── MyApp.swift
+│   └── ContentView.swift
+└── Packages/
+    ├── Core/                       # Shared models, protocols, utilities
+    │   ├── Package.swift
+    │   └── Sources/Core/
+    │       ├── Models/
+    │       ├── Protocols/
+    │       └── Extensions/
+    ├── DocumentFeature/            # Document management feature
+    │   ├── Package.swift
+    │   └── Sources/DocumentFeature/
+    │       ├── DocumentListView.swift
+    │       ├── DocumentDetailView.swift
+    │       └── DocumentViewModel.swift
+    ├── Persistence/                # Data layer
+    │   ├── Package.swift
+    │   └── Sources/Persistence/
+    │       ├── SwiftDataModels/
+    │       └── Repositories/
+    └── Networking/                  # Network layer
+        ├── Package.swift
+        └── Sources/Networking/
+            ├── APIClient.swift
+            └── Endpoints/
+```
+
+### Package.swift for a Feature Module
+
+```swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "DocumentFeature",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "DocumentFeature", targets: ["DocumentFeature"]),
+    ],
+    dependencies: [
+        .package(path: "../Core"),
+        .package(path: "../Persistence"),
+    ],
+    targets: [
+        .target(
+            name: "DocumentFeature",
+            dependencies: ["Core", "Persistence"]
+        ),
+        .testTarget(
+            name: "DocumentFeatureTests",
+            dependencies: ["DocumentFeature"]
+        ),
+    ]
+)
+```
+
+### Dependency Graph Rules
+
+1. **Core** depends on nothing — shared models, protocols, utilities
+2. **Service layers** (Persistence, Networking) depend on Core only
+3. **Feature modules** depend on Core and relevant service layers
+4. **App target** depends on all feature modules and wires them together
+5. **No circular dependencies** — if two modules need each other, extract the shared part into Core
+
+```
+App → DocumentFeature → Persistence → Core
+    → SettingsFeature → Core
+    → SearchFeature → Networking → Core
+```
+
+## Access Control for Module Boundaries
+
+Use Swift's access levels to enforce clean module APIs:
+
+```swift
+// In Persistence module
+
+// Public: API surface used by other modules
+public protocol TaskRepository: Sendable {
+    func fetchAll() async throws -> [Task]
+    func save(_ task: Task) async throws
+}
+
+// Public: consumers need to create this
+public struct SwiftDataTaskRepository: TaskRepository {
+    public init(modelContext: ModelContext) { ... }
+    public func fetchAll() async throws -> [Task] { ... }
+    public func save(_ task: Task) async throws { ... }
+}
+
+// Internal: implementation detail, not visible outside module
+struct CacheManager {
+    func invalidate() { ... }
+}
+
+// Package: visible to other targets in same package, not outside
+package struct MigrationHelper {
+    package func migrate(from oldSchema: Schema) { ... }
+}
+```
+
+### Access Level Summary
+
+| Level | Visible To |
+|-------|-----------|
+| `private` | Enclosing declaration only |
+| `fileprivate` | Same source file |
+| `internal` (default) | Same module/target |
+| `package` | Same package (Swift 5.9+) |
+| `public` | Any importing module |
+| `open` | Any module (can subclass/override) |
+
+## DRY: Reducing Duplication
+
+### Extract Shared Views
+
+```swift
+// Reusable components in Core or a shared UI module
+struct EmptyStateView: View {
+    let title: String
+    let systemImage: String
+    let description: String
+
+    var body: some View {
+        ContentUnavailableView(title, systemImage: systemImage, description: Text(description))
+    }
+}
+
+struct LoadingOverlay: View {
+    let isLoading: Bool
+    var body: some View {
+        if isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(.ultraThinMaterial)
+        }
+    }
+}
+```
+
+### Extract Common Logic into Extensions
+
+```swift
+// Instead of duplicating date formatting across features
+extension Date {
+    var relativeDisplay: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: self, relativeTo: .now)
+    }
+
+    var shortDisplay: String {
+        formatted(date: .abbreviated, time: .shortened)
+    }
+}
+```
+
+### Protocol with Default Implementations
+
+```swift
+protocol Searchable {
+    var searchableText: String { get }
+}
+
+extension Array where Element: Searchable {
+    func search(query: String) -> [Element] {
+        guard !query.isEmpty else { return self }
+        let lowered = query.lowercased()
+        return filter { $0.searchableText.lowercased().contains(lowered) }
+    }
+}
+
+// Any model can opt-in
+struct Document: Searchable {
+    let title: String
+    let content: String
+    var searchableText: String { "\(title) \(content)" }
+}
+
+struct Contact: Searchable {
+    let name: String
+    let email: String
+    var searchableText: String { "\(name) \(email)" }
+}
+```
+
+## When to Modularize
+
+| Signal | Action |
+|--------|--------|
+| Build times getting slow | Extract stable code into packages |
+| Multiple developers working on same files | Split into feature modules |
+| Want to share code between app and extension | Extract into shared package |
+| Tests require the full app to compile | Extract testable code into packages |
+| Hard to find files | Reorganize by feature |
+
+**Don't modularize prematurely** — start with feature folders in the app target and extract to packages when there's a concrete benefit.
+
+## Testing Across Modules
+
+Each package has its own test target with fast, isolated tests:
+
+```swift
+// In DocumentFeatureTests/
+@testable import DocumentFeature
+import Core
+
+struct MockTaskRepository: TaskRepository {
+    var tasks: [Task] = []
+    func fetchAll() async throws -> [Task] { tasks }
+    func save(_ task: Task) async throws { }
+}
+
+@Test func testFilteredTasks() async {
+    let repo = MockTaskRepository(tasks: [
+        Task(id: UUID(), title: "Active", isCompleted: false),
+        Task(id: UUID(), title: "Done", isCompleted: true),
+    ])
+    let viewModel = TaskListViewModel(repository: repo)
+    await viewModel.loadTasks()
+
+    viewModel.filterOption = .active
+    #expect(viewModel.filteredTasks.count == 1)
+    #expect(viewModel.filteredTasks[0].title == "Active")
+}
+```

--- a/.claude/skills/macos-development/architecture-patterns/skill.md
+++ b/.claude/skills/macos-development/architecture-patterns/skill.md
@@ -1,0 +1,171 @@
+---
+name: architecture-patterns
+description: Deep dive into software architecture for macOS. Covers SOLID principles, design patterns, and modular code organization. Use when designing app architecture or refactoring.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Architecture Patterns Expert
+
+You are a macOS software architect specializing in Swift 6+ application design. You help developers choose the right architecture, apply SOLID principles, and organize code for maintainability and testability.
+
+## Your Role
+
+Guide developers through architectural decisions for macOS applications, from project structure to design patterns to dependency management. Focus on pragmatic, testable designs that leverage Swift's type system.
+
+## Core Focus Areas
+
+1. **SOLID Principles** - Applied to real-world Swift with concrete refactoring examples
+2. **Design Patterns** - MVVM, Repository, Factory, Observer, Coordinator patterns
+3. **Modular Design** - Swift Package Manager structure, feature modules, code organization
+
+## When This Skill Activates
+
+- Designing a new macOS application's architecture
+- Refactoring an existing app for better maintainability
+- Reviewing architecture choices and patterns
+- Deciding between architectural approaches (MVVM vs MVC, etc.)
+- Organizing a growing codebase into modules
+
+## Architectural Decision Guide
+
+### Small App (1-3 screens)
+- Simple MVVM with @Observable
+- Single module, flat file structure
+- No need for complex abstractions
+
+### Medium App (4-10 screens)
+- MVVM with repository pattern for data access
+- Group by feature folders
+- Protocol-based dependency injection
+
+### Large App (10+ screens, multiple developers)
+- Full modular architecture with SPM packages
+- Feature modules with clear API boundaries
+- Coordinator pattern for navigation
+- Shared domain layer
+
+## How to Conduct Reviews
+
+### Step 1: Understand the Context
+- What's the app's scale and team size?
+- What's the minimum macOS deployment target?
+- Are there existing architectural patterns in place?
+
+### Step 2: Review Against Module Guidelines
+- SOLID principles (see solid-detailed.md)
+- Design patterns (see design-patterns.md)
+- Code organization (see modular-design.md)
+
+### Step 3: Provide Structured Feedback
+
+For each issue found:
+1. **Issue**: Describe the architectural problem
+2. **Principle Violated**: Reference specific principle
+3. **Impact**: Technical debt, testability, maintainability
+4. **Fix**: Concrete refactoring with before/after code
+5. **Trade-offs**: Acknowledge when simplicity beats purity
+
+## Quick Reference: Common Anti-Patterns
+
+### Massive View Model
+```swift
+// Wrong - ViewModel does everything
+@Observable class ContentViewModel {
+    var items: [Item] = []
+    func fetchItems() { /* networking */ }
+    func saveItem(_ item: Item) { /* persistence */ }
+    func validateItem(_ item: Item) -> Bool { /* validation */ }
+    func exportItems() { /* file export */ }
+    func importItems(from url: URL) { /* file import */ }
+}
+
+// Right - separate concerns
+@Observable class ContentViewModel {
+    private let repository: ItemRepository
+    private let validator: ItemValidator
+
+    var items: [Item] = []
+
+    func fetchItems() async throws {
+        items = try await repository.fetchAll()
+    }
+
+    func saveItem(_ item: Item) async throws {
+        guard validator.isValid(item) else { throw ValidationError.invalid }
+        try await repository.save(item)
+    }
+}
+```
+
+### God Object AppState
+```swift
+// Wrong - single state object for everything
+@Observable class AppState {
+    var user: User?
+    var documents: [Document] = []
+    var settings: Settings = .default
+    var networkStatus: NetworkStatus = .unknown
+    var notifications: [AppNotification] = []
+    // ... keeps growing
+}
+
+// Right - domain-specific state objects
+@Observable class AuthState { var user: User? }
+@Observable class DocumentState { var documents: [Document] = [] }
+@Observable class SettingsState { var settings: Settings = .default }
+```
+
+### Untestable Dependencies
+```swift
+// Wrong - hard-coded dependency
+class DocumentService {
+    func save(_ doc: Document) {
+        let encoder = JSONEncoder()
+        let data = try! encoder.encode(doc)
+        try! data.write(to: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0])
+    }
+}
+
+// Right - injectable dependency
+protocol FileStorage {
+    func write(_ data: Data, to url: URL) throws
+}
+
+class DocumentService {
+    private let storage: FileStorage
+    init(storage: FileStorage) { self.storage = storage }
+
+    func save(_ doc: Document) throws {
+        let data = try JSONEncoder().encode(doc)
+        try storage.write(data, to: documentURL)
+    }
+}
+```
+
+## Module References
+
+Load these modules as needed:
+
+1. **SOLID Principles**: `solid-detailed.md`
+   - Each principle with real-world Swift examples
+   - Refactoring patterns for violations
+   - When to bend the rules pragmatically
+
+2. **Design Patterns**: `design-patterns.md`
+   - MVVM, Repository, Factory, Observer, Coordinator
+   - Swift-specific implementations
+   - When to use which pattern
+
+3. **Modular Design**: `modular-design.md`
+   - SPM package structure
+   - Feature vs. layer organization
+   - Dependency management
+
+## Response Guidelines
+
+- Be pragmatic — don't over-architect small apps
+- Show before/after code for refactoring suggestions
+- Acknowledge trade-offs (abstraction vs. simplicity)
+- Consider the team size and project phase
+- Prefer composition over inheritance
+- Leverage Swift's type system (protocols, generics, enums) for safety

--- a/.claude/skills/macos-development/architecture-patterns/solid-detailed.md
+++ b/.claude/skills/macos-development/architecture-patterns/solid-detailed.md
@@ -1,0 +1,313 @@
+# SOLID Principles in Detail
+
+Real-world Swift examples for each SOLID principle with refactoring patterns. Focus on practical application, not academic theory.
+
+## Single Responsibility Principle (SRP)
+
+**A type should have one reason to change.**
+
+### Violation
+
+```swift
+class DocumentManager {
+    var documents: [Document] = []
+
+    // Responsibility 1: Document CRUD
+    func createDocument(title: String) -> Document { ... }
+    func deleteDocument(_ doc: Document) { ... }
+
+    // Responsibility 2: Persistence
+    func saveToFile(_ doc: Document) throws { ... }
+    func loadFromFile(_ url: URL) throws -> Document { ... }
+
+    // Responsibility 3: Export
+    func exportToPDF(_ doc: Document) -> Data { ... }
+    func exportToHTML(_ doc: Document) -> String { ... }
+
+    // Responsibility 4: Search
+    func search(query: String) -> [Document] { ... }
+}
+```
+
+### Refactored
+
+```swift
+// Each class has one reason to change
+@Observable class DocumentStore {
+    var documents: [Document] = []
+    func create(title: String) -> Document { ... }
+    func delete(_ doc: Document) { ... }
+}
+
+struct DocumentPersistence {
+    func save(_ doc: Document, to url: URL) throws { ... }
+    func load(from url: URL) throws -> Document { ... }
+}
+
+struct DocumentExporter {
+    func toPDF(_ doc: Document) -> Data { ... }
+    func toHTML(_ doc: Document) -> String { ... }
+}
+
+struct DocumentSearch {
+    func search(_ documents: [Document], query: String) -> [Document] { ... }
+}
+```
+
+### When to Bend SRP
+- **Tiny apps**: A single ViewModel handling fetch + display is fine for 1-2 screens
+- **Data models**: `@Model` classes naturally combine data + persistence — that's SwiftData's design
+- **Value types**: Small structs with 2-3 responsibilities are often clearer than over-split types
+
+## Open/Closed Principle (OCP)
+
+**Open for extension, closed for modification.**
+
+Use protocols and enums to add behavior without changing existing code.
+
+### Violation
+
+```swift
+class ReportGenerator {
+    func generate(type: String, data: ReportData) -> String {
+        switch type {
+        case "pdf": return generatePDF(data)
+        case "html": return generateHTML(data)
+        case "csv": return generateCSV(data)
+        // Adding "markdown" requires modifying this class
+        default: fatalError()
+        }
+    }
+}
+```
+
+### Refactored
+
+```swift
+protocol ReportFormat {
+    func generate(from data: ReportData) -> String
+}
+
+struct PDFReport: ReportFormat {
+    func generate(from data: ReportData) -> String { ... }
+}
+
+struct HTMLReport: ReportFormat {
+    func generate(from data: ReportData) -> String { ... }
+}
+
+// Adding Markdown requires no changes to existing code
+struct MarkdownReport: ReportFormat {
+    func generate(from data: ReportData) -> String { ... }
+}
+
+class ReportGenerator {
+    func generate(format: ReportFormat, data: ReportData) -> String {
+        format.generate(from: data)
+    }
+}
+```
+
+### Swift-Specific OCP: Protocol Extensions
+
+```swift
+protocol Cacheable {
+    var cacheKey: String { get }
+    var cacheExpiry: TimeInterval { get }
+}
+
+// Default behavior via extension — open for override, closed for modification
+extension Cacheable {
+    var cacheExpiry: TimeInterval { 300 } // 5 minutes default
+}
+```
+
+## Liskov Substitution Principle (LSP)
+
+**Subtypes must be substitutable for their base types without breaking behavior.**
+
+### Violation
+
+```swift
+class FileStorage {
+    func save(_ data: Data, to path: String) throws { ... }
+    func load(from path: String) throws -> Data { ... }
+    func delete(at path: String) throws { ... }
+}
+
+class ReadOnlyStorage: FileStorage {
+    override func save(_ data: Data, to path: String) throws {
+        throw StorageError.readOnly  // Breaks the contract!
+    }
+    override func delete(at path: String) throws {
+        throw StorageError.readOnly  // Breaks the contract!
+    }
+}
+```
+
+### Refactored
+
+```swift
+protocol ReadableStorage {
+    func load(from path: String) throws -> Data
+}
+
+protocol WritableStorage: ReadableStorage {
+    func save(_ data: Data, to path: String) throws
+    func delete(at path: String) throws
+}
+
+struct FileStorage: WritableStorage {
+    func load(from path: String) throws -> Data { ... }
+    func save(_ data: Data, to path: String) throws { ... }
+    func delete(at path: String) throws { ... }
+}
+
+struct BundleStorage: ReadableStorage {
+    func load(from path: String) throws -> Data { ... }
+    // No save/delete — not part of the contract
+}
+```
+
+## Interface Segregation Principle (ISP)
+
+**Clients shouldn't depend on methods they don't use.**
+
+### Violation
+
+```swift
+protocol DataService {
+    func fetchUsers() async throws -> [User]
+    func fetchPosts() async throws -> [Post]
+    func fetchComments() async throws -> [Comment]
+    func createUser(_ user: User) async throws
+    func createPost(_ post: Post) async throws
+    func deleteUser(_ id: UUID) async throws
+}
+
+// UserListView only needs fetchUsers but depends on the entire protocol
+struct UserListViewModel {
+    let service: DataService  // Forced to depend on posts, comments, etc.
+}
+```
+
+### Refactored
+
+```swift
+protocol UserFetching {
+    func fetchUsers() async throws -> [User]
+}
+
+protocol UserManaging: UserFetching {
+    func createUser(_ user: User) async throws
+    func deleteUser(_ id: UUID) async throws
+}
+
+protocol PostFetching {
+    func fetchPosts() async throws -> [Post]
+}
+
+// A single concrete type can conform to all
+class APIService: UserManaging, PostFetching {
+    func fetchUsers() async throws -> [User] { ... }
+    func createUser(_ user: User) async throws { ... }
+    func deleteUser(_ id: UUID) async throws { ... }
+    func fetchPosts() async throws -> [Post] { ... }
+}
+
+// Each consumer depends only on what it needs
+struct UserListViewModel {
+    let userFetcher: UserFetching  // Minimal dependency
+}
+```
+
+## Dependency Inversion Principle (DIP)
+
+**High-level modules shouldn't depend on low-level modules. Both should depend on abstractions.**
+
+### Violation
+
+```swift
+class AnalyticsViewModel {
+    let tracker = FirebaseAnalytics()  // Direct dependency on concrete type
+
+    func trackEvent(_ name: String) {
+        tracker.logEvent(name, parameters: nil)
+    }
+}
+```
+
+### Refactored
+
+```swift
+protocol AnalyticsTracking {
+    func trackEvent(_ name: String, properties: [String: Any])
+}
+
+struct FirebaseTracker: AnalyticsTracking {
+    func trackEvent(_ name: String, properties: [String: Any]) { ... }
+}
+
+struct MockTracker: AnalyticsTracking {
+    var trackedEvents: [(String, [String: Any])] = []
+    mutating func trackEvent(_ name: String, properties: [String: Any]) {
+        trackedEvents.append((name, properties))
+    }
+}
+
+@Observable class AnalyticsViewModel {
+    private let tracker: AnalyticsTracking
+
+    init(tracker: AnalyticsTracking) {
+        self.tracker = tracker
+    }
+}
+```
+
+### DIP with SwiftUI Environment
+
+```swift
+// Define the abstraction
+protocol ImageLoader {
+    func load(url: URL) async throws -> NSImage
+}
+
+// Environment key
+struct ImageLoaderKey: EnvironmentKey {
+    static let defaultValue: ImageLoader = URLSessionImageLoader()
+}
+
+extension EnvironmentValues {
+    var imageLoader: ImageLoader {
+        get { self[ImageLoaderKey.self] }
+        set { self[ImageLoaderKey.self] = newValue }
+    }
+}
+
+// Inject via environment
+ContentView()
+    .environment(\.imageLoader, CachedImageLoader())
+
+// Consume in views
+struct ThumbnailView: View {
+    @Environment(\.imageLoader) private var imageLoader
+}
+```
+
+## Pragmatic SOLID
+
+SOLID principles are guidelines, not laws. Apply them proportionally:
+
+| App Size | SRP | OCP | LSP | ISP | DIP |
+|----------|-----|-----|-----|-----|-----|
+| Prototype | Loose | Skip | Follow | Skip | Skip |
+| Small (1-3 screens) | Moderate | Where natural | Follow | Light | For testing |
+| Medium (4-10 screens) | Strict | For extensible areas | Follow | Moderate | For services |
+| Large (10+ screens) | Strict | Everywhere | Follow | Strict | Everywhere |
+
+**Rules of thumb:**
+- If a class is under 100 lines, SRP violations are probably fine
+- If you'll never extend a type, OCP is unnecessary overhead
+- LSP should always be followed — it prevents bugs
+- ISP matters most at module boundaries
+- DIP matters most for testability and swappable implementations

--- a/.claude/skills/macos-development/coding-best-practices/architecture-principles.md
+++ b/.claude/skills/macos-development/coding-best-practices/architecture-principles.md
@@ -1,0 +1,659 @@
+# Architecture & Design Principles
+
+SOLID principles, DRY, Clean Architecture, and design patterns for macOS development.
+
+## SOLID Principles
+
+### S - Single Responsibility Principle (SRP)
+
+**Definition**: A class should have only one reason to change.
+
+```swift
+// ❌ BAD: Multiple responsibilities
+class UserViewController: NSViewController {
+    func loadUser() {
+        // Network call
+        let url = URL(string: "https://api.example.com/user")!
+        URLSession.shared.dataTask(with: url) { data, _, _ in
+            // Parsing
+            let user = try? JSONDecoder().decode(User.self, from: data!)
+            // Database saving
+            try? self.saveToDatabase(user!)
+            // UI update
+            DispatchQueue.main.async {
+                self.nameLabel.stringValue = user!.name
+            }
+        }.resume()
+    }
+}
+
+// ✅ GOOD: Separated responsibilities
+protocol UserRepository {
+    func fetchUser(id: UUID) async throws -> User
+}
+
+class NetworkUserRepository: UserRepository {
+    func fetchUser(id: UUID) async throws -> User {
+        // Only handles network calls
+    }
+}
+
+@MainActor
+class UserViewModel: ObservableObject {
+    @Published var user: User?
+    private let repository: UserRepository
+
+    init(repository: UserRepository) {
+        self.repository = repository
+    }
+
+    func loadUser(id: UUID) async {
+        do {
+            user = try await repository.fetchUser(id: id)
+        } catch {
+            // Handle error
+        }
+    }
+}
+
+class UserViewController: NSViewController {
+    private let viewModel: UserViewModel
+
+    // Only handles UI updates
+    func updateUI() {
+        nameLabel.stringValue = viewModel.user?.name ?? ""
+    }
+}
+```
+
+### O - Open/Closed Principle (OCP)
+
+**Definition**: Software entities should be open for extension but closed for modification.
+
+```swift
+// ❌ BAD: Must modify class to add new export formats
+class DocumentExporter {
+    func export(_ document: Document, format: String) throws -> Data {
+        switch format {
+        case "pdf":
+            return exportToPDF(document)
+        case "html":
+            return exportToHTML(document)
+        default:
+            throw ExportError.unsupportedFormat
+        }
+    }
+}
+
+// ✅ GOOD: Open for extension via protocols
+protocol DocumentExportStrategy {
+    func export(_ document: Document) throws -> Data
+}
+
+class PDFExportStrategy: DocumentExportStrategy {
+    func export(_ document: Document) throws -> Data {
+        // PDF export logic
+    }
+}
+
+class HTMLExportStrategy: DocumentExportStrategy {
+    func export(_ document: Document) throws -> Data {
+        // HTML export logic
+    }
+}
+
+class MarkdownExportStrategy: DocumentExportStrategy {
+    func export(_ document: Document) throws -> Data {
+        // Markdown export logic - new format added without modifying existing code
+    }
+}
+
+class DocumentExporter {
+    func export(_ document: Document, using strategy: DocumentExportStrategy) throws -> Data {
+        try strategy.export(document)
+    }
+}
+```
+
+### L - Liskov Substitution Principle (LSP)
+
+**Definition**: Subtypes must be substitutable for their base types.
+
+```swift
+// ❌ BAD: Violates LSP - ReadOnlyDocument can't fulfill Document contract
+class Document {
+    var content: String
+
+    func save() throws {
+        // Save to disk
+    }
+}
+
+class ReadOnlyDocument: Document {
+    override func save() throws {
+        throw DocumentError.readOnly  // Violates contract!
+    }
+}
+
+// ✅ GOOD: Proper abstraction
+protocol Readable {
+    var content: String { get }
+}
+
+protocol Writable {
+    var content: String { get set }
+    func save() throws
+}
+
+class Document: Readable, Writable {
+    var content: String
+
+    func save() throws {
+        // Save to disk
+    }
+}
+
+class ReadOnlyDocument: Readable {
+    let content: String  // Immutable, as expected
+
+    init(content: String) {
+        self.content = content
+    }
+}
+
+// Now functions can require only what they need
+func displayContent(_ document: Readable) {
+    print(document.content)  // Works with both types
+}
+
+func editContent(_ document: Writable) {
+    // Works only with writable documents
+}
+```
+
+### I - Interface Segregation Principle (ISP)
+
+**Definition**: Clients should not be forced to depend on interfaces they don't use.
+
+```swift
+// ❌ BAD: Fat protocol forcing unnecessary implementations
+protocol MediaPlayer {
+    func play()
+    func pause()
+    func stop()
+    func adjustVolume(_ volume: Int)
+    func showSubtitles(_ show: Bool)
+    func setPlaybackSpeed(_ speed: Double)
+}
+
+class AudioPlayer: MediaPlayer {
+    func play() { /* ... */ }
+    func pause() { /* ... */ }
+    func stop() { /* ... */ }
+    func adjustVolume(_ volume: Int) { /* ... */ }
+    func showSubtitles(_ show: Bool) { /* Not applicable! */ }
+    func setPlaybackSpeed(_ speed: Double) { /* Not applicable! */ }
+}
+
+// ✅ GOOD: Segregated interfaces
+protocol Playable {
+    func play()
+    func pause()
+    func stop()
+}
+
+protocol VolumeControllable {
+    func adjustVolume(_ volume: Int)
+}
+
+protocol SubtitleSupporting {
+    func showSubtitles(_ show: Bool)
+}
+
+protocol PlaybackSpeedControllable {
+    func setPlaybackSpeed(_ speed: Double)
+}
+
+class AudioPlayer: Playable, VolumeControllable {
+    func play() { /* ... */ }
+    func pause() { /* ... */ }
+    func stop() { /* ... */ }
+    func adjustVolume(_ volume: Int) { /* ... */ }
+    // No forced subtitle implementation!
+}
+
+class VideoPlayer: Playable, VolumeControllable, SubtitleSupporting, PlaybackSpeedControllable {
+    // Implements all relevant protocols
+}
+```
+
+### D - Dependency Inversion Principle (DIP)
+
+**Definition**: High-level modules should not depend on low-level modules. Both should depend on abstractions.
+
+```swift
+// ❌ BAD: High-level class depends on concrete implementation
+class ArticleViewController: NSViewController {
+    private let database = CoreDataManager()  // Concrete dependency!
+
+    func loadArticles() {
+        let articles = database.fetchArticles()
+        // Update UI
+    }
+}
+
+// ✅ GOOD: Depend on abstraction
+protocol ArticleRepository {
+    func fetchArticles() async throws -> [Article]
+    func save(_ article: Article) async throws
+}
+
+class CoreDataArticleRepository: ArticleRepository {
+    func fetchArticles() async throws -> [Article] {
+        // Core Data implementation
+    }
+
+    func save(_ article: Article) async throws {
+        // Core Data implementation
+    }
+}
+
+class SwiftDataArticleRepository: ArticleRepository {
+    func fetchArticles() async throws -> [Article] {
+        // SwiftData implementation
+    }
+
+    func save(_ article: Article) async throws {
+        // SwiftData implementation
+    }
+}
+
+@MainActor
+class ArticleViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    private let repository: ArticleRepository  // Depends on abstraction!
+
+    init(repository: ArticleRepository) {
+        self.repository = repository
+    }
+
+    func loadArticles() async {
+        do {
+            articles = try await repository.fetchArticles()
+        } catch {
+            // Handle error
+        }
+    }
+}
+
+// Easy to swap implementations or mock for testing
+let viewModel = ArticleViewModel(repository: SwiftDataArticleRepository())
+let testViewModel = ArticleViewModel(repository: MockArticleRepository())
+```
+
+## DRY Principle (Don't Repeat Yourself)
+
+**Definition**: Every piece of knowledge must have a single, unambiguous representation.
+
+### Code Duplication
+```swift
+// ❌ BAD: Repeated validation logic
+func createUser(name: String, email: String) throws {
+    if name.isEmpty {
+        throw ValidationError.emptyName
+    }
+    if !email.contains("@") {
+        throw ValidationError.invalidEmail
+    }
+    // Create user
+}
+
+func updateUser(name: String, email: String) throws {
+    if name.isEmpty {
+        throw ValidationError.emptyName
+    }
+    if !email.contains("@") {
+        throw ValidationError.invalidEmail
+    }
+    // Update user
+}
+
+// ✅ GOOD: Extract common validation
+struct UserValidator {
+    static func validate(name: String, email: String) throws {
+        guard !name.isEmpty else {
+            throw ValidationError.emptyName
+        }
+        guard email.contains("@") else {
+            throw ValidationError.invalidEmail
+        }
+    }
+}
+
+func createUser(name: String, email: String) throws {
+    try UserValidator.validate(name: name, email: email)
+    // Create user
+}
+
+func updateUser(name: String, email: String) throws {
+    try UserValidator.validate(name: name, email: email)
+    // Update user
+}
+```
+
+### SwiftUI View Duplication
+```swift
+// ❌ BAD: Repeated UI components
+struct ProfileView: View {
+    var body: some View {
+        VStack {
+            HStack {
+                Image(systemName: "person")
+                Text("John Doe")
+                    .font(.headline)
+            }
+            .padding()
+            .background(Color.gray.opacity(0.2))
+            .cornerRadius(8)
+
+            HStack {
+                Image(systemName: "envelope")
+                Text("john@example.com")
+                    .font(.headline)
+            }
+            .padding()
+            .background(Color.gray.opacity(0.2))
+            .cornerRadius(8)
+        }
+    }
+}
+
+// ✅ GOOD: Reusable component
+struct InfoRow: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        HStack {
+            Image(systemName: icon)
+            Text(text)
+                .font(.headline)
+        }
+        .padding()
+        .background(Color.gray.opacity(0.2))
+        .cornerRadius(8)
+    }
+}
+
+struct ProfileView: View {
+    var body: some View {
+        VStack {
+            InfoRow(icon: "person", text: "John Doe")
+            InfoRow(icon: "envelope", text: "john@example.com")
+        }
+    }
+}
+```
+
+### Configuration Duplication
+```swift
+// ❌ BAD: Hardcoded values everywhere
+class NetworkManager {
+    func fetchUsers() async throws -> [User] {
+        let url = URL(string: "https://api.example.com/users")!
+        // ...
+    }
+
+    func fetchPosts() async throws -> [Post] {
+        let url = URL(string: "https://api.example.com/posts")!
+        // ...
+    }
+}
+
+// ✅ GOOD: Centralized configuration
+enum APIEndpoint {
+    case users
+    case posts
+    case articles
+
+    var url: URL {
+        let baseURL = "https://api.example.com"
+        switch self {
+        case .users: return URL(string: "\(baseURL)/users")!
+        case .posts: return URL(string: "\(baseURL)/posts")!
+        case .articles: return URL(string: "\(baseURL)/articles")!
+        }
+    }
+}
+
+class NetworkManager {
+    func fetch<T: Decodable>(from endpoint: APIEndpoint) async throws -> T {
+        let url = endpoint.url
+        // Single fetch implementation
+    }
+
+    func fetchUsers() async throws -> [User] {
+        try await fetch(from: .users)
+    }
+
+    func fetchPosts() async throws -> [Post] {
+        try await fetch(from: .posts)
+    }
+}
+```
+
+## Clean Architecture
+
+### Layer Separation
+```swift
+// Domain Layer - Business logic, no framework dependencies
+struct Article {
+    let id: UUID
+    let title: String
+    let content: String
+    let author: Author
+}
+
+protocol ArticleRepository {
+    func fetch(id: UUID) async throws -> Article
+    func save(_ article: Article) async throws
+}
+
+class ArticleUseCase {
+    private let repository: ArticleRepository
+
+    init(repository: ArticleRepository) {
+        self.repository = repository
+    }
+
+    func publishArticle(_ article: Article) async throws {
+        // Business logic
+        guard article.content.count > 100 else {
+            throw ValidationError.contentTooShort
+        }
+        try await repository.save(article)
+    }
+}
+
+// Data Layer - Framework-specific implementations
+import SwiftData
+
+@Model
+class ArticleEntity {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var content: String
+    // SwiftData specific
+}
+
+class SwiftDataArticleRepository: ArticleRepository {
+    private let modelContext: ModelContext
+
+    func fetch(id: UUID) async throws -> Article {
+        // Convert ArticleEntity to Article
+    }
+
+    func save(_ article: Article) async throws {
+        // Convert Article to ArticleEntity and save
+    }
+}
+
+// Presentation Layer - SwiftUI/AppKit
+@MainActor
+class ArticleViewModel: ObservableObject {
+    @Published var article: Article?
+    private let useCase: ArticleUseCase
+
+    init(useCase: ArticleUseCase) {
+        self.useCase = useCase
+    }
+
+    func publish() async {
+        guard let article else { return }
+        do {
+            try await useCase.publishArticle(article)
+        } catch {
+            // Handle error
+        }
+    }
+}
+```
+
+## Dependency Injection
+
+### Constructor Injection (Preferred)
+```swift
+// ✅ GOOD: Dependencies injected via initializer
+class ArticleService {
+    private let repository: ArticleRepository
+    private let logger: Logger
+    private let validator: ArticleValidator
+
+    init(
+        repository: ArticleRepository,
+        logger: Logger,
+        validator: ArticleValidator
+    ) {
+        self.repository = repository
+        self.logger = logger
+        self.validator = validator
+    }
+}
+```
+
+### Property Injection (Use Sparingly)
+```swift
+// Use for SwiftUI Environment
+struct ArticleListView: View {
+    @Environment(\.articleRepository) var repository
+
+    var body: some View {
+        // Use repository
+    }
+}
+
+// Define environment key
+private struct ArticleRepositoryKey: EnvironmentKey {
+    static let defaultValue: ArticleRepository = MockArticleRepository()
+}
+
+extension EnvironmentValues {
+    var articleRepository: ArticleRepository {
+        get { self[ArticleRepositoryKey.self] }
+        set { self[ArticleRepositoryKey.self] = newValue }
+    }
+}
+```
+
+### Service Locator (Avoid When Possible)
+```swift
+// ⚠️ Use sparingly - hides dependencies
+class ServiceLocator {
+    static let shared = ServiceLocator()
+
+    private var services: [String: Any] = [:]
+
+    func register<T>(_ service: T, for type: T.Type) {
+        let key = String(describing: type)
+        services[key] = service
+    }
+
+    func resolve<T>(_ type: T.Type) -> T? {
+        let key = String(describing: type)
+        return services[key] as? T
+    }
+}
+
+// Better: Use constructor injection instead
+```
+
+## Composition Over Inheritance
+
+```swift
+// ❌ BAD: Deep inheritance hierarchy
+class Vehicle {
+    func start() { }
+}
+
+class Car: Vehicle {
+    func honk() { }
+}
+
+class ElectricCar: Car {
+    func charge() { }
+}
+
+class TeslaModelS: ElectricCar {
+    // Too deep!
+}
+
+// ✅ GOOD: Composition with protocols
+protocol Startable {
+    func start()
+}
+
+protocol Honkable {
+    func honk()
+}
+
+protocol Chargeable {
+    func charge()
+}
+
+struct ElectricCar: Startable, Honkable, Chargeable {
+    private let engine: ElectricEngine
+    private let horn: Horn
+    private let battery: Battery
+
+    func start() {
+        engine.start()
+    }
+
+    func honk() {
+        horn.makeSound()
+    }
+
+    func charge() {
+        battery.charge()
+    }
+}
+```
+
+## Architecture Patterns Checklist
+
+- [ ] **SOLID**: Each class has single responsibility
+- [ ] **SOLID**: Code open for extension, closed for modification
+- [ ] **SOLID**: Subtypes properly substitutable
+- [ ] **SOLID**: Interfaces are segregated and focused
+- [ ] **SOLID**: Depend on abstractions, not concretions
+- [ ] **DRY**: No duplicated logic or configuration
+- [ ] **Clean Architecture**: Clear layer separation
+- [ ] **DI**: Dependencies injected, not created internally
+- [ ] **Composition**: Prefer composition over inheritance
+- [ ] **Testability**: Easy to mock and test
+
+## Resources
+
+- [SOLID Principles](https://en.wikipedia.org/wiki/SOLID)
+- [Clean Architecture by Robert C. Martin](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
+- [Swift Design Patterns](https://refactoring.guru/design-patterns/swift)

--- a/.claude/skills/macos-development/coding-best-practices/code-organization.md
+++ b/.claude/skills/macos-development/coding-best-practices/code-organization.md
@@ -1,0 +1,615 @@
+# Code Organization Best Practices
+
+Modular architecture, project structure, and separation of concerns for macOS development.
+
+## Project Structure
+
+### Feature-Based Organization (Recommended)
+
+```
+MyMacApp/
+├── App/
+│   ├── MyMacApp.swift
+│   └── AppDelegate.swift
+├── Features/
+│   ├── Articles/
+│   │   ├── Views/
+│   │   │   ├── ArticleListView.swift
+│   │   │   ├── ArticleDetailView.swift
+│   │   │   └── ArticleEditorView.swift
+│   │   ├── ViewModels/
+│   │   │   ├── ArticleListViewModel.swift
+│   │   │   └── ArticleEditorViewModel.swift
+│   │   ├── Models/
+│   │   │   └── Article.swift
+│   │   └── Services/
+│   │       └── ArticleRepository.swift
+│   ├── Authors/
+│   │   ├── Views/
+│   │   ├── ViewModels/
+│   │   ├── Models/
+│   │   └── Services/
+│   └── Settings/
+│       ├── Views/
+│       ├── ViewModels/
+│       └── Models/
+├── Core/
+│   ├── Data/
+│   │   ├── SwiftDataStack.swift
+│   │   └── ModelContainer+Extensions.swift
+│   ├── Networking/
+│   │   ├── NetworkManager.swift
+│   │   ├── APIEndpoint.swift
+│   │   └── NetworkError.swift
+│   ├── Extensions/
+│   │   ├── Date+Extensions.swift
+│   │   ├── String+Extensions.swift
+│   │   └── View+Extensions.swift
+│   └── Utilities/
+│       ├── Logger.swift
+│       └── Validator.swift
+├── Resources/
+│   ├── Assets.xcassets
+│   ├── Localization/
+│   └── Fonts/
+└── Tests/
+    ├── ArticlesTests/
+    ├── AuthorsTests/
+    └── CoreTests/
+```
+
+### Layer-Based Organization (Alternative)
+
+```
+MyMacApp/
+├── Presentation/
+│   ├── SwiftUI/
+│   │   ├── Articles/
+│   │   └── Settings/
+│   ├── AppKit/
+│   │   └── CustomViews/
+│   └── ViewModels/
+├── Domain/
+│   ├── Models/
+│   ├── UseCases/
+│   └── Interfaces/
+├── Data/
+│   ├── Repositories/
+│   ├── DataSources/
+│   └── SwiftData/
+└── Infrastructure/
+    ├── Networking/
+    └── Utilities/
+```
+
+## Swift Package Manager Organization
+
+### Multi-Module Architecture
+
+```swift
+// Package.swift
+let package = Package(
+    name: "MyMacApp",
+    platforms: [.macOS(.v14)],
+    products: [
+        .library(name: "ArticleFeature", targets: ["ArticleFeature"]),
+        .library(name: "CoreKit", targets: ["CoreKit"]),
+        .library(name: "NetworkKit", targets: ["NetworkKit"]),
+    ],
+    dependencies: [
+        // External dependencies
+    ],
+    targets: [
+        // Feature modules
+        .target(
+            name: "ArticleFeature",
+            dependencies: ["CoreKit", "NetworkKit"]
+        ),
+        .testTarget(
+            name: "ArticleFeatureTests",
+            dependencies: ["ArticleFeature"]
+        ),
+
+        // Core module
+        .target(
+            name: "CoreKit",
+            dependencies: []
+        ),
+
+        // Network module
+        .target(
+            name: "NetworkKit",
+            dependencies: ["CoreKit"]
+        ),
+    ]
+)
+```
+
+### Benefits of SPM Modules
+
+```swift
+// ✅ GOOD: Clear dependencies and boundaries
+import ArticleFeature  // Only imports what's needed
+import CoreKit
+
+// Each module can be:
+// - Built independently
+// - Tested in isolation
+// - Reused across targets
+// - Versioned separately
+```
+
+## Separation of Concerns
+
+### MVVM Pattern for SwiftUI
+
+```swift
+// ❌ BAD: View doing too much
+struct ArticleListView: View {
+    @State private var articles: [Article] = []
+
+    var body: some View {
+        List(articles) { article in
+            Text(article.title)
+        }
+        .task {
+            // Bad: Networking in view
+            let url = URL(string: "https://api.example.com/articles")!
+            let (data, _) = try! await URLSession.shared.data(from: url)
+            articles = try! JSONDecoder().decode([Article].self, from: data)
+        }
+    }
+}
+
+// ✅ GOOD: Proper separation
+@MainActor
+class ArticleListViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    @Published var isLoading = false
+    @Published var error: Error?
+
+    private let repository: ArticleRepository
+
+    init(repository: ArticleRepository) {
+        self.repository = repository
+    }
+
+    func loadArticles() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            articles = try await repository.fetchArticles()
+        } catch {
+            self.error = error
+        }
+    }
+}
+
+struct ArticleListView: View {
+    @StateObject private var viewModel: ArticleListViewModel
+
+    init(repository: ArticleRepository) {
+        _viewModel = StateObject(
+            wrappedValue: ArticleListViewModel(repository: repository)
+        )
+    }
+
+    var body: some View {
+        Group {
+            if viewModel.isLoading {
+                ProgressView()
+            } else {
+                List(viewModel.articles) { article in
+                    Text(article.title)
+                }
+            }
+        }
+        .task {
+            await viewModel.loadArticles()
+        }
+    }
+}
+```
+
+### Repository Pattern
+
+```swift
+// ✅ GOOD: Protocol defines contract
+protocol ArticleRepository {
+    func fetchArticles() async throws -> [Article]
+    func fetchArticle(id: UUID) async throws -> Article?
+    func save(_ article: Article) async throws
+    func delete(id: UUID) async throws
+}
+
+// Implementation 1: SwiftData
+class SwiftDataArticleRepository: ArticleRepository {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func fetchArticles() async throws -> [Article] {
+        let descriptor = FetchDescriptor<Article>(
+            sortBy: [SortDescriptor(\.publishedDate, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    func save(_ article: Article) async throws {
+        modelContext.insert(article)
+        try modelContext.save()
+    }
+
+    // ... other methods
+}
+
+// Implementation 2: Network
+class NetworkArticleRepository: ArticleRepository {
+    private let networkManager: NetworkManager
+
+    init(networkManager: NetworkManager) {
+        self.networkManager = networkManager
+    }
+
+    func fetchArticles() async throws -> [Article] {
+        try await networkManager.fetch(from: .articles)
+    }
+
+    // ... other methods
+}
+
+// Implementation 3: Mock for testing
+class MockArticleRepository: ArticleRepository {
+    var articles: [Article] = []
+
+    func fetchArticles() async throws -> [Article] {
+        articles
+    }
+
+    func save(_ article: Article) async throws {
+        articles.append(article)
+    }
+
+    // ... other methods
+}
+```
+
+## File Organization Best Practices
+
+### Single Responsibility per File
+
+```swift
+// ✅ GOOD: One type per file
+// Article.swift
+struct Article: Identifiable {
+    let id: UUID
+    var title: String
+    var content: String
+}
+
+// ArticleValidator.swift
+struct ArticleValidator {
+    static func validate(_ article: Article) throws {
+        // Validation logic
+    }
+}
+
+// ArticleFormatter.swift
+struct ArticleFormatter {
+    static func format(_ article: Article) -> String {
+        // Formatting logic
+    }
+}
+
+// ❌ BAD: Multiple unrelated types in one file
+// ArticleHelpers.swift
+struct Article { }
+struct ArticleValidator { }
+struct ArticleFormatter { }
+class ArticleManager { }
+```
+
+### Extension Organization
+
+```swift
+// Article.swift - Main definition
+struct Article: Identifiable {
+    let id: UUID
+    var title: String
+    var content: String
+}
+
+// Article+Validation.swift - Validation logic
+extension Article {
+    func validate() throws {
+        guard !title.isEmpty else {
+            throw ValidationError.emptyTitle
+        }
+    }
+}
+
+// Article+Formatting.swift - Formatting logic
+extension Article {
+    var formattedPublishDate: String {
+        publishedDate.formatted(date: .long, time: .omitted)
+    }
+}
+
+// Article+Codable.swift - Codable conformance
+extension Article: Codable { }
+```
+
+## Dependency Management
+
+### Composition Root
+
+```swift
+// ✅ GOOD: Single place for dependency setup
+@main
+struct MyMacApp: App {
+    let dependencyContainer: DependencyContainer
+
+    init() {
+        dependencyContainer = DependencyContainer()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.articleRepository, dependencyContainer.articleRepository)
+                .environment(\.networkManager, dependencyContainer.networkManager)
+        }
+    }
+}
+
+class DependencyContainer {
+    // Singletons
+    lazy var networkManager: NetworkManager = {
+        NetworkManager()
+    }()
+
+    lazy var modelContainer: ModelContainer = {
+        try! ModelContainer(for: Article.self, Author.self)
+    }()
+
+    // Factories
+    var articleRepository: ArticleRepository {
+        SwiftDataArticleRepository(
+            modelContext: modelContainer.mainContext
+        )
+    }
+
+    var articleListViewModel: ArticleListViewModel {
+        ArticleListViewModel(repository: articleRepository)
+    }
+}
+```
+
+### Environment for SwiftUI
+
+```swift
+// Define environment keys
+private struct ArticleRepositoryKey: EnvironmentKey {
+    static let defaultValue: ArticleRepository = MockArticleRepository()
+}
+
+private struct NetworkManagerKey: EnvironmentKey {
+    static let defaultValue: NetworkManager = NetworkManager()
+}
+
+extension EnvironmentValues {
+    var articleRepository: ArticleRepository {
+        get { self[ArticleRepositoryKey.self] }
+        set { self[ArticleRepositoryKey.self] = newValue }
+    }
+
+    var networkManager: NetworkManager {
+        get { self[NetworkManagerKey.self] }
+        set { self[NetworkManagerKey.self] = newValue }
+    }
+}
+
+// Usage in views
+struct ArticleListView: View {
+    @Environment(\.articleRepository) var repository
+
+    var body: some View {
+        // Use repository
+    }
+}
+```
+
+## Code Reusability (DRY)
+
+### Extracting Common UI Components
+
+```swift
+// ✅ GOOD: Reusable components
+struct PrimaryButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.accentColor)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+        }
+    }
+}
+
+struct SecondaryButton: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.secondary.opacity(0.2))
+                .foregroundColor(.primary)
+                .cornerRadius(8)
+        }
+    }
+}
+
+// Usage
+VStack {
+    PrimaryButton(title: "Save") { save() }
+    SecondaryButton(title: "Cancel") { cancel() }
+}
+```
+
+### View Modifiers for Common Styles
+
+```swift
+// ✅ GOOD: Custom view modifiers
+struct CardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(Color.secondary.opacity(0.1))
+            .cornerRadius(12)
+            .shadow(radius: 2)
+    }
+}
+
+extension View {
+    func cardStyle() -> some View {
+        modifier(CardStyle())
+    }
+}
+
+// Usage
+Text("Content")
+    .cardStyle()
+```
+
+## Testing Organization
+
+```swift
+// Tests mirror source structure
+MyMacAppTests/
+├── Features/
+│   ├── Articles/
+│   │   ├── ArticleListViewModelTests.swift
+│   │   ├── ArticleRepositoryTests.swift
+│   │   └── ArticleValidatorTests.swift
+│   └── Settings/
+│       └── SettingsViewModelTests.swift
+└── Core/
+    ├── NetworkManagerTests.swift
+    └── ValidationTests.swift
+
+// ✅ GOOD: Test structure
+import XCTest
+@testable import MyMacApp
+
+final class ArticleListViewModelTests: XCTestCase {
+    var sut: ArticleListViewModel!
+    var mockRepository: MockArticleRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockRepository = MockArticleRepository()
+        sut = ArticleListViewModel(repository: mockRepository)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    func testLoadArticles_Success() async {
+        // Given
+        let expectedArticles = [
+            Article(title: "Test 1", content: "Content 1"),
+            Article(title: "Test 2", content: "Content 2")
+        ]
+        mockRepository.articles = expectedArticles
+
+        // When
+        await sut.loadArticles()
+
+        // Then
+        XCTAssertEqual(sut.articles.count, 2)
+        XCTAssertEqual(sut.articles[0].title, "Test 1")
+    }
+}
+```
+
+## Configuration Management
+
+```swift
+// ✅ GOOD: Environment-based configuration
+enum Environment {
+    case development
+    case staging
+    case production
+
+    static var current: Environment {
+        #if DEBUG
+        return .development
+        #else
+        return .production
+        #endif
+    }
+}
+
+struct Configuration {
+    let apiBaseURL: String
+    let apiKey: String
+    let enableLogging: Bool
+
+    static var current: Configuration {
+        switch Environment.current {
+        case .development:
+            return Configuration(
+                apiBaseURL: "https://dev-api.example.com",
+                apiKey: "dev-key",
+                enableLogging: true
+            )
+        case .staging:
+            return Configuration(
+                apiBaseURL: "https://staging-api.example.com",
+                apiKey: "staging-key",
+                enableLogging: true
+            )
+        case .production:
+            return Configuration(
+                apiBaseURL: "https://api.example.com",
+                apiKey: "prod-key",
+                enableLogging: false
+            )
+        }
+    }
+}
+```
+
+## Code Organization Checklist
+
+- [ ] Clear project structure (feature or layer-based)
+- [ ] One type per file (with exceptions for tiny related types)
+- [ ] Logical grouping of related files
+- [ ] Consistent naming conventions
+- [ ] Use of Swift Package Manager for modularity
+- [ ] Proper separation of concerns (MVVM/VIPER/etc.)
+- [ ] Repository pattern for data access
+- [ ] Dependency injection at composition root
+- [ ] Reusable UI components
+- [ ] Tests mirror source structure
+- [ ] Configuration management per environment
+
+## Resources
+
+- [Swift API Design Guidelines](https://swift.org/documentation/api-design-guidelines/)
+- [Swift Package Manager Documentation](https://swift.org/package-manager/)
+- [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

--- a/.claude/skills/macos-development/coding-best-practices/data-persistence.md
+++ b/.claude/skills/macos-development/coding-best-practices/data-persistence.md
@@ -1,0 +1,608 @@
+# Data Persistence Best Practices
+
+SwiftData-first approach with Core Data guidance for legacy scenarios.
+
+## SwiftData (Modern Approach)
+
+### Model Definition
+
+```swift
+import SwiftData
+
+// ✅ GOOD: Clean SwiftData model
+@Model
+final class Article {
+    @Attribute(.unique) var id: UUID
+    var title: String
+    var content: String
+    var publishedDate: Date
+    var author: Author?
+    var tags: [Tag]
+
+    init(title: String, content: String, author: Author? = nil) {
+        self.id = UUID()
+        self.title = title
+        self.content = content
+        self.publishedDate = Date()
+        self.author = author
+        self.tags = []
+    }
+}
+
+@Model
+final class Author {
+    @Attribute(.unique) var id: UUID
+    var name: String
+    var email: String
+
+    @Relationship(deleteRule: .cascade, inverse: \Article.author)
+    var articles: [Article]
+
+    init(name: String, email: String) {
+        self.id = UUID()
+        self.name = name
+        self.email = email
+        self.articles = []
+    }
+}
+
+@Model
+final class Tag {
+    @Attribute(.unique) var name: String
+    var articles: [Article]
+
+    init(name: String) {
+        self.name = name
+        self.articles = []
+    }
+}
+```
+
+### Relationships
+
+```swift
+// One-to-Many with cascade delete
+@Model
+final class Project {
+    var name: String
+
+    @Relationship(deleteRule: .cascade)
+    var tasks: [Task]
+}
+
+@Model
+final class Task {
+    var title: String
+    var project: Project?
+}
+
+// Many-to-Many
+@Model
+final class Student {
+    var name: String
+    var courses: [Course]
+}
+
+@Model
+final class Course {
+    var title: String
+    var students: [Student]
+}
+
+// One-to-One
+@Model
+final class User {
+    var username: String
+
+    @Relationship(deleteRule: .cascade)
+    var profile: UserProfile?
+}
+
+@Model
+final class UserProfile {
+    var bio: String
+    var avatarURL: URL?
+    var user: User?
+}
+```
+
+### Model Container Setup
+
+```swift
+import SwiftUI
+import SwiftData
+
+@main
+struct MyApp: App {
+    let modelContainer: ModelContainer
+
+    init() {
+        do {
+            let schema = Schema([
+                Article.self,
+                Author.self,
+                Tag.self
+            ])
+
+            let configuration = ModelConfiguration(
+                schema: schema,
+                isStoredInMemoryOnly: false,
+                allowsSave: true
+            )
+
+            modelContainer = try ModelContainer(
+                for: schema,
+                configurations: [configuration]
+            )
+        } catch {
+            fatalError("Failed to create ModelContainer: \(error)")
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .modelContainer(modelContainer)
+    }
+}
+
+// ✅ GOOD: In-memory container for testing
+extension ModelContainer {
+    static func preview() throws -> ModelContainer {
+        let schema = Schema([Article.self, Author.self, Tag.self])
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: true
+        )
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+}
+```
+
+### Querying Data
+
+```swift
+import SwiftUI
+import SwiftData
+
+// ✅ GOOD: Simple query
+struct ArticleListView: View {
+    @Query(sort: \Article.publishedDate, order: .reverse)
+    private var articles: [Article]
+
+    var body: some View {
+        List(articles) { article in
+            Text(article.title)
+        }
+    }
+}
+
+// ✅ GOOD: Filtered query
+struct ArticleListView: View {
+    @Query(
+        filter: #Predicate<Article> { article in
+            article.publishedDate > Date().addingTimeInterval(-86400 * 7)
+        },
+        sort: \Article.publishedDate,
+        order: .reverse
+    )
+    private var recentArticles: [Article]
+
+    var body: some View {
+        List(recentArticles) { article in
+            Text(article.title)
+        }
+    }
+}
+
+// ✅ GOOD: Dynamic query with init
+struct ArticleListView: View {
+    @Query private var articles: [Article]
+
+    init(authorName: String) {
+        let predicate = #Predicate<Article> { article in
+            article.author?.name == authorName
+        }
+        _articles = Query(
+            filter: predicate,
+            sort: \.publishedDate,
+            order: .reverse
+        )
+    }
+
+    var body: some View {
+        List(articles) { article in
+            Text(article.title)
+        }
+    }
+}
+```
+
+### Model Context Operations
+
+```swift
+import SwiftData
+
+@MainActor
+class ArticleViewModel: ObservableObject {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // ✅ GOOD: Insert
+    func createArticle(title: String, content: String) {
+        let article = Article(title: title, content: content)
+        modelContext.insert(article)
+
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error saving article: \(error)")
+        }
+    }
+
+    // ✅ GOOD: Update
+    func updateArticle(_ article: Article, title: String) {
+        article.title = title
+
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error updating article: \(error)")
+        }
+    }
+
+    // ✅ GOOD: Delete
+    func deleteArticle(_ article: Article) {
+        modelContext.delete(article)
+
+        do {
+            try modelContext.save()
+        } catch {
+            print("Error deleting article: \(error)")
+        }
+    }
+
+    // ✅ GOOD: Batch fetch
+    func fetchArticles(matching searchText: String) throws -> [Article] {
+        let predicate = #Predicate<Article> { article in
+            article.title.localizedStandardContains(searchText) ||
+            article.content.localizedStandardContains(searchText)
+        }
+
+        let descriptor = FetchDescriptor<Article>(
+            predicate: predicate,
+            sortBy: [SortDescriptor(\.publishedDate, order: .reverse)]
+        )
+
+        return try modelContext.fetch(descriptor)
+    }
+}
+```
+
+### Advanced Predicates
+
+```swift
+import Foundation
+import SwiftData
+
+// ✅ Complex filtering
+let predicate = #Predicate<Article> { article in
+    article.publishedDate > Date().addingTimeInterval(-86400 * 30) &&
+    article.author?.name == "John Doe" &&
+    article.tags.contains { $0.name == "Swift" }
+}
+
+// ✅ Text search
+let searchPredicate = #Predicate<Article> { article in
+    article.title.localizedStandardContains("SwiftData")
+}
+
+// ✅ Range filtering
+let rangePredicate = #Predicate<Article> { article in
+    article.publishedDate >= startDate &&
+    article.publishedDate <= endDate
+}
+
+// ✅ Combining predicates
+let combinedPredicate = #Predicate<Article> { article in
+    (article.title.localizedStandardContains("Swift") ||
+     article.content.localizedStandardContains("Swift")) &&
+    article.publishedDate > Date().addingTimeInterval(-86400 * 7)
+}
+```
+
+### Migration and Versioning
+
+```swift
+import SwiftData
+
+// Version 1
+enum SchemaV1: VersionedSchema {
+    static var versionIdentifier = Schema.Version(1, 0, 0)
+    static var models: [any PersistentModel.Type] {
+        [Article.self, Author.self]
+    }
+
+    @Model
+    final class Article {
+        var title: String
+        var content: String
+    }
+
+    @Model
+    final class Author {
+        var name: String
+    }
+}
+
+// Version 2 - Added fields
+enum SchemaV2: VersionedSchema {
+    static var versionIdentifier = Schema.Version(2, 0, 0)
+    static var models: [any PersistentModel.Type] {
+        [Article.self, Author.self]
+    }
+
+    @Model
+    final class Article {
+        var title: String
+        var content: String
+        var publishedDate: Date  // New field
+        var tags: [String]       // New field
+    }
+
+    @Model
+    final class Author {
+        var name: String
+        var email: String  // New field
+    }
+}
+
+// Migration plan
+enum ArticleMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [SchemaV1.self, SchemaV2.self]
+    }
+
+    static var stages: [MigrationStage] {
+        [migrateV1toV2]
+    }
+
+    static let migrateV1toV2 = MigrationStage.custom(
+        fromVersion: SchemaV1.self,
+        toVersion: SchemaV2.self,
+        willMigrate: nil,
+        didMigrate: { context in
+            // Custom migration logic
+            let articles = try context.fetch(FetchDescriptor<SchemaV2.Article>())
+            for article in articles {
+                article.publishedDate = Date()
+                article.tags = []
+            }
+            try context.save()
+        }
+    )
+}
+```
+
+### Performance Optimization
+
+```swift
+// ✅ GOOD: Batch operations
+func batchInsert(articles: [ArticleData]) {
+    let modelContext = ModelContext(modelContainer)
+
+    for articleData in articles {
+        let article = Article(
+            title: articleData.title,
+            content: articleData.content
+        )
+        modelContext.insert(article)
+    }
+
+    do {
+        try modelContext.save()  // Single save for all inserts
+    } catch {
+        print("Batch insert error: \(error)")
+    }
+}
+
+// ✅ GOOD: Lazy loading with limits
+func fetchRecentArticles(limit: Int = 20) throws -> [Article] {
+    let descriptor = FetchDescriptor<Article>(
+        sortBy: [SortDescriptor(\.publishedDate, order: .reverse)]
+    )
+    descriptor.fetchLimit = limit
+
+    return try modelContext.fetch(descriptor)
+}
+
+// ✅ GOOD: Background context for heavy operations
+func processArticles() async {
+    await Task.detached {
+        let backgroundContext = ModelContext(modelContainer)
+
+        let articles = try? backgroundContext.fetch(FetchDescriptor<Article>())
+        // Process articles...
+
+        try? backgroundContext.save()
+    }.value
+}
+```
+
+### CloudKit Integration
+
+```swift
+import SwiftData
+
+// ✅ Configure CloudKit sync
+let configuration = ModelConfiguration(
+    schema: schema,
+    isStoredInMemoryOnly: false,
+    allowsSave: true,
+    cloudKitDatabase: .automatic  // Enables CloudKit sync
+)
+
+let container = try ModelContainer(
+    for: schema,
+    configurations: [configuration]
+)
+
+// ✅ Handle sync conflicts
+@Model
+final class Article {
+    var title: String
+    var content: String
+
+    // CloudKit metadata
+    @Attribute(.cloudKitSystemFields)
+    var cloudKitMetadata: Data?
+}
+```
+
+## Core Data (Legacy Scenarios)
+
+### When to Use Core Data Instead of SwiftData
+
+- Complex migrations from existing Core Data apps
+- Need for advanced Core Data features not yet in SwiftData
+- Fetched Results Controllers with complex predicates
+- Custom NSManagedObject subclasses with complex logic
+
+### Core Data Best Practices
+
+```swift
+import CoreData
+
+// ✅ GOOD: Core Data stack
+class CoreDataStack {
+    static let shared = CoreDataStack()
+
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "MyApp")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Failed to load Core Data stack: \(error)")
+            }
+        }
+        return container
+    }()
+
+    var viewContext: NSManagedObjectContext {
+        persistentContainer.viewContext
+    }
+
+    func saveContext() {
+        let context = viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nsError = error as NSError
+                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+}
+
+// ✅ GOOD: Background operations
+extension CoreDataStack {
+    func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
+        persistentContainer.performBackgroundTask(block)
+    }
+}
+```
+
+### Migration from Core Data to SwiftData
+
+```swift
+// Step 1: Create SwiftData models matching Core Data entities
+@Model
+final class Article {
+    var title: String
+    var content: String
+    var publishedDate: Date
+
+    init(from managedObject: NSManagedObject) {
+        self.title = managedObject.value(forKey: "title") as? String ?? ""
+        self.content = managedObject.value(forKey: "content") as? String ?? ""
+        self.publishedDate = managedObject.value(forKey: "publishedDate") as? Date ?? Date()
+    }
+}
+
+// Step 2: Migration utility
+class CoreDataToSwiftDataMigration {
+    static func migrate() async throws {
+        let coreDataContext = CoreDataStack.shared.viewContext
+        let swiftDataContainer = try ModelContainer(for: Article.self)
+        let swiftDataContext = ModelContext(swiftDataContainer)
+
+        let fetchRequest = NSFetchRequest<NSManagedObject>(entityName: "Article")
+        let coreDataArticles = try coreDataContext.fetch(fetchRequest)
+
+        for managedObject in coreDataArticles {
+            let article = Article(from: managedObject)
+            swiftDataContext.insert(article)
+        }
+
+        try swiftDataContext.save()
+    }
+}
+```
+
+## UserDefaults for Simple Data
+
+```swift
+// ✅ GOOD: Property wrapper for UserDefaults
+@propertyWrapper
+struct UserDefault<T> {
+    let key: String
+    let defaultValue: T
+
+    var wrappedValue: T {
+        get {
+            UserDefaults.standard.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: key)
+        }
+    }
+}
+
+// ✅ GOOD: Settings with UserDefaults
+struct AppSettings {
+    @UserDefault(key: "theme", defaultValue: "light")
+    static var theme: String
+
+    @UserDefault(key: "fontSize", defaultValue: 14)
+    static var fontSize: Int
+
+    @UserDefault(key: "notificationsEnabled", defaultValue: true)
+    static var notificationsEnabled: Bool
+}
+
+// ⚠️ Don't use UserDefaults for large data or complex objects
+// Use SwiftData/Core Data instead
+```
+
+## Data Persistence Checklist
+
+- [ ] Use SwiftData for new projects
+- [ ] Define clear model relationships
+- [ ] Implement proper delete rules
+- [ ] Use @Query in SwiftUI views
+- [ ] Handle save errors gracefully
+- [ ] Use background contexts for heavy operations
+- [ ] Implement migrations for schema changes
+- [ ] Consider CloudKit sync if needed
+- [ ] Use UserDefaults only for simple preferences
+- [ ] Test with realistic data volumes
+
+## Resources
+
+- [SwiftData Documentation](https://developer.apple.com/documentation/swiftdata)
+- [WWDC 2024: What's new in SwiftData](https://developer.apple.com/videos/swiftdata)
+- [Core Data Programming Guide](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CoreData/)

--- a/.claude/skills/macos-development/coding-best-practices/modern-concurrency.md
+++ b/.claude/skills/macos-development/coding-best-practices/modern-concurrency.md
@@ -1,0 +1,645 @@
+# Modern Concurrency Best Practices
+
+Async/await, actors, structured concurrency, and Swift 6 concurrency patterns for macOS.
+
+## Async/Await Basics
+
+### Converting from Completion Handlers
+
+```swift
+// ❌ OLD: Completion handler
+func fetchUser(id: UUID, completion: @escaping (Result<User, Error>) -> Void) {
+    URLSession.shared.dataTask(with: url) { data, response, error in
+        // Handle callback
+    }.resume()
+}
+
+// Usage with pyramid of doom
+fetchUser(id: userID) { result in
+    switch result {
+    case .success(let user):
+        fetchPosts(for: user) { result in
+            switch result {
+            case .success(let posts):
+                // More nesting...
+            case .failure(let error):
+                // Handle error
+            }
+        }
+    case .failure(let error):
+        // Handle error
+    }
+}
+
+// ✅ GOOD: Async/await
+func fetchUser(id: UUID) async throws -> User {
+    let (data, _) = try await URLSession.shared.data(from: url)
+    return try JSONDecoder().decode(User.self, from: data)
+}
+
+func fetchPosts(for user: User) async throws -> [Post] {
+    let (data, _) = try await URLSession.shared.data(from: url)
+    return try JSONDecoder().decode([Post].self, from: data)
+}
+
+// Usage - clean and linear
+do {
+    let user = try await fetchUser(id: userID)
+    let posts = try await fetchPosts(for: user)
+    // Process posts
+} catch {
+    // Handle error
+}
+```
+
+### Async Properties
+
+```swift
+// ✅ GOOD: Async computed property
+class ImageLoader {
+    var image: UIImage {
+        get async throws {
+            let (data, _) = try await URLSession.shared.data(from: imageURL)
+            guard let image = UIImage(data: data) else {
+                throw ImageError.invalidData
+            }
+            return image
+        }
+    }
+}
+
+// Usage
+let image = try await imageLoader.image
+```
+
+## Task Management
+
+### Creating and Managing Tasks
+
+```swift
+// ✅ GOOD: Unstructured task
+class ViewController: NSViewController {
+    private var loadingTask: Task<Void, Never>?
+
+    func loadData() {
+        loadingTask = Task {
+            do {
+                let data = try await fetchData()
+                await updateUI(with: data)
+            } catch {
+                await showError(error)
+            }
+        }
+    }
+
+    override func viewDidDisappear() {
+        super.viewDidDisappear()
+        loadingTask?.cancel()  // Cancel when view disappears
+    }
+}
+
+// ✅ GOOD: Detached task (runs independently)
+Task.detached {
+    // Runs with default priority, no parent context
+    let result = await heavyComputation()
+    await MainActor.run {
+        // Update UI on main thread
+        updateUI(with: result)
+    }
+}
+```
+
+### Task Groups for Parallel Execution
+
+```swift
+// ✅ GOOD: Parallel fetching with task group
+func fetchAllArticles(ids: [UUID]) async throws -> [Article] {
+    try await withThrowingTaskGroup(of: Article.self) { group in
+        for id in ids {
+            group.addTask {
+                try await self.fetchArticle(id: id)
+            }
+        }
+
+        var articles: [Article] = []
+        for try await article in group {
+            articles.append(article)
+        }
+        return articles
+    }
+}
+
+// ✅ GOOD: With error handling per task
+func fetchAllArticles(ids: [UUID]) async -> [Result<Article, Error>] {
+    await withTaskGroup(of: Result<Article, Error>.self) { group in
+        for id in ids {
+            group.addTask {
+                do {
+                    let article = try await self.fetchArticle(id: id)
+                    return .success(article)
+                } catch {
+                    return .failure(error)
+                }
+            }
+        }
+
+        var results: [Result<Article, Error>] = []
+        for await result in group {
+            results.append(result)
+        }
+        return results
+    }
+}
+```
+
+### Async Sequences
+
+```swift
+// ✅ GOOD: Processing async sequences
+func processLines(from url: URL) async throws {
+    let lines = url.lines  // AsyncSequence
+
+    for try await line in lines {
+        processLine(line)
+    }
+}
+
+// ✅ GOOD: Custom async sequence
+struct NumberGenerator: AsyncSequence {
+    typealias Element = Int
+
+    let range: Range<Int>
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        var current: Int
+        let end: Int
+
+        mutating func next() async -> Int? {
+            guard current < end else { return nil }
+            let value = current
+            current += 1
+            try? await Task.sleep(for: .milliseconds(100))  // Simulate delay
+            return value
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(current: range.lowerBound, end: range.upperBound)
+    }
+}
+
+// Usage
+for await number in NumberGenerator(range: 0..<10) {
+    print(number)
+}
+```
+
+## Actors for Thread Safety
+
+### Basic Actor Usage
+
+```swift
+// ❌ BAD: Unsafe class with mutable state
+class Counter {
+    var value = 0  // Race condition!
+
+    func increment() {
+        value += 1
+    }
+}
+
+// ✅ GOOD: Thread-safe actor
+actor Counter {
+    private var value = 0
+
+    func increment() {
+        value += 1
+    }
+
+    func getValue() -> Int {
+        value
+    }
+}
+
+// Usage (async required)
+let counter = Counter()
+await counter.increment()
+let value = await counter.getValue()
+```
+
+### Actor Isolation
+
+```swift
+actor DataManager {
+    private var cache: [UUID: Data] = [:]
+
+    // Isolated to actor - synchronous within actor
+    func updateCache(id: UUID, data: Data) {
+        cache[id] = data
+    }
+
+    // Non-isolated - can be called synchronously
+    nonisolated func generateID() -> UUID {
+        UUID()  // Pure function, no actor state access
+    }
+
+    // Isolated - async from outside
+    func getData(id: UUID) -> Data? {
+        cache[id]
+    }
+}
+
+// Usage
+let manager = DataManager()
+let id = manager.generateID()  // Synchronous - nonisolated
+await manager.updateCache(id: id, data: data)  // Async - isolated
+```
+
+### Global Actors
+
+```swift
+// ✅ GOOD: MainActor for UI updates
+@MainActor
+class ViewModel: ObservableObject {
+    @Published var items: [Item] = []
+
+    // Runs on main thread
+    func updateItems(_ newItems: [Item]) {
+        items = newItems
+    }
+
+    // Explicitly run off main thread
+    nonisolated func processInBackground() async {
+        // Heavy computation off main thread
+        let processed = await heavyComputation()
+
+        // Switch back to main thread for UI update
+        await updateItems(processed)
+    }
+}
+
+// Individual functions can be marked
+@MainActor
+func updateUI() {
+    // Guaranteed to run on main thread
+}
+
+// Mix isolated and non-isolated in same type
+class MixedClass {
+    @MainActor
+    var uiProperty: String = ""
+
+    nonisolated
+    func backgroundWork() {
+        // Runs on background thread
+    }
+}
+```
+
+## Sendable Protocol
+
+### Sendable Types
+
+```swift
+// ✅ GOOD: Value types are automatically Sendable
+struct User: Sendable {
+    let id: UUID
+    let name: String
+}
+
+// ✅ GOOD: Immutable classes can be Sendable
+final class Configuration: Sendable {
+    let apiKey: String
+    let baseURL: URL
+
+    init(apiKey: String, baseURL: URL) {
+        self.apiKey = apiKey
+        self.baseURL = baseURL
+    }
+}
+
+// ❌ BAD: Mutable class can't be Sendable safely
+final class Counter: Sendable {  // Warning!
+    var count = 0  // Mutable property not thread-safe
+}
+
+// ✅ GOOD: Use actor instead
+actor Counter {
+    var count = 0  // Thread-safe via actor isolation
+}
+
+// ✅ GOOD: @unchecked Sendable when you know it's safe
+final class ThreadSafeCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _count = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _count
+    }
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        _count += 1
+    }
+}
+```
+
+### Sendable Closures
+
+```swift
+// ✅ GOOD: Sendable closure
+func processAsync(_ handler: @Sendable () -> Void) async {
+    await Task.detached {
+        handler()
+    }.value
+}
+
+// ❌ BAD: Capturing mutable state
+var counter = 0
+processAsync {
+    counter += 1  // Error: capturing mutable state
+}
+
+// ✅ GOOD: Use actor for mutable state
+actor SharedCounter {
+    var value = 0
+}
+
+let sharedCounter = SharedCounter()
+processAsync {
+    await sharedCounter.increment()
+}
+```
+
+## Concurrency Patterns
+
+### Repository Pattern with Async/Await
+
+```swift
+protocol ArticleRepository {
+    func fetchArticles() async throws -> [Article]
+    func save(_ article: Article) async throws
+}
+
+actor SwiftDataArticleRepository: ArticleRepository {
+    private let modelContext: ModelContext
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    func fetchArticles() async throws -> [Article] {
+        let descriptor = FetchDescriptor<Article>()
+        return try modelContext.fetch(descriptor)
+    }
+
+    func save(_ article: Article) async throws {
+        modelContext.insert(article)
+        try modelContext.save()
+    }
+}
+```
+
+### ViewModel with Async Operations
+
+```swift
+@MainActor
+class ArticleListViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    @Published var isLoading = false
+    @Published var error: Error?
+
+    private let repository: ArticleRepository
+
+    init(repository: ArticleRepository) {
+        self.repository = repository
+    }
+
+    func loadArticles() async {
+        isLoading = true
+        error = nil
+
+        do {
+            articles = try await repository.fetchArticles()
+        } catch {
+            self.error = error
+        }
+
+        isLoading = false
+    }
+
+    func refresh() async {
+        await loadArticles()
+    }
+}
+
+// Usage in SwiftUI
+struct ArticleListView: View {
+    @StateObject private var viewModel: ArticleListViewModel
+
+    var body: some View {
+        List(viewModel.articles) { article in
+            Text(article.title)
+        }
+        .task {
+            await viewModel.loadArticles()
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+}
+```
+
+### Cancellation Handling
+
+```swift
+// ✅ GOOD: Checking for cancellation
+func performLongOperation() async throws {
+    for i in 0..<1000 {
+        // Check if task was cancelled
+        try Task.checkCancellation()
+
+        // Or check manually
+        if Task.isCancelled {
+            cleanup()
+            return
+        }
+
+        await processItem(i)
+    }
+}
+
+// ✅ GOOD: Cancellation in view model
+@MainActor
+class SearchViewModel: ObservableObject {
+    @Published var results: [Result] = []
+    private var searchTask: Task<Void, Never>?
+
+    func search(_ query: String) {
+        // Cancel previous search
+        searchTask?.cancel()
+
+        searchTask = Task {
+            do {
+                try await Task.sleep(for: .milliseconds(300))  // Debounce
+                try Task.checkCancellation()
+
+                let results = try await performSearch(query)
+                self.results = results
+            } catch is CancellationError {
+                // Ignore cancellation
+            } catch {
+                // Handle other errors
+            }
+        }
+    }
+}
+```
+
+## Concurrency Best Practices
+
+### Avoid Blocking Main Thread
+
+```swift
+// ❌ BAD: Blocking main thread
+@MainActor
+func loadData() {
+    let data = heavyComputation()  // Blocks UI!
+    updateUI(with: data)
+}
+
+// ✅ GOOD: Run computation off main thread
+@MainActor
+func loadData() async {
+    let data = await Task.detached {
+        heavyComputation()
+    }.value
+    updateUI(with: data)
+}
+```
+
+### Use Structured Concurrency
+
+```swift
+// ❌ BAD: Unstructured tasks can leak
+func fetchAllData() {
+    Task {
+        let users = try await fetchUsers()
+    }
+    Task {
+        let posts = try await fetchPosts()
+    }
+    // Tasks may outlive this function
+}
+
+// ✅ GOOD: Structured with task group
+func fetchAllData() async throws -> (users: [User], posts: [Post]) {
+    try await withThrowingTaskGroup(of: Void.self) { group in
+        var users: [User] = []
+        var posts: [Post] = []
+
+        group.addTask {
+            users = try await self.fetchUsers()
+        }
+
+        group.addTask {
+            posts = try await self.fetchPosts()
+        }
+
+        try await group.waitForAll()
+
+        return (users, posts)
+    }
+}
+```
+
+### Prioritize Tasks
+
+```swift
+// ✅ GOOD: Task priorities
+Task(priority: .background) {
+    await performBackgroundSync()
+}
+
+Task(priority: .userInitiated) {
+    await loadUserData()
+}
+
+Task(priority: .high) {
+    await handleUrgentRequest()
+}
+```
+
+## AsyncStream for Continuous Updates
+
+```swift
+// ✅ GOOD: AsyncStream for real-time updates
+actor NotificationCenter {
+    private var continuations: [UUID: AsyncStream<Notification>.Continuation] = [:]
+
+    func notifications() -> AsyncStream<Notification> {
+        AsyncStream { continuation in
+            let id = UUID()
+            continuations[id] = continuation
+
+            continuation.onTermination = { [weak self] _ in
+                Task { await self?.removeContinuation(id) }
+            }
+        }
+    }
+
+    func post(_ notification: Notification) {
+        for continuation in continuations.values {
+            continuation.yield(notification)
+        }
+    }
+
+    private func removeContinuation(_ id: UUID) {
+        continuations.removeValue(forKey: id)
+    }
+}
+
+// Usage
+let notificationCenter = NotificationCenter()
+
+Task {
+    for await notification in await notificationCenter.notifications() {
+        print("Received: \(notification)")
+    }
+}
+
+await notificationCenter.post(Notification(name: "test"))
+```
+
+## Concurrency Checklist
+
+- [ ] Use async/await instead of completion handlers
+- [ ] Mark UI-related code with @MainActor
+- [ ] Use actors for mutable shared state
+- [ ] Ensure types crossing concurrency boundaries are Sendable
+- [ ] Handle task cancellation appropriately
+- [ ] Use structured concurrency (task groups) over unstructured tasks
+- [ ] Check for race conditions in mutable state
+- [ ] Avoid blocking the main thread
+- [ ] Set appropriate task priorities
+- [ ] Clean up resources on task cancellation
+
+## Swift 6 Concurrency Migration
+
+- [ ] Enable strict concurrency checking
+- [ ] Fix non-Sendable type warnings
+- [ ] Mark appropriate types as @MainActor
+- [ ] Replace DispatchQueue with async/await
+- [ ] Convert @escaping closures to async functions
+- [ ] Use actors instead of locks
+- [ ] Audit @unchecked Sendable usage
+
+## Resources
+
+- [Swift Concurrency Documentation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/)
+- [WWDC 2023: Beyond the basics of structured concurrency](https://developer.apple.com/videos/play/wwdc2023/10170/)
+- [Swift Evolution: Concurrency](https://github.com/apple/swift-evolution/blob/main/proposals/0306-actors.md)

--- a/.claude/skills/macos-development/coding-best-practices/skill.md
+++ b/.claude/skills/macos-development/coding-best-practices/skill.md
@@ -1,0 +1,152 @@
+---
+name: coding-best-practices
+description: Reviews macOS Swift 6+ code for modern idioms, SOLID principles, SwiftData patterns, and concurrency best practices. Use when reviewing macOS code quality or asking about best practices.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Coding Best Practices for macOS Development
+
+You are a macOS development expert specializing in Swift 6+, modern architecture patterns, and best practices for macOS 26 (Tahoe) development.
+
+## When This Skill Activates
+
+- User asks to review macOS code quality
+- User asks about Swift 6+ best practices or modern idioms
+- User wants a SOLID / DRY / Clean Architecture review
+- User asks about SwiftData or modern concurrency patterns
+- User is auditing an existing macOS codebase
+
+## Your Role
+
+Review Swift and macOS code against modern idioms, design principles, and best practices. Provide actionable feedback to improve code quality, maintainability, and performance.
+
+## Core Focus Areas
+
+1. **Swift Language Best Practices** - Modern Swift 6+ patterns and idioms
+2. **Architecture & Design Principles** - SOLID, DRY, Clean Architecture
+3. **Data Persistence** - SwiftData-first approach, Core Data when needed
+4. **Code Organization** - Modular architecture and separation of concerns
+5. **Modern Concurrency** - Async/await, actors, structured concurrency
+
+## How to Conduct Reviews
+
+### Step 1: Understand Context
+- Ask about the code's purpose and requirements
+- Identify the target macOS version and minimum deployment target
+- Understand existing architecture and patterns in use
+
+### Step 2: Systematic Review
+Review code against each module's guidelines:
+- Swift language patterns (see swift-language.md)
+- Architecture principles (see architecture-principles.md)
+- Data persistence approach (see data-persistence.md)
+- Code organization (see code-organization.md)
+- Concurrency usage (see modern-concurrency.md)
+
+### Step 3: Provide Structured Feedback
+
+For each issue found:
+1. **Issue**: Clearly state what's wrong
+2. **Principle Violated**: Reference specific principle (SOLID, DRY, etc.)
+3. **Impact**: Explain why it matters
+4. **Fix**: Provide concrete code example showing the improvement
+5. **Resources**: Link to relevant documentation or guidelines
+
+### Step 4: Prioritize Recommendations
+
+Categorize feedback:
+- 🔴 **Critical**: Security issues, crashes, memory leaks
+- 🟡 **Important**: Architecture violations, maintainability issues
+- 🟢 **Nice-to-have**: Style improvements, minor optimizations
+
+## Review Checklist
+
+Before completing review, ensure you've checked:
+
+- [ ] Swift 6 language features used appropriately
+- [ ] SOLID principles followed
+- [ ] No code duplication (DRY)
+- [ ] Proper error handling
+- [ ] Concurrency safety (Sendable, MainActor)
+- [ ] SwiftData used correctly (if applicable)
+- [ ] Modular and testable design
+- [ ] Performance considerations
+- [ ] Memory management
+- [ ] Accessibility support
+
+## Module References
+
+Load these modules as needed during review:
+
+1. **Swift Language**: `skills/coding-best-practices/swift-language.md`
+   - Modern Swift 6+ features
+   - Value vs reference types
+   - Protocol-oriented programming
+
+2. **Architecture Principles**: `skills/coding-best-practices/architecture-principles.md`
+   - SOLID principles with examples
+   - DRY principle
+   - Clean Architecture patterns
+
+3. **Data Persistence**: `skills/coding-best-practices/data-persistence.md`
+   - SwiftData best practices
+   - Core Data (when needed)
+   - Migration strategies
+
+4. **Code Organization**: `skills/coding-best-practices/code-organization.md`
+   - Modular architecture
+   - Feature vs layer organization
+   - Package structure
+
+5. **Modern Concurrency**: `skills/coding-best-practices/modern-concurrency.md`
+   - Async/await patterns
+   - Actors and isolation
+   - Structured concurrency
+
+## Example Review Format
+
+```markdown
+# Code Review: [Component Name]
+
+## Summary
+Brief overview of the code and its purpose.
+
+## Critical Issues 🔴
+1. **Memory Leak in Observer**
+   - Principle: Resource management
+   - Impact: App will consume increasing memory over time
+   - Fix: [code example]
+
+## Important Issues 🟡
+1. **Violates Single Responsibility Principle**
+   - Principle: SOLID - SRP
+   - Impact: Hard to test and maintain
+   - Fix: [code example]
+
+## Suggestions 🟢
+1. **Consider using SwiftData instead of UserDefaults**
+   - Principle: Use appropriate tools
+   - Benefit: Better type safety and querying
+   - Example: [code example]
+
+## Overall Assessment
+[Summary and priority recommendations]
+```
+
+## Response Guidelines
+
+- Be constructive and educational
+- Provide specific examples, not just theory
+- Reference official Apple documentation when relevant
+- Acknowledge good practices already in use
+- Consider the context and constraints of the project
+- Balance idealism with pragmatism
+
+## When to Load Modules
+
+- Load modules on-demand as specific topics arise
+- Don't load all modules upfront
+- Reference module filenames when providing guidance
+- Suggest reading specific modules for deeper understanding
+
+Begin reviews by asking about the code to review and its context.

--- a/.claude/skills/macos-development/coding-best-practices/swift-language.md
+++ b/.claude/skills/macos-development/coding-best-practices/swift-language.md
@@ -1,0 +1,486 @@
+# Swift Language Best Practices
+
+Modern Swift 6+ language patterns and idioms for macOS development.
+
+## Swift 6 Features
+
+### Strict Concurrency Checking
+```swift
+// ✅ GOOD: Sendable conformance
+struct User: Sendable {
+    let id: UUID
+    let name: String
+}
+
+// ❌ BAD: Mutable reference type without protection
+class UserManager {
+    var users: [User] = []  // Not thread-safe!
+}
+
+// ✅ GOOD: Use actor for mutable state
+actor UserManager {
+    private var users: [User] = []
+
+    func addUser(_ user: User) {
+        users.append(user)
+    }
+}
+```
+
+### Macro System
+```swift
+// ✅ Use macros for reducing boilerplate
+import SwiftData
+
+@Model
+class Article {
+    var title: String
+    var content: String
+    var publishedDate: Date
+}
+
+// Generates: Codable, Hashable, Observable, and more
+```
+
+### Typed Throws (Swift 6+)
+```swift
+// ✅ GOOD: Specific error types
+enum NetworkError: Error {
+    case invalidURL
+    case timeout
+    case serverError(Int)
+}
+
+func fetchData() throws(NetworkError) -> Data {
+    // Implementation
+}
+
+// Usage with specific error handling
+do {
+    let data = try fetchData()
+} catch let error as NetworkError {
+    switch error {
+    case .invalidURL:
+        // Handle specific error
+    case .timeout:
+        // Handle timeout
+    case .serverError(let code):
+        // Handle server error
+    }
+}
+```
+
+## Value Types vs Reference Types
+
+### Prefer Value Types
+```swift
+// ✅ GOOD: Value type for data
+struct Settings {
+    var theme: Theme
+    var fontSize: Int
+    var notifications: Bool
+}
+
+// ❌ BAD: Unnecessary class
+class Settings {
+    var theme: Theme
+    var fontSize: Int
+    var notifications: Bool
+}
+```
+
+### When to Use Reference Types
+```swift
+// ✅ GOOD: Reference type for identity and shared state
+final class DocumentController: ObservableObject {
+    @Published var document: Document
+    private let fileManager: FileManager
+
+    // Complex lifecycle, needs identity
+}
+
+// ✅ GOOD: Reference type for inheritance
+class BaseViewController: NSViewController {
+    // AppKit requires inheritance
+}
+```
+
+## Protocol-Oriented Programming
+
+### Protocol Composition
+```swift
+// ✅ GOOD: Small, focused protocols
+protocol Identifiable {
+    var id: UUID { get }
+}
+
+protocol Timestamped {
+    var createdAt: Date { get }
+    var updatedAt: Date { get }
+}
+
+protocol Searchable {
+    var searchableText: String { get }
+}
+
+// Compose protocols
+struct Article: Identifiable, Timestamped, Searchable {
+    let id: UUID
+    let createdAt: Date
+    var updatedAt: Date
+    var title: String
+    var content: String
+
+    var searchableText: String {
+        "\(title) \(content)"
+    }
+}
+```
+
+### Protocol Extensions
+```swift
+// ✅ GOOD: Default implementations
+protocol Validatable {
+    func validate() throws
+}
+
+extension Validatable {
+    func isValid() -> Bool {
+        do {
+            try validate()
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+```
+
+### Protocol Witnesses (Avoid Runtime Type Checks)
+```swift
+// ❌ BAD: Runtime type checking
+func process(_ item: Any) {
+    if let article = item as? Article {
+        print(article.title)
+    } else if let video = item as? Video {
+        print(video.title)
+    }
+}
+
+// ✅ GOOD: Protocol-based approach
+protocol Displayable {
+    var displayTitle: String { get }
+}
+
+extension Article: Displayable {
+    var displayTitle: String { title }
+}
+
+extension Video: Displayable {
+    var displayTitle: String { title }
+}
+
+func process(_ item: Displayable) {
+    print(item.displayTitle)
+}
+```
+
+## Generics and Type Safety
+
+### Generic Functions
+```swift
+// ✅ GOOD: Generic function with constraints
+func findFirst<T: Collection>(
+    in collection: T,
+    matching predicate: (T.Element) -> Bool
+) -> T.Element? where T.Element: Equatable {
+    collection.first(where: predicate)
+}
+```
+
+### Associated Types
+```swift
+// ✅ GOOD: Protocol with associated type
+protocol Repository {
+    associatedtype Entity
+
+    func fetch(id: UUID) async throws -> Entity?
+    func save(_ entity: Entity) async throws
+    func delete(id: UUID) async throws
+}
+
+struct ArticleRepository: Repository {
+    typealias Entity = Article
+
+    func fetch(id: UUID) async throws -> Article? {
+        // Implementation
+    }
+
+    func save(_ entity: Article) async throws {
+        // Implementation
+    }
+
+    func delete(id: UUID) async throws {
+        // Implementation
+    }
+}
+```
+
+## Optionals Best Practices
+
+### Optional Binding
+```swift
+// ✅ GOOD: Guard for early exit
+func processUser(_ user: User?) {
+    guard let user else { return }
+    // Work with unwrapped user
+}
+
+// ✅ GOOD: If-let for scoped usage
+if let user = optionalUser {
+    print(user.name)
+}
+
+// ❌ BAD: Force unwrapping
+let name = user!.name  // Dangerous!
+
+// ❌ BAD: Implicit unwrapping (use sparingly)
+var user: User!
+```
+
+### Nil-Coalescing and Optional Chaining
+```swift
+// ✅ GOOD: Nil-coalescing with default
+let displayName = user?.name ?? "Guest"
+
+// ✅ GOOD: Optional chaining
+let uppercasedName = user?.name?.uppercased()
+
+// ✅ GOOD: Optional map and flatMap
+let userID = optionalUser.map { $0.id }
+```
+
+## Property Wrappers
+
+### Built-in Property Wrappers
+```swift
+import SwiftUI
+
+struct SettingsView: View {
+    @AppStorage("theme") private var theme: String = "light"
+    @State private var isEditing = false
+    @ObservedObject var viewModel: SettingsViewModel
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        // View implementation
+    }
+}
+```
+
+### Custom Property Wrappers
+```swift
+// ✅ GOOD: Custom property wrapper for validation
+@propertyWrapper
+struct Clamped<Value: Comparable> {
+    private var value: Value
+    private let range: ClosedRange<Value>
+
+    var wrappedValue: Value {
+        get { value }
+        set { value = min(max(range.lowerBound, newValue), range.upperBound) }
+    }
+
+    init(wrappedValue: Value, _ range: ClosedRange<Value>) {
+        self.range = range
+        self.value = min(max(range.lowerBound, wrappedValue), range.upperBound)
+    }
+}
+
+struct Settings {
+    @Clamped(0...100) var volume: Int = 50
+    @Clamped(10...72) var fontSize: Int = 14
+}
+```
+
+## Result Builders
+
+### SwiftUI-Style DSL
+```swift
+// ✅ GOOD: Result builder for custom DSL
+@resultBuilder
+struct MenuBuilder {
+    static func buildBlock(_ components: MenuItem...) -> [MenuItem] {
+        components
+    }
+}
+
+struct MenuItem {
+    let title: String
+    let action: () -> Void
+}
+
+func createMenu(@MenuBuilder builder: () -> [MenuItem]) -> [MenuItem] {
+    builder()
+}
+
+// Usage
+let menu = createMenu {
+    MenuItem(title: "Open") { /* action */ }
+    MenuItem(title: "Save") { /* action */ }
+    MenuItem(title: "Close") { /* action */ }
+}
+```
+
+## Error Handling
+
+### Swift Error Protocol
+```swift
+// ✅ GOOD: Well-structured error types
+enum ValidationError: Error, LocalizedError {
+    case emptyField(String)
+    case invalidFormat(field: String, expected: String)
+    case outOfRange(field: String, range: ClosedRange<Int>)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyField(let field):
+            return "\(field) cannot be empty"
+        case .invalidFormat(let field, let expected):
+            return "\(field) has invalid format. Expected: \(expected)"
+        case .outOfRange(let field, let range):
+            return "\(field) must be between \(range.lowerBound) and \(range.upperBound)"
+        }
+    }
+}
+```
+
+### Do-Catch Best Practices
+```swift
+// ✅ GOOD: Specific error handling
+func saveDocument(_ document: Document) async {
+    do {
+        try await repository.save(document)
+        showSuccess()
+    } catch let error as ValidationError {
+        showValidationError(error)
+    } catch let error as NetworkError {
+        showNetworkError(error)
+    } catch {
+        showGenericError(error)
+    }
+}
+
+// ✅ GOOD: Using Result type
+func loadDocument(id: UUID) -> Result<Document, Error> {
+    do {
+        let document = try repository.fetch(id: id)
+        return .success(document)
+    } catch {
+        return .failure(error)
+    }
+}
+```
+
+## Collections and Algorithms
+
+### Use Appropriate Collection Types
+```swift
+// ✅ GOOD: Array for ordered collections
+var items: [Item] = []
+
+// ✅ GOOD: Set for unique values and fast lookup
+var uniqueIDs: Set<UUID> = []
+
+// ✅ GOOD: Dictionary for key-value pairs
+var usersByID: [UUID: User] = [:]
+
+// ✅ GOOD: OrderedSet (Swift Collections) when order + uniqueness matter
+import OrderedCollections
+var orderedUniqueItems: OrderedSet<Item> = []
+```
+
+### Functional Programming Patterns
+```swift
+// ✅ GOOD: Map, filter, reduce
+let activeUserNames = users
+    .filter { $0.isActive }
+    .map { $0.name }
+    .sorted()
+
+let totalScore = scores.reduce(0, +)
+
+// ✅ GOOD: CompactMap for removing nils
+let validURLs = strings.compactMap { URL(string: $0) }
+
+// ✅ GOOD: FlatMap for flattening nested collections
+let allTags = articles.flatMap { $0.tags }
+```
+
+## Memory Management
+
+### Capture Lists in Closures
+```swift
+// ✅ GOOD: Weak self to avoid retain cycles
+class DocumentViewController: NSViewController {
+    private var document: Document
+
+    func setupObserver() {
+        NotificationCenter.default.addObserver(
+            forName: .documentDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            self.updateUI()
+        }
+    }
+}
+
+// ✅ GOOD: Unowned when guaranteed to exist
+class ChildView: NSView {
+    unowned let parentController: ParentViewController
+
+    func handleAction() {
+        parentController.performAction()  // Safe: parent owns this view
+    }
+}
+```
+
+### Automatic Reference Counting (ARC)
+```swift
+// ❌ BAD: Strong reference cycle
+class Author {
+    var books: [Book] = []
+}
+
+class Book {
+    var author: Author  // Strong reference creates cycle!
+}
+
+// ✅ GOOD: Break cycle with weak reference
+class Author {
+    var books: [Book] = []
+}
+
+class Book {
+    weak var author: Author?  // Weak reference breaks cycle
+}
+```
+
+## Swift 6 Migration Checklist
+
+- [ ] Enable strict concurrency checking
+- [ ] Mark types as `Sendable` where appropriate
+- [ ] Use actors for mutable shared state
+- [ ] Replace completion handlers with async/await
+- [ ] Use typed throws for better error handling
+- [ ] Adopt new Swift 6 features (macros, etc.)
+- [ ] Remove deprecated APIs
+- [ ] Update to use `@Observable` instead of `ObservableObject`
+
+## Resources
+
+- [Swift Language Guide](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/)
+- [Swift Evolution Proposals](https://github.com/apple/swift-evolution)
+- [WWDC 2024: What's new in Swift](https://developer.apple.com/videos/play/wwdc2024/)

--- a/.claude/skills/macos-development/macos-capabilities/background.md
+++ b/.claude/skills/macos-development/macos-capabilities/background.md
@@ -1,0 +1,360 @@
+# Background Operations
+
+Login items, launch agents, and background task management for macOS apps.
+
+## Login Items (Modern, macOS 13+)
+
+Use the ServiceManagement framework to register your app as a login item.
+
+### Register as Login Item
+
+```swift
+import ServiceManagement
+
+func enableLoginItem() throws {
+    try SMAppService.mainApp.register()
+}
+
+func disableLoginItem() throws {
+    try SMAppService.mainApp.unregister()
+}
+
+func isLoginItemEnabled() -> Bool {
+    SMAppService.mainApp.status == .enabled
+}
+```
+
+### SwiftUI Settings Toggle
+
+```swift
+struct GeneralSettingsView: View {
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
+
+    var body: some View {
+        Form {
+            Toggle("Launch at Login", isOn: $launchAtLogin)
+                .onChange(of: launchAtLogin) { _, newValue in
+                    do {
+                        if newValue {
+                            try SMAppService.mainApp.register()
+                        } else {
+                            try SMAppService.mainApp.unregister()
+                        }
+                    } catch {
+                        // Revert toggle on failure
+                        launchAtLogin = SMAppService.mainApp.status == .enabled
+                    }
+                }
+        }
+    }
+}
+```
+
+### Login Item Status
+
+```swift
+switch SMAppService.mainApp.status {
+case .notRegistered:
+    print("Not registered as login item")
+case .enabled:
+    print("Will launch at login")
+case .requiresApproval:
+    print("User needs to approve in System Settings > General > Login Items")
+case .notFound:
+    print("App not found")
+@unknown default:
+    break
+}
+```
+
+## Launch Agents (Advanced)
+
+For helper tools that run independently of the main app. The helper registers as a launch agent via ServiceManagement.
+
+### Helper Tool Setup
+
+1. Create a new target for the helper (Command Line Tool or App)
+2. Embed it in the main app's bundle under `Contents/Library/LoginItems/`
+3. Register via ServiceManagement
+
+```swift
+// In the main app
+let helperService = SMAppService.agent(plistName: "com.example.myapp.helper.plist")
+
+func installHelper() throws {
+    try helperService.register()
+}
+
+func removeHelper() throws {
+    try helperService.unregister()
+}
+```
+
+### Launch Agent Plist
+
+Place in the helper's bundle or the app's `Contents/Library/LaunchAgents/`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.myapp.helper</string>
+    <key>BundleProgram</key>
+    <string>Contents/Library/LoginItems/MyHelper.app/Contents/MacOS/MyHelper</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+</dict>
+</plist>
+```
+
+## Background Tasks in Sandboxed Apps
+
+### BGTaskScheduler (macOS 13+)
+
+Schedule background work that the system manages:
+
+```swift
+import BackgroundTasks
+
+// Register in App init or applicationDidFinishLaunching
+BGTaskScheduler.shared.register(
+    forTaskWithIdentifier: "com.example.myapp.refresh",
+    using: nil
+) { task in
+    handleRefresh(task as! BGAppRefreshTask)
+}
+
+// Schedule
+func scheduleRefresh() {
+    let request = BGAppRefreshTaskRequest(identifier: "com.example.myapp.refresh")
+    request.earliestBeginDate = Date(timeIntervalSinceNow: 15 * 60) // 15 min
+    try? BGTaskScheduler.shared.submit(request)
+}
+
+// Handle
+func handleRefresh(_ task: BGAppRefreshTask) {
+    let refreshTask = Task {
+        do {
+            try await performDataRefresh()
+            task.setTaskCompleted(success: true)
+        } catch {
+            task.setTaskCompleted(success: false)
+        }
+    }
+
+    task.expirationHandler = {
+        refreshTask.cancel()
+    }
+
+    // Schedule next refresh
+    scheduleRefresh()
+}
+```
+
+**Info.plist requirement:**
+```xml
+<key>BGTaskSchedulerPermittedIdentifiers</key>
+<array>
+    <string>com.example.myapp.refresh</string>
+</array>
+```
+
+### ProcessInfo for Extended Runtime
+
+Keep the app alive for critical work when the user switches away:
+
+```swift
+func performCriticalWork() async {
+    let activity = ProcessInfo.processInfo.beginActivity(
+        options: [.userInitiated, .idleSystemSleepDisabled],
+        reason: "Processing export"
+    )
+
+    defer { ProcessInfo.processInfo.endActivity(activity) }
+
+    // This work continues even if the user switches to another app
+    await exportLargeFile()
+}
+```
+
+### NSBackgroundActivityScheduler
+
+For periodic background work (macOS 10.10+):
+
+```swift
+class BackgroundScheduler {
+    private var activity: NSBackgroundActivityScheduler?
+
+    func startPeriodicSync() {
+        activity = NSBackgroundActivityScheduler(identifier: "com.example.myapp.sync")
+        activity?.repeats = true
+        activity?.interval = 30 * 60  // 30 minutes
+        activity?.tolerance = 5 * 60  // 5 minute tolerance
+        activity?.qualityOfService = .utility
+
+        activity?.schedule { completion in
+            Task {
+                do {
+                    try await self.performSync()
+                    completion(.finished)
+                } catch {
+                    completion(.deferred)  // Try again later
+                }
+            }
+        }
+    }
+
+    func stopPeriodicSync() {
+        activity?.invalidate()
+        activity = nil
+    }
+}
+```
+
+## File System Monitoring
+
+Watch for file changes using DispatchSource:
+
+```swift
+class FileWatcher {
+    private var source: DispatchSourceFileSystemObject?
+    private var fileDescriptor: Int32 = -1
+
+    func watch(url: URL, events: DispatchSource.FileSystemEvent = [.write, .delete, .rename],
+               handler: @escaping () -> Void) {
+        fileDescriptor = open(url.path, O_EVTONLY)
+        guard fileDescriptor >= 0 else { return }
+
+        source = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileDescriptor,
+            eventMask: events,
+            queue: .main
+        )
+
+        source?.setEventHandler {
+            handler()
+        }
+
+        source?.setCancelHandler { [weak self] in
+            if let fd = self?.fileDescriptor, fd >= 0 {
+                close(fd)
+            }
+        }
+
+        source?.resume()
+    }
+
+    func stop() {
+        source?.cancel()
+        source = nil
+    }
+
+    deinit { stop() }
+}
+
+// Usage
+let watcher = FileWatcher()
+watcher.watch(url: configFileURL) {
+    print("Config file changed, reloading...")
+    reloadConfig()
+}
+```
+
+### Directory Monitoring with FSEvents
+
+For watching entire directory trees:
+
+```swift
+class DirectoryWatcher {
+    private var stream: FSEventStreamRef?
+
+    func watch(paths: [String], handler: @escaping ([String]) -> Void) {
+        let callback: FSEventStreamCallback = { _, clientCallBackInfo, numEvents, eventPaths, _, _ in
+            let handler = Unmanaged<WatcherBox>.fromOpaque(clientCallBackInfo!).takeUnretainedValue()
+            let paths = Unmanaged<CFArray>.fromOpaque(eventPaths).takeUnretainedValue() as! [String]
+            handler.handler(paths)
+        }
+
+        let box = WatcherBox(handler: handler)
+        var context = FSEventStreamContext(
+            version: 0,
+            info: Unmanaged.passRetained(box).toOpaque(),
+            retain: nil, release: nil, copyDescription: nil
+        )
+
+        stream = FSEventStreamCreate(
+            nil, callback, &context,
+            paths as CFArray,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            1.0,  // Latency in seconds
+            FSEventStreamCreateFlags(kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagFileEvents)
+        )
+
+        FSEventStreamScheduleWithRunLoop(stream!, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
+        FSEventStreamStart(stream!)
+    }
+
+    func stop() {
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+        stream = nil
+    }
+
+    class WatcherBox {
+        let handler: ([String]) -> Void
+        init(handler: @escaping ([String]) -> Void) { self.handler = handler }
+    }
+}
+```
+
+## Preventing System Sleep
+
+```swift
+// Prevent display sleep during presentations/exports
+import IOKit.pwr_mgt
+
+class SleepPreventer {
+    private var assertionID: IOPMAssertionID = 0
+    private var isActive = false
+
+    func preventSleep(reason: String) {
+        guard !isActive else { return }
+        let result = IOPMAssertionCreateWithName(
+            kIOPMAssertionTypeNoDisplaySleep as CFString,
+            IOPMAssertionLevel(kIOPMAssertionLevelOn),
+            reason as CFString,
+            &assertionID
+        )
+        isActive = (result == kIOReturnSuccess)
+    }
+
+    func allowSleep() {
+        guard isActive else { return }
+        IOPMAssertionRelease(assertionID)
+        isActive = false
+    }
+
+    deinit { allowSleep() }
+}
+```
+
+## Best Practices
+
+1. **Use SMAppService for login items** - Modern API, handles registration properly
+2. **Handle `requiresApproval` status** - Guide users to System Settings if needed
+3. **Use BGTaskScheduler for periodic work** - System-managed, power efficient
+4. **Use ProcessInfo activities for critical work** - Prevents suspension during exports
+5. **Always clean up watchers and timers** - Cancel in deinit or when no longer needed
+6. **Be power-conscious** - Use appropriate QoS levels, respect system power state
+7. **Test background behavior** - Use `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.example.myapp.refresh"]` in debugger
+8. **Avoid deprecated APIs** - Don't use `SMLoginItemSetEnabled`, use `SMAppService`

--- a/.claude/skills/macos-development/macos-capabilities/extensions.md
+++ b/.claude/skills/macos-development/macos-capabilities/extensions.md
@@ -1,0 +1,278 @@
+# System Extensions
+
+App extensions, system extensions, and XPC services for extending macOS capabilities.
+
+## App Extension Types
+
+| Extension Type | Purpose | Host App |
+|---------------|---------|----------|
+| Share Extension | Share content to your app | Share sheet |
+| Action Extension | Transform content in-place | Any app with action menu |
+| Finder Sync | Badges, toolbar items, context menu in Finder | Finder |
+| Quick Look Preview | Preview custom file types | Finder, Mail, etc. |
+| Spotlight Importer | Index custom file types for search | Spotlight |
+| Widget (WidgetKit) | Desktop/Notification Center widgets | System |
+| Intents/App Intents | Siri, Shortcuts, Spotlight actions | System |
+| Photo Editing | Edit photos in Photos.app | Photos |
+| Network Extension | VPN, content filter, DNS proxy | System |
+| Endpoint Security | Process monitoring, file access control | System |
+
+## Share Extension
+
+Allow users to share content from other apps into yours:
+
+### Setup
+1. File > New > Target > Share Extension
+2. Configure supported content types in Info.plist
+
+```swift
+// ShareViewController.swift
+import SwiftUI
+import UniformTypeIdentifiers
+
+class ShareViewController: NSViewController {
+    override func loadView() {
+        let hostingView = NSHostingView(rootView: ShareView(extensionContext: extensionContext))
+        self.view = hostingView
+    }
+}
+
+struct ShareView: View {
+    let extensionContext: NSExtensionContext?
+    @State private var sharedText = ""
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Save to MyApp")
+                .font(.headline)
+            TextEditor(text: $sharedText)
+                .frame(height: 100)
+            HStack {
+                Button("Cancel") { cancel() }
+                Button("Save") { save() }
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding()
+        .frame(width: 300)
+        .task { await loadSharedContent() }
+    }
+
+    func loadSharedContent() async {
+        guard let items = extensionContext?.inputItems as? [NSExtensionItem] else { return }
+        for item in items {
+            for provider in item.attachments ?? [] {
+                if provider.hasItemConformingToTypeIdentifier(UTType.plainText.identifier) {
+                    let text = try? await provider.loadItem(forTypeIdentifier: UTType.plainText.identifier) as? String
+                    sharedText = text ?? ""
+                }
+            }
+        }
+    }
+
+    func save() {
+        // Save via App Group shared container or UserDefaults suite
+        let defaults = UserDefaults(suiteName: "group.com.example.myapp")
+        var items = defaults?.stringArray(forKey: "sharedItems") ?? []
+        items.append(sharedText)
+        defaults?.set(items, forKey: "sharedItems")
+
+        extensionContext?.completeRequest(returningItems: nil)
+    }
+
+    func cancel() {
+        extensionContext?.cancelRequest(withError: NSError(domain: "user", code: 0))
+    }
+}
+```
+
+## Finder Sync Extension
+
+Add badges, contextual menus, and toolbar buttons in Finder:
+
+```swift
+import FinderSync
+
+class FinderSyncExtension: FIFinderSync {
+    override init() {
+        super.init()
+        // Monitor these directories
+        let monitoredFolder = URL(fileURLWithPath: "/Users/Shared/MyApp")
+        FIFinderSyncController.default().directoryURLs = [monitoredFolder]
+    }
+
+    // Badge icons for file status
+    override func requestBadgeIdentifier(for url: URL) {
+        let status = getFileStatus(url)
+        switch status {
+        case .synced: FIFinderSyncController.default().setBadgeIdentifier("synced", for: url)
+        case .syncing: FIFinderSyncController.default().setBadgeIdentifier("syncing", for: url)
+        case .error: FIFinderSyncController.default().setBadgeIdentifier("error", for: url)
+        }
+    }
+
+    // Context menu items
+    override func menu(for menuKind: FIMenuKind) -> NSMenu? {
+        let menu = NSMenu(title: "MyApp")
+        menu.addItem(withTitle: "Share via MyApp", action: #selector(shareFile(_:)), keyEquivalent: "")
+        return menu
+    }
+
+    @objc func shareFile(_ sender: Any) {
+        guard let items = FIFinderSyncController.default().selectedItemURLs() else { return }
+        // Handle selected files
+    }
+}
+```
+
+## Quick Look Preview Extension
+
+Preview custom file types in Finder and other apps:
+
+```swift
+import Cocoa
+import Quartz
+import QuickLookUI
+
+class PreviewViewController: NSViewController, QLPreviewingController {
+    func preparePreviewOfFile(at url: URL) async throws {
+        let data = try Data(contentsOf: url)
+        let content = try MyFileFormat.parse(data)
+
+        let hostingView = NSHostingView(rootView: FilePreviewView(content: content))
+        view.addSubview(hostingView)
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingView.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}
+```
+
+## XPC Services
+
+Separate privilege domains within your app. XPC services run in their own process with their own sandbox.
+
+### When to Use XPC
+- Isolate crash-prone code (e.g., parsing untrusted data)
+- Run privileged operations separately
+- Share functionality between app and extensions
+- Long-running background tasks that shouldn't crash the main app
+
+### Setting Up an XPC Service
+
+1. File > New > Target > XPC Service
+
+```swift
+// XPC Protocol - shared between app and service
+@objc protocol MyServiceProtocol {
+    func processFile(at path: String, reply: @escaping (Data?, Error?) -> Void)
+    func getStatus(reply: @escaping (String) -> Void)
+}
+
+// XPC Service implementation
+class MyService: NSObject, MyServiceProtocol {
+    func processFile(at path: String, reply: @escaping (Data?, Error?) -> Void) {
+        do {
+            let url = URL(fileURLWithPath: path)
+            let data = try Data(contentsOf: url)
+            let processed = transform(data)
+            reply(processed, nil)
+        } catch {
+            reply(nil, error)
+        }
+    }
+
+    func getStatus(reply: @escaping (String) -> Void) {
+        reply("ready")
+    }
+}
+
+// Service delegate
+class ServiceDelegate: NSObject, NSXPCListenerDelegate {
+    func listener(_ listener: NSXPCListener, shouldAcceptNewConnection connection: NSXPCConnection) -> Bool {
+        connection.exportedInterface = NSXPCInterface(with: MyServiceProtocol.self)
+        connection.exportedObject = MyService()
+        connection.resume()
+        return true
+    }
+}
+
+// main.swift for the XPC service
+let delegate = ServiceDelegate()
+let listener = NSXPCListener.service()
+listener.delegate = delegate
+listener.resume()
+```
+
+### Connecting from the App
+
+```swift
+class XPCClient {
+    private var connection: NSXPCConnection?
+
+    func connect() -> MyServiceProtocol? {
+        let connection = NSXPCConnection(serviceName: "com.example.myapp.xpcservice")
+        connection.remoteObjectInterface = NSXPCInterface(with: MyServiceProtocol.self)
+        connection.resume()
+        self.connection = connection
+
+        return connection.remoteObjectProxyWithErrorHandler { error in
+            print("XPC error: \(error)")
+        } as? MyServiceProtocol
+    }
+
+    func processFile(at path: String) async throws -> Data {
+        guard let service = connect() else { throw XPCError.connectionFailed }
+        return try await withCheckedThrowingContinuation { continuation in
+            service.processFile(at: path) { data, error in
+                if let error { continuation.resume(throwing: error) }
+                else if let data { continuation.resume(returning: data) }
+                else { continuation.resume(throwing: XPCError.noData) }
+            }
+        }
+    }
+
+    func disconnect() {
+        connection?.invalidate()
+        connection = nil
+    }
+}
+```
+
+## App Groups (Sharing Data Between App and Extensions)
+
+Share data between your main app and its extensions:
+
+```swift
+// 1. Add App Group entitlement to both app and extension
+// com.apple.security.application-groups: ["group.com.example.myapp"]
+
+// 2. Shared UserDefaults
+let shared = UserDefaults(suiteName: "group.com.example.myapp")
+shared?.set("value", forKey: "sharedKey")
+
+// 3. Shared file container
+let containerURL = FileManager.default.containerURL(
+    forSecurityApplicationGroupIdentifier: "group.com.example.myapp"
+)
+
+// 4. Shared SwiftData (macOS 14+)
+let schema = Schema([MyModel.self])
+let config = ModelConfiguration(
+    groupContainer: .identifier("group.com.example.myapp")
+)
+let container = try ModelContainer(for: schema, configurations: config)
+```
+
+## Best Practices
+
+1. **Minimal extension footprint** - Extensions have memory limits (varies by type)
+2. **Use App Groups for shared data** - Not file coordination or IPC
+3. **Handle extension lifecycle** - Extensions can be terminated at any time
+4. **Test extensions independently** - Use separate scheme for extension targets
+5. **XPC for crash isolation** - Keep unstable code in XPC services
+6. **Declare capabilities in Info.plist** - Extensions need explicit type declarations

--- a/.claude/skills/macos-development/macos-capabilities/menubar.md
+++ b/.claude/skills/macos-development/macos-capabilities/menubar.md
@@ -1,0 +1,344 @@
+# Menu Bar Apps
+
+Building menu bar applications with MenuBarExtra (SwiftUI) and NSStatusItem (AppKit). Covers background-only apps, popover menus, and hybrid architectures.
+
+## MenuBarExtra (SwiftUI, macOS 13+)
+
+The modern, declarative way to build menu bar apps.
+
+### Simple Menu
+
+```swift
+@main
+struct MyMenuBarApp: App {
+    var body: some Scene {
+        MenuBarExtra("MyApp", systemImage: "star.fill") {
+            Button("Open Dashboard") {
+                // Action
+            }
+            Button("Check for Updates") {
+                // Action
+            }
+            Divider()
+            Button("Quit") {
+                NSApplication.shared.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        }
+    }
+}
+```
+
+### Window-Style Popover
+
+For richer UIs, use `.menuBarExtraStyle(.window)`:
+
+```swift
+@main
+struct StatusApp: App {
+    @State private var appState = AppState()
+
+    var body: some Scene {
+        MenuBarExtra("Status", systemImage: appState.statusIcon) {
+            StatusPopoverView()
+                .environment(appState)
+                .frame(width: 320, height: 400)
+        }
+        .menuBarExtraStyle(.window)
+
+        // Optional: main window
+        Window("Settings", id: "settings") {
+            SettingsView()
+                .environment(appState)
+        }
+    }
+}
+
+struct StatusPopoverView: View {
+    @Environment(AppState.self) private var appState
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header
+            HStack {
+                Text("System Status")
+                    .font(.headline)
+                Spacer()
+                Button("Settings", systemImage: "gear") {
+                    openWindow(id: "settings")
+                    NSApp.activate(ignoringOtherApps: true)
+                    dismiss()
+                }
+                .buttonStyle(.borderless)
+            }
+
+            Divider()
+
+            // Content
+            ForEach(appState.statusItems) { item in
+                StatusRow(item: item)
+            }
+
+            Divider()
+
+            // Footer
+            HStack {
+                Text("Last updated: \(appState.lastUpdate.formatted())")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Refresh") {
+                    Task { await appState.refresh() }
+                }
+                .controlSize(.small)
+            }
+        }
+        .padding()
+    }
+}
+```
+
+### Dynamic Icon
+
+Update the menu bar icon based on state:
+
+```swift
+@Observable class AppState {
+    var isConnected = false
+    var unreadCount = 0
+
+    var statusIcon: String {
+        if !isConnected { return "wifi.slash" }
+        if unreadCount > 0 { return "bell.badge.fill" }
+        return "bell.fill"
+    }
+}
+
+// The icon updates automatically when properties change
+MenuBarExtra("Status", systemImage: appState.statusIcon) { ... }
+```
+
+### Dismissing the Menu After Actions
+
+The menu should dismiss after the user clicks an action item:
+
+```swift
+struct MenuView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Button("Open Main Window") {
+            openWindow(id: "main")
+            NSApp.activate(ignoringOtherApps: true)
+            dismiss()  // Dismiss after action
+        }
+    }
+}
+```
+
+## NSStatusItem (AppKit)
+
+For more control over the menu bar item, use AppKit's NSStatusItem directly.
+
+### Basic Setup
+
+```swift
+class StatusBarController {
+    private var statusItem: NSStatusItem?
+
+    func setup() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+        if let button = statusItem?.button {
+            button.image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: "MyApp")
+            button.action = #selector(handleClick(_:))
+            button.target = self
+            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        }
+    }
+
+    @objc func handleClick(_ sender: NSStatusBarButton) {
+        let event = NSApp.currentEvent!
+        if event.type == .rightMouseUp {
+            showContextMenu()
+        } else {
+            togglePopover()
+        }
+    }
+
+    func showContextMenu() {
+        let menu = NSMenu()
+        menu.addItem(NSMenuItem(title: "Settings...", action: #selector(openSettings), keyEquivalent: ","))
+        menu.addItem(.separator())
+        menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
+        statusItem?.menu = menu
+        statusItem?.button?.performClick(nil)
+        statusItem?.menu = nil  // Reset so left-click works again
+    }
+}
+```
+
+### Popover with SwiftUI Content
+
+```swift
+class StatusBarController {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+
+    func setup() {
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        statusItem?.button?.image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: "MyApp")
+        statusItem?.button?.action = #selector(togglePopover)
+        statusItem?.button?.target = self
+
+        popover = NSPopover()
+        popover?.contentSize = NSSize(width: 320, height: 400)
+        popover?.behavior = .transient  // Auto-dismiss when clicking outside
+        popover?.contentViewController = NSHostingController(
+            rootView: PopoverContentView()
+        )
+    }
+
+    @objc func togglePopover() {
+        guard let popover, let button = statusItem?.button else { return }
+        if popover.isShown {
+            popover.performClose(nil)
+        } else {
+            popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+}
+```
+
+## Background-Only App Architecture
+
+A menu bar app with no Dock icon and no main window:
+
+### Info.plist Configuration
+
+```xml
+<!-- Hide from Dock -->
+<key>LSUIElement</key>
+<true/>
+```
+
+### SwiftUI Approach
+
+```swift
+@main
+struct BackgroundApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    var body: some Scene {
+        MenuBarExtra("MyUtil", systemImage: "gearshape") {
+            MenuView()
+        }
+        .menuBarExtraStyle(.window)
+
+        // Settings window (opens on demand)
+        Settings {
+            SettingsView()
+        }
+    }
+}
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // No main window to show
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // Clicking Dock icon (if visible) doesn't open a window
+        false
+    }
+}
+```
+
+### Activation Policy Switching
+
+Toggle between Dock and menu-bar-only mode:
+
+```swift
+@Observable class AppMode {
+    var showInDock: Bool = false {
+        didSet {
+            NSApp.setActivationPolicy(showInDock ? .regular : .accessory)
+        }
+    }
+}
+```
+
+## Common Patterns
+
+### Status Item with Badge Count
+
+```swift
+func updateBadge(count: Int) {
+    guard let button = statusItem?.button else { return }
+    if count > 0 {
+        button.title = " \(count)"
+        button.imagePosition = .imageLeading
+    } else {
+        button.title = ""
+        button.imagePosition = .imageOnly
+    }
+}
+```
+
+### Opening Windows from Menu Bar
+
+```swift
+// Problem: openWindow() opens the window but doesn't bring it to front
+// Solution: activate the app after opening
+
+Button("Show Dashboard") {
+    openWindow(id: "dashboard")
+    NSApp.activate(ignoringOtherApps: true)
+    dismiss()  // Close the menu
+}
+```
+
+### Global Keyboard Shortcut
+
+Register a hotkey to toggle the menu bar popover:
+
+```swift
+import Carbon
+
+class HotkeyManager {
+    private var hotkeyRef: EventHotKeyRef?
+
+    func register(keyCode: UInt32, modifiers: UInt32, handler: @escaping () -> Void) {
+        var hotKeyID = EventHotKeyID()
+        hotKeyID.signature = OSType(0x4D794170) // "MyAp"
+        hotKeyID.id = 1
+
+        var eventType = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                       eventKind: UInt32(kEventHotKeyPressed))
+
+        InstallEventHandler(GetApplicationEventTarget(), { _, event, _ -> OSStatus in
+            // Handler called on hotkey press
+            return noErr
+        }, 1, &eventType, nil, nil)
+
+        RegisterEventHotKey(keyCode, modifiers, hotKeyID,
+                           GetApplicationEventTarget(), 0, &hotkeyRef)
+    }
+}
+```
+
+## Best Practices
+
+1. **Use MenuBarExtra for new apps** - Simpler, declarative, less code
+2. **Use `.menuBarExtraStyle(.window)` for rich UIs** - Default menu style is limited
+3. **Always provide a Quit option** - Users expect it in menu bar apps
+4. **Dismiss the menu after actions** - Standard macOS behavior
+5. **Activate the app when opening windows** - Use `NSApp.activate(ignoringOtherApps: true)`
+6. **Set LSUIElement for background-only apps** - Hides from Dock
+7. **Keep menus lightweight** - Don't do heavy computation in the menu view
+8. **Support keyboard shortcuts** - Add `.keyboardShortcut()` to menu items
+9. **Use SF Symbols for the status item** - Automatic template rendering for dark/light menu bar

--- a/.claude/skills/macos-development/macos-capabilities/sandboxing.md
+++ b/.claude/skills/macos-development/macos-capabilities/sandboxing.md
@@ -1,0 +1,236 @@
+# Sandboxing and Entitlements
+
+App Sandbox requirements, security-scoped bookmarks, and file access patterns for macOS apps.
+
+## App Sandbox Fundamentals
+
+The App Sandbox restricts your app to a container directory and limits access to system resources. It is **required** for Mac App Store distribution.
+
+### What the Sandbox Restricts
+
+| Resource | Default Access | How to Enable |
+|----------|---------------|---------------|
+| File system | App container only | Entitlements + user consent |
+| Network | None | `network.client` / `network.server` |
+| Camera | None | `device.camera` + usage description |
+| Microphone | None | `device.microphone` + usage description |
+| Location | None | `personal-information.location` |
+| Contacts | None | `personal-information.addressbook` |
+| Calendar | None | `personal-information.calendars` |
+| USB | None | `device.usb` |
+| Printing | None | `print` |
+| Apple Events | None | `automation.apple-events` |
+
+### Container Directory
+
+Sandboxed apps write to `~/Library/Containers/<bundle-id>/`:
+
+```swift
+// These resolve to the container automatically
+let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+```
+
+## File Access Patterns
+
+### User-Selected Files (Open/Save Panels)
+
+The sandbox grants temporary access to files the user explicitly selects:
+
+```swift
+// Open panel - user selects a file
+let panel = NSOpenPanel()
+panel.allowedContentTypes = [.png, .jpeg, .pdf]
+panel.allowsMultipleSelection = true
+
+let response = await panel.begin()
+if response == .OK {
+    for url in panel.urls {
+        // Access is granted for this session only
+        let data = try Data(contentsOf: url)
+        processFile(data)
+    }
+}
+```
+
+**Entitlement required:**
+```xml
+<key>com.apple.security.files.user-selected.read-only</key><true/>
+<!-- or for read-write: -->
+<key>com.apple.security.files.user-selected.read-write</key><true/>
+```
+
+### Security-Scoped Bookmarks
+
+Persist access to user-selected files/folders across app launches:
+
+```swift
+class BookmarkManager {
+    private let bookmarkKey = "savedBookmarks"
+
+    /// Save a bookmark for a user-selected URL
+    func saveBookmark(for url: URL) throws {
+        let bookmarkData = try url.bookmarkData(
+            options: .withSecurityScope,
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil
+        )
+
+        var bookmarks = UserDefaults.standard.dictionary(forKey: bookmarkKey) ?? [:]
+        bookmarks[url.path] = bookmarkData
+        UserDefaults.standard.set(bookmarks, forKey: bookmarkKey)
+    }
+
+    /// Restore access from a saved bookmark
+    func restoreBookmark(for path: String) -> URL? {
+        guard let bookmarks = UserDefaults.standard.dictionary(forKey: bookmarkKey),
+              let data = bookmarks[path] as? Data else { return nil }
+
+        var isStale = false
+        guard let url = try? URL(
+            resolvingBookmarkData: data,
+            options: .withSecurityScope,
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        ) else { return nil }
+
+        if isStale {
+            // Re-save the bookmark
+            try? saveBookmark(for: url)
+        }
+
+        return url
+    }
+
+    /// Access a bookmarked resource (must be balanced with stopAccessingSecurityScopedResource)
+    func accessResource(at url: URL, work: (URL) throws -> Void) rethrows {
+        guard url.startAccessingSecurityScopedResource() else {
+            throw SandboxError.accessDenied
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+        try work(url)
+    }
+}
+```
+
+**Entitlement required:**
+```xml
+<key>com.apple.security.files.bookmarks.app-scope</key><true/>
+<!-- For sharing bookmarks between apps: -->
+<key>com.apple.security.files.bookmarks.document-scope</key><true/>
+```
+
+### Critical: Start/Stop Access Pairing
+
+Always balance `startAccessingSecurityScopedResource()` with `stopAccessingSecurityScopedResource()`:
+
+```swift
+// Wrong - never stops accessing
+let url = restoreBookmark(for: path)!
+url.startAccessingSecurityScopedResource()
+let data = try Data(contentsOf: url)
+// Leaked security scope!
+
+// Right - use defer
+guard url.startAccessingSecurityScopedResource() else { return }
+defer { url.stopAccessingSecurityScopedResource() }
+let data = try Data(contentsOf: url)
+```
+
+### Folder Access Pattern
+
+Let users select a folder, then access all files within it:
+
+```swift
+func selectWorkingFolder() async -> URL? {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = true
+    panel.canChooseFiles = false
+    panel.message = "Select a folder to grant access"
+
+    let response = await panel.begin()
+    guard response == .OK, let url = panel.url else { return nil }
+
+    // Save bookmark for persistent access
+    try? bookmarkManager.saveBookmark(for: url)
+    return url
+}
+
+func listFiles(in folderURL: URL) throws -> [URL] {
+    guard folderURL.startAccessingSecurityScopedResource() else {
+        throw SandboxError.accessDenied
+    }
+    defer { folderURL.stopAccessingSecurityScopedResource() }
+
+    let contents = try FileManager.default.contentsOfDirectory(
+        at: folderURL,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: .skipsHiddenFiles
+    )
+    return contents
+}
+```
+
+## Related Items (Implicitly Accessed Files)
+
+Access files related to a user-selected file (e.g., .srt subtitle for a .mp4 video):
+
+```xml
+<!-- Info.plist - declare related file types -->
+<key>NSServices</key>
+<array>
+    <dict>
+        <key>NSRelatedItemsContentTypes</key>
+        <array>
+            <string>public.plain-text</string>
+        </array>
+    </dict>
+</array>
+```
+
+## Temporary Exceptions
+
+For direct distribution (outside Mac App Store), you can use temporary exceptions:
+
+```xml
+<!-- Access specific paths (NOT allowed on Mac App Store) -->
+<key>com.apple.security.temporary-exception.files.absolute-path.read-write</key>
+<array>
+    <string>/usr/local/bin/</string>
+</array>
+```
+
+## Common Sandbox Rejection Reasons
+
+| Issue | Solution |
+|-------|----------|
+| Accessing files without user consent | Use NSOpenPanel or security-scoped bookmarks |
+| Network access without entitlement | Add `network.client` entitlement |
+| Writing outside container | Use Powerbox (panels) or bookmarks |
+| Apple Events without entitlement | Add `automation.apple-events` + target app in Info.plist |
+| Hardcoded paths (e.g., `~/Desktop`) | Use system APIs (`FileManager.urls(for:)`) |
+
+## Testing Sandbox
+
+```bash
+# Verify sandbox is active
+codesign -dvvv --entitlements :- /path/to/MyApp.app
+
+# Check sandbox violations in Console.app
+# Filter by process name and "sandbox" or "deny"
+
+# Run with sandbox enforcement in debug
+# Product > Scheme > Edit Scheme > Run > Arguments
+# Add environment variable: APP_SANDBOX_CONTAINER_ID = <bundle-id>
+```
+
+## Best Practices
+
+1. **Enable sandbox early** - Retrofitting is painful; start sandboxed
+2. **Request minimal entitlements** - Only what you actually need
+3. **Always use security-scoped bookmarks** - For any persistent file access
+4. **Balance start/stop calls** - Use `defer` to prevent resource leaks
+5. **Handle access failures gracefully** - `startAccessingSecurityScopedResource` can return false
+6. **Test in sandboxed mode** - Don't disable sandbox for debugging
+7. **Use NSOpenPanel for user consent** - The sandbox Powerbox handles the rest

--- a/.claude/skills/macos-development/macos-capabilities/skill.md
+++ b/.claude/skills/macos-development/macos-capabilities/skill.md
@@ -1,0 +1,117 @@
+---
+name: macos-capabilities
+description: Expert guidance on macOS platform capabilities. Covers sandboxing, app extensions, menu bar apps, and background execution. Use when implementing system integration features.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# macOS Capabilities Expert
+
+You are a macOS development expert specializing in platform capabilities and system integration. You help developers leverage macOS-specific features including sandboxing, extensions, menu bar apps, and background execution.
+
+## Your Role
+
+Guide developers through implementing macOS platform capabilities correctly, with attention to sandboxing requirements, security best practices, and Mac App Store compatibility.
+
+## Core Focus Areas
+
+1. **Sandboxing** - App Sandbox, entitlements, security-scoped bookmarks, file access
+2. **Extensions** - App extensions, system extensions, XPC services
+3. **Menu Bar Apps** - MenuBarExtra, NSStatusItem, background-only apps
+4. **Background Operations** - Login items, launch agents, background task management
+
+## When This Skill Activates
+
+- Implementing file access patterns in sandboxed apps
+- Building menu bar apps or status item utilities
+- Creating app extensions (Share, Finder Sync, etc.)
+- Setting up background execution or login items
+- Preparing for Mac App Store sandboxing requirements
+
+## Quick Decision Guide
+
+| Need | Solution | Module |
+|------|----------|--------|
+| Persist user-selected folder access | Security-scoped bookmarks | sandboxing.md |
+| Share content to other apps | Share Extension | extensions.md |
+| Utility that lives in the menu bar | MenuBarExtra | menubar.md |
+| App launches at login | Login Item (ServiceManagement) | background.md |
+| Long-running background work | BackgroundTask / DispatchSource | background.md |
+| Custom Finder integration | Finder Sync Extension | extensions.md |
+| Network filtering/proxy | System Extension | extensions.md |
+| Inter-process communication | XPC Service | extensions.md |
+
+## How to Conduct Reviews
+
+### Step 1: Identify Capabilities Used
+- What system features does the app need?
+- Is it sandboxed (required for Mac App Store)?
+- What entitlements are required?
+
+### Step 2: Review Against Module Guidelines
+- Sandboxing compliance (see sandboxing.md)
+- Extension architecture (see extensions.md)
+- Menu bar implementation (see menubar.md)
+- Background execution (see background.md)
+
+### Step 3: Provide Structured Feedback
+
+For each issue found:
+1. **Issue**: Describe the capability problem
+2. **Impact**: Rejection, crash, security risk, user confusion
+3. **Fix**: Correct implementation with entitlements and code
+4. **Apple Review**: Note any App Store review implications
+
+## Entitlements Quick Reference
+
+```xml
+<!-- File access -->
+<key>com.apple.security.files.user-selected.read-write</key><true/>
+<key>com.apple.security.files.bookmarks.app-scope</key><true/>
+
+<!-- Network -->
+<key>com.apple.security.network.client</key><true/>
+<key>com.apple.security.network.server</key><true/>
+
+<!-- Hardware -->
+<key>com.apple.security.device.camera</key><true/>
+<key>com.apple.security.device.microphone</key><true/>
+
+<!-- Apple Events (automation) -->
+<key>com.apple.security.automation.apple-events</key><true/>
+
+<!-- Keychain sharing -->
+<key>com.apple.security.application-groups</key>
+<array><string>$(TeamIdentifierPrefix)com.example.shared</string></array>
+```
+
+## Module References
+
+Load these modules as needed:
+
+1. **Sandboxing**: `sandboxing.md`
+   - App Sandbox fundamentals
+   - Security-scoped bookmarks
+   - File access patterns
+
+2. **Extensions**: `extensions.md`
+   - App extension types and lifecycle
+   - System extensions
+   - XPC services
+
+3. **Menu Bar**: `menubar.md`
+   - MenuBarExtra (SwiftUI)
+   - NSStatusItem (AppKit)
+   - Background-only app architecture
+
+4. **Background Operations**: `background.md`
+   - Login items
+   - Launch agents
+   - Background task management
+
+## Response Guidelines
+
+- Always specify required entitlements for each capability
+- Note Mac App Store vs. direct distribution differences
+- Warn about common rejection reasons
+- Prefer modern APIs (ServiceManagement over deprecated SMLoginItemSetEnabled)
+- Include Info.plist keys when relevant

--- a/.claude/skills/macos-development/macos-tahoe-apis/apple-intelligence.md
+++ b/.claude/skills/macos-development/macos-tahoe-apis/apple-intelligence.md
@@ -1,0 +1,87 @@
+# Apple Intelligence Integration
+
+Foundation Models, on-device AI, and MCP (Model Context Protocol) support in macOS 26.
+
+## Foundation Models API
+
+```swift
+import AppleIntelligence  // Hypothetical framework
+
+// ✅ Text generation
+func generateText(prompt: String) async throws -> String {
+    let model = try await AIFoundationModel.load(.textGeneration)
+    let response = try await model.generate(prompt: prompt)
+    return response.text
+}
+
+// ✅ Text summarization
+func summarize(_ text: String) async throws -> String {
+    let model = try await AIFoundationModel.load(.summarization)
+    return try await model.summarize(text)
+}
+
+// ✅ On-device processing (privacy-preserving)
+func analyzeOnDevice(_ data: String) async throws -> Analysis {
+    let model = try await AIFoundationModel.load(.analysis)
+    model.processingLocation = .onDevice  // Ensures privacy
+    return try await model.analyze(data)
+}
+```
+
+## Model Context Protocol (MCP)
+
+```swift
+// ✅ MCP integration for AI context
+struct MCPContext {
+    let tools: [MCPTool]
+    let resources: [MCPResource]
+}
+
+protocol MCPTool {
+    var name: String { get }
+    var description: String { get }
+    func execute(parameters: [String: Any]) async throws -> Any
+}
+
+// Example MCP tool
+struct FileSearchTool: MCPTool {
+    let name = "file_search"
+    let description = "Search for files in the system"
+
+    func execute(parameters: [String: Any]) async throws -> Any {
+        guard let query = parameters["query"] as? String else {
+            throw MCPError.invalidParameters
+        }
+        // Perform file search
+        return searchFiles(query: query)
+    }
+
+    private func searchFiles(query: String) -> [URL] {
+        // Implementation
+        return []
+    }
+}
+```
+
+## Privacy-Preserving AI
+
+```swift
+// ✅ On-device model inference
+func processPrivately(_ input: String) async throws -> Result {
+    // All processing happens on-device
+    let model = try await LocalAIModel.load()
+    return try await model.process(input)
+}
+
+// ✅ Check processing location
+func verifyPrivacy() async -> Bool {
+    let model = try? await AIFoundationModel.load(.textGeneration)
+    return model?.processingLocation == .onDevice
+}
+```
+
+## Resources
+
+- [Apple Intelligence Documentation](https://developer.apple.com/documentation/apple-intelligence)
+- [MCP Specification](https://modelcontextprotocol.io/)
+- [WWDC 2025: Apple Intelligence](https://developer.apple.com/videos/)

--- a/.claude/skills/macos-development/macos-tahoe-apis/continuity.md
+++ b/.claude/skills/macos-development/macos-tahoe-apis/continuity.md
@@ -1,0 +1,69 @@
+# Continuity Features
+
+Cross-device integration between macOS, iOS, and iPadOS.
+
+## Universal Clipboard
+
+```swift
+// ✅ Copy to universal clipboard
+NSPasteboard.general.clearContents()
+NSPasteboard.general.setString(text, forType: .string)
+// Automatically syncs to other devices
+
+// ✅ Monitor clipboard changes
+NotificationCenter.default.addObserver(
+    forName: NSPasteboard.didChangeNotification,
+    object: nil,
+    queue: .main
+) { _ in
+    handleClipboardChange()
+}
+```
+
+## Handoff
+
+```swift
+// ✅ Enable Handoff
+func setupHandoff() {
+    let activity = NSUserActivity(activityType: "com.app.editing")
+    activity.title = "Editing Document"
+    activity.userInfo = ["documentID": document.id.uuidString]
+    activity.isEligibleForHandoff = true
+    activity.becomeCurrent()
+}
+
+// ✅ Continue activity from another device
+func application(
+    _ application: NSApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void
+) -> Bool {
+    if userActivity.activityType == "com.app.editing",
+       let documentID = userActivity.userInfo?["documentID"] as? String {
+        openDocument(id: documentID)
+        return true
+    }
+    return false
+}
+```
+
+## AirDrop Integration
+
+```swift
+import AppKit
+
+// ✅ Share via AirDrop
+let sharingService = NSSharingService(named: .sendViaAirDrop)
+sharingService?.perform(withItems: [url])
+
+// ✅ Receive AirDrop files
+func application(_ application: NSApplication, open urls: [URL]) {
+    for url in urls {
+        handleReceivedFile(url)
+    }
+}
+```
+
+## Resources
+
+- [Continuity Documentation](https://developer.apple.com/documentation/foundation/nsuseractivity)

--- a/.claude/skills/macos-development/macos-tahoe-apis/mlx-framework.md
+++ b/.claude/skills/macos-development/macos-tahoe-apis/mlx-framework.md
@@ -1,0 +1,57 @@
+# MLX Framework
+
+Apple's machine learning framework with M5 chip neural accelerator support.
+
+## MLX Basics
+
+```swift
+import MLX
+
+// ✅ Load and run ML model with MLX
+func runMLXModel() async throws {
+    let model = try await MLXModel.load(from: modelURL)
+
+    // Leverages M5 neural accelerators automatically
+    let input = MLXArray(data: inputData)
+    let output = try await model.predict(input)
+
+    print("Prediction: \(output)")
+}
+```
+
+## Neural Accelerator Access (M5)
+
+```swift
+// ✅ Optimize for M5 chip
+func configureForM5() {
+    MLX.configuration.useNeuralAccelerators = true
+    MLX.configuration.preferredDevice = .neuralEngine
+}
+
+// ✅ Check hardware capabilities
+func checkMLXCapabilities() -> Bool {
+    MLX.neuralAcceleratorsAvailable
+}
+```
+
+## Training on Device
+
+```swift
+// ✅ On-device model training
+func trainModel() async throws {
+    let trainer = MLXTrainer(model: model)
+    trainer.configuration.device = .neuralEngine
+
+    for epoch in 0..<numEpochs {
+        let loss = try await trainer.train(epoch: epoch, data: trainingData)
+        print("Epoch \(epoch): Loss = \(loss)")
+    }
+
+    try await trainer.save(to: modelURL)
+}
+```
+
+## Resources
+
+- [MLX Documentation](https://ml-explore.github.io/mlx/)
+- [M5 Neural Engine Guide](https://developer.apple.com/documentation/coreml)

--- a/.claude/skills/macos-development/macos-tahoe-apis/skill.md
+++ b/.claude/skills/macos-development/macos-tahoe-apis/skill.md
@@ -1,0 +1,47 @@
+---
+name: macos-tahoe-apis
+description: Guide to macOS 26 Tahoe APIs and features. Covers Apple Intelligence, Foundation Models, MLX framework, and Continuity. Use when implementing macOS 26 specific features.
+allowed-tools: [Read, Glob, Grep, WebFetch]
+---
+
+# macOS Tahoe APIs
+
+You are a macOS 26 (Tahoe) API expert specializing in the latest platform features, Apple Intelligence, and modern development tools.
+
+## When This Skill Activates
+
+- User wants to implement macOS 26 (Tahoe)-specific features
+- User asks about Apple Intelligence on macOS or Foundation Models
+- User wants to use the MLX framework (M5 chip optimization)
+- User asks about Continuity features or cross-device integration
+- User asks "what's new in macOS Tahoe" or targets macOS 26
+
+## Your Role
+
+Guide developers in using macOS 26 (Tahoe) specific features and APIs effectively.
+
+## Core Focus Areas
+
+1. **Tahoe Features** - macOS 26 specific features (Spotlight, Control Center, Phone app, etc.)
+2. **Apple Intelligence** - Foundation Models, on-device AI, MCP support
+3. **MLX Framework** - Machine learning with M5 chip optimization
+4. **Continuity** - Cross-device features and integration
+5. **Xcode 16** - Modern development tools and optimizations
+
+## Module References
+
+1. **Tahoe Features**: `skills/macos-tahoe-apis/tahoe-features.md`
+2. **Apple Intelligence**: `skills/macos-tahoe-apis/apple-intelligence.md`
+3. **MLX Framework**: `skills/macos-tahoe-apis/mlx-framework.md`
+4. **Continuity**: `skills/macos-tahoe-apis/continuity.md`
+5. **Xcode 16**: `skills/macos-tahoe-apis/xcode16.md`
+
+## Review Approach
+
+1. Identify which macOS 26 features are relevant to the project
+2. Suggest modern API usage over deprecated approaches
+3. Provide code examples with best practices
+4. Reference official Apple documentation
+5. Consider backwards compatibility when needed
+
+Begin by asking about the project's requirements and target macOS version.

--- a/.claude/skills/macos-development/macos-tahoe-apis/tahoe-features.md
+++ b/.claude/skills/macos-development/macos-tahoe-apis/tahoe-features.md
@@ -1,0 +1,252 @@
+# macOS Tahoe Features
+
+New and enhanced features in macOS 26 (Tahoe).
+
+## Redesigned Spotlight Search
+
+### Quick Actions API
+
+```swift
+import AppKit
+
+// ✅ Register Spotlight quick actions
+extension AppDelegate {
+    func registerSpotlightActions() {
+        let action = NSUserActivity(activityType: "com.app.createDocument")
+        action.title = "Create New Document"
+        action.isEligibleForSearch = true
+        action.isEligibleForPrediction = true
+
+        // Add to Spotlight
+        action.becomeCurrent()
+    }
+}
+
+// Handle quick action
+func application(
+    _ application: NSApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void
+) -> Bool {
+    if userActivity.activityType == "com.app.createDocument" {
+        createNewDocument()
+        return true
+    }
+    return false
+}
+```
+
+### Third-Party Spotlight Integration
+
+```swift
+import CoreSpotlight
+
+// ✅ Index content for Spotlight
+func indexArticle(_ article: Article) {
+    let attributeSet = CSSearchableItemAttributeSet(contentType: .content)
+    attributeSet.title = article.title
+    attributeSet.contentDescription = article.content
+    attributeSet.keywords = article.tags
+    attributeSet.thumbnailData = article.thumbnail
+
+    let item = CSSearchableItem(
+        uniqueIdentifier: article.id.uuidString,
+        domainIdentifier: "com.app.articles",
+        attributeSet: attributeSet
+    )
+
+    CSSearchableIndex.default().indexSearchableItems([item]) { error in
+        if let error = error {
+            print("Indexing error: \(error)")
+        }
+    }
+}
+
+// ✅ Handle Spotlight selection
+func handleSpotlightSelection(_ uniqueIdentifier: String) {
+    guard let articleID = UUID(uuidString: uniqueIdentifier) else { return }
+    openArticle(id: articleID)
+}
+```
+
+## Phone App on Mac (Continuity)
+
+### Making Calls from Mac
+
+```swift
+// ✅ Tel links automatically open in Phone app
+Link("Call Support", destination: URL(string: "tel:1-800-555-0123")!)
+
+// ✅ FaceTime links
+Link("FaceTime", destination: URL(string: "facetime:user@example.com")!)
+
+// Check if calling is available
+if let url = URL(string: "tel:1-800-555-0123"),
+   NSWorkspace.shared.urlForApplication(toOpen: url) != nil {
+    // Phone app available
+}
+```
+
+## Control Center Integration
+
+### Custom Control Center Widgets
+
+```swift
+// Note: Control Center customization is system-level
+// Apps can provide widgets through WidgetKit
+
+import WidgetKit
+import SwiftUI
+
+struct ControlWidget: Widget {
+    let kind: String = "ControlWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            ControlWidgetView(entry: entry)
+        }
+        .configurationDisplayName("Quick Control")
+        .description("Quick access control")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+struct ControlWidgetView: View {
+    let entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Image(systemName: "power")
+                .font(.largeTitle)
+            Text("Toggle")
+                .font(.caption)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.ultraThinMaterial)
+    }
+}
+```
+
+## Custom Folder Icons and Emblems
+
+### Programmatic Icon Customization
+
+```swift
+import AppKit
+
+// ✅ Set custom folder icon
+func setCustomFolderIcon(for url: URL, icon: NSImage) {
+    NSWorkspace.shared.setIcon(icon, forFile: url.path, options: [])
+}
+
+// ✅ Get folder icon
+func getFolderIcon(for url: URL) -> NSImage? {
+    NSWorkspace.shared.icon(forFile: url.path)
+}
+
+// ✅ Support accent color in icons
+let icon = NSImage(systemSymbolName: "folder.fill", accessibilityDescription: nil)
+icon?.isTemplate = true  // Respects accent color
+```
+
+## Edge Light for Video Calls
+
+### Detecting Low Light Conditions
+
+```swift
+import AVFoundation
+
+// ✅ Monitor camera light conditions
+class CameraMonitor: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        // Analyze brightness
+        let brightness = calculateBrightness(imageBuffer)
+
+        if brightness < 0.3 {
+            // Low light - Edge Light will activate automatically
+            print("Low light detected")
+        }
+    }
+
+    private func calculateBrightness(_ imageBuffer: CVImageBuffer) -> Double {
+        // Implementation
+        return 0.0
+    }
+}
+
+// Note: Edge Light is automatic in system video call apps
+// Third-party apps can detect conditions but system handles the feature
+```
+
+## Thunderbolt 5 Multi-Mac Support
+
+### Detecting Multi-Mac Cluster
+
+```swift
+import IOKit
+
+// ✅ Check for Thunderbolt 5 connections
+func detectThunderbolt5() -> Bool {
+    // Query IOKit for Thunderbolt 5 controllers
+    // This is a low-level API check
+    return false  // Placeholder
+}
+
+// ✅ Distributed computing setup
+// Use distributed actor frameworks for multi-Mac processing
+```
+
+## Urgent Reminders
+
+### Creating Urgent Reminders
+
+```swift
+import EventKit
+
+// ✅ Create urgent reminder
+func createUrgentReminder() {
+    let eventStore = EKEventStore()
+
+    eventStore.requestAccess(to: .reminder) { granted, error in
+        guard granted else { return }
+
+        let reminder = EKReminder(eventStore: eventStore)
+        reminder.title = "Important Task"
+        reminder.calendar = eventStore.defaultCalendarForNewReminders()
+
+        // Set due date
+        let dueDate = Calendar.current.date(byAdding: .hour, value: 2, to: Date())
+        reminder.dueDateComponents = Calendar.current.dateComponents(
+            [.year, .month, .day, .hour, .minute],
+            from: dueDate!
+        )
+
+        // Mark as urgent (macOS 26+)
+        reminder.priority = 1  // High priority triggers urgent flag
+
+        try? eventStore.save(reminder, commit: true)
+    }
+}
+```
+
+## macOS Tahoe Checklist
+
+- [ ] Integrate with redesigned Spotlight (quick actions, indexing)
+- [ ] Support Phone app links (tel:, facetime:)
+- [ ] Consider Control Center widgets (WidgetKit)
+- [ ] Support custom folder icons and accent colors
+- [ ] Detect low light for video features (if applicable)
+- [ ] Consider Thunderbolt 5 for distributed computing
+- [ ] Use urgent reminders API correctly
+
+## Resources
+
+- [macOS 26 Release Notes](https://developer.apple.com/documentation/macos-release-notes/macos-26-release-notes)
+- [Core Spotlight Framework](https://developer.apple.com/documentation/corespotlight)
+- [WidgetKit Documentation](https://developer.apple.com/documentation/widgetkit)

--- a/.claude/skills/macos-development/macos-tahoe-apis/xcode16.md
+++ b/.claude/skills/macos-development/macos-tahoe-apis/xcode16.md
@@ -1,0 +1,59 @@
+# Xcode 16 Features
+
+Modern development tools and optimizations for macOS 26 development.
+
+## Swift 6 Support
+
+```swift
+// ✅ Enable strict concurrency checking
+// Build Settings > Swift Compiler > Strict Concurrency Checking: Complete
+
+// ✅ Use Swift 6 language mode
+// Build Settings > Swift Language Version: Swift 6
+```
+
+## Apple Silicon Optimization
+
+```swift
+// ✅ Build for Apple Silicon
+// Architecture: arm64 (for M-series chips)
+
+// ✅ Optimize for M5
+// Build Settings > Deployment > Architectures: arm64
+
+// Performance improvements automatically applied for M5
+```
+
+## Previews and Testing
+
+```swift
+import SwiftUI
+
+// ✅ Xcode Previews
+#Preview {
+    ContentView()
+}
+
+// ✅ Multiple preview configurations
+#Preview("Light Mode") {
+    ContentView()
+        .preferredColorScheme(.light)
+}
+
+#Preview("Dark Mode") {
+    ContentView()
+        .preferredColorScheme(.dark)
+}
+```
+
+## Debugging Tools
+
+- Instruments improvements for macOS 26
+- Memory Graph Debugger enhancements
+- Network debugging tools
+- SwiftData debugging support
+
+## Resources
+
+- [Xcode 16 Release Notes](https://developer.apple.com/documentation/xcode-release-notes)
+- [Swift 6 Migration Guide](https://www.swift.org/migration/)

--- a/.claude/skills/macos-development/swiftdata-architecture/performance.md
+++ b/.claude/skills/macos-development/swiftdata-architecture/performance.md
@@ -1,0 +1,378 @@
+# SwiftData Performance Optimization
+
+Batch operations, background contexts, lazy loading, and memory management techniques for SwiftData.
+
+## Measuring Performance
+
+Before optimizing, measure. Use Instruments to identify actual bottlenecks:
+
+```swift
+// Quick timing in code
+func measureFetch() async throws {
+    let start = CFAbsoluteTimeGetCurrent()
+    let results = try modelContext.fetch(FetchDescriptor<Document>())
+    let elapsed = CFAbsoluteTimeGetCurrent() - start
+    print("Fetched \(results.count) documents in \(elapsed)s")
+}
+```
+
+### Instruments Traces
+- **SwiftData** instrument: query durations, save operations
+- **Core Data** instrument: underlying SQLite operations (SwiftData uses Core Data)
+- **Allocations**: memory growth from model objects
+- **Time Profiler**: CPU time in fetch/save operations
+
+## Background Context Operations
+
+Never block the main thread with heavy data operations. Use `@ModelActor` for background work.
+
+### Background Imports
+
+```swift
+@ModelActor
+actor DataImporter {
+    func importItems(_ items: [ImportItem]) async throws -> Int {
+        var importedCount = 0
+
+        for item in items {
+            let model = DocumentModel(
+                title: item.title,
+                content: item.content,
+                createdAt: item.date
+            )
+            modelContext.insert(model)
+            importedCount += 1
+
+            // Save in batches to manage memory
+            if importedCount % 500 == 0 {
+                try modelContext.save()
+            }
+        }
+
+        try modelContext.save()
+        return importedCount
+    }
+}
+
+// Usage from ViewModel
+@Observable @MainActor
+class ImportViewModel {
+    var progress: Double = 0
+    var isImporting = false
+
+    func importFile(url: URL, container: ModelContainer) async throws {
+        isImporting = true
+        defer { isImporting = false }
+
+        let items = try parseFile(url)
+        let importer = DataImporter(modelContainer: container)
+        let count = try await importer.importItems(items)
+        print("Imported \(count) items")
+    }
+}
+```
+
+### Background Deletions
+
+```swift
+@ModelActor
+actor DataCleaner {
+    func deleteOldItems(olderThan date: Date) async throws -> Int {
+        let descriptor = FetchDescriptor<LogEntry>(
+            predicate: #Predicate { $0.timestamp < date }
+        )
+        let items = try modelContext.fetch(descriptor)
+        let count = items.count
+
+        for item in items {
+            modelContext.delete(item)
+        }
+        try modelContext.save()
+        return count
+    }
+}
+```
+
+## Batch Operations
+
+### Efficient Batch Insert
+
+```swift
+@ModelActor
+actor BatchProcessor {
+    func batchInsert(_ records: [Record]) async throws {
+        // Insert in chunks to manage memory
+        let chunkSize = 1000
+        for chunk in records.chunked(into: chunkSize) {
+            for record in chunk {
+                modelContext.insert(record.toModel())
+            }
+            try modelContext.save()
+
+            // Reset context to free memory from processed objects
+            modelContext.reset()
+        }
+    }
+}
+
+// Array chunking helper
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0..<Swift.min($0 + size, count)])
+        }
+    }
+}
+```
+
+### Efficient Batch Updates
+
+```swift
+@ModelActor
+actor BatchUpdater {
+    func markAllCompleted(projectID: UUID) async throws {
+        let descriptor = FetchDescriptor<TaskModel>(
+            predicate: #Predicate { $0.project?.id == projectID && !$0.isCompleted }
+        )
+        let tasks = try modelContext.fetch(descriptor)
+        for task in tasks {
+            task.isCompleted = true
+        }
+        try modelContext.save()
+    }
+}
+```
+
+## Fetch Optimization
+
+### Fetch Only What You Need
+
+```swift
+// Wrong - fetches all properties of all records
+let everything = try modelContext.fetch(FetchDescriptor<Document>())
+let titles = everything.map(\.title)
+
+// Right - fetch specific properties
+var descriptor = FetchDescriptor<Document>()
+descriptor.propertiesToFetch = [\.title, \.createdAt]
+let documents = try modelContext.fetch(descriptor)
+```
+
+### Use Count Instead of Fetch
+
+```swift
+// Wrong - fetches all objects just to count them
+let count = try modelContext.fetch(FetchDescriptor<Task>()).count
+
+// Right - count at the database level
+let count = try modelContext.fetchCount(FetchDescriptor<Task>())
+```
+
+### Use Identifiers for Lightweight Checks
+
+```swift
+// Fetch just IDs (no object materialization)
+let ids = try modelContext.fetchIdentifiers(
+    FetchDescriptor<Document>(predicate: #Predicate { $0.isArchived })
+)
+let archivedCount = ids.count
+```
+
+### Pagination for Large Datasets
+
+```swift
+struct PaginatedList<Model: PersistentModel>: View {
+    @State private var items: [Model] = []
+    @State private var hasMore = true
+    @State private var currentPage = 0
+    let pageSize = 50
+    let sortDescriptor: SortDescriptor<Model>
+
+    @Environment(\.modelContext) private var context
+
+    var body: some View {
+        List {
+            ForEach(items) { item in
+                // Row view
+            }
+
+            if hasMore {
+                ProgressView()
+                    .task { await loadNextPage() }
+            }
+        }
+        .task { await loadNextPage() }
+    }
+
+    func loadNextPage() async {
+        var descriptor = FetchDescriptor<Model>(sortBy: [sortDescriptor])
+        descriptor.fetchOffset = currentPage * pageSize
+        descriptor.fetchLimit = pageSize
+
+        do {
+            let newItems = try context.fetch(descriptor)
+            items.append(contentsOf: newItems)
+            hasMore = newItems.count == pageSize
+            currentPage += 1
+        } catch {
+            hasMore = false
+        }
+    }
+}
+```
+
+## Memory Management
+
+### Autosave Considerations
+
+By default, SwiftData autosaves. For bulk operations, you may want to control saves:
+
+```swift
+let config = ModelConfiguration(isStoredInMemoryOnly: false)
+let container = try ModelContainer(
+    for: Document.self,
+    configurations: config
+)
+
+// The ModelContext.autosaveEnabled property controls auto-saves
+// For background contexts in @ModelActor, auto-save is off by default
+```
+
+### Reset Context After Bulk Work
+
+```swift
+@ModelActor
+actor HeavyProcessor {
+    func processAllDocuments() async throws {
+        var offset = 0
+        let batchSize = 100
+
+        while true {
+            var descriptor = FetchDescriptor<Document>(
+                sortBy: [SortDescriptor(\.createdAt)]
+            )
+            descriptor.fetchOffset = offset
+            descriptor.fetchLimit = batchSize
+
+            let batch = try modelContext.fetch(descriptor)
+            guard !batch.isEmpty else { break }
+
+            for doc in batch {
+                doc.processedAt = .now
+            }
+
+            try modelContext.save()
+            modelContext.reset()  // Free memory from processed objects
+
+            offset += batchSize
+        }
+    }
+}
+```
+
+### Relationship Faulting
+
+SwiftData lazily loads relationships. Access them only when needed:
+
+```swift
+// Good - relationship not accessed until needed
+struct ProjectListView: View {
+    @Query var projects: [Project]
+
+    var body: some View {
+        List(projects) { project in
+            HStack {
+                Text(project.name)
+                Spacer()
+                // Tasks loaded on-demand when this view appears
+                Text("\(project.tasks.count) tasks")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+```
+
+## Predicate Performance
+
+### Use Indexed Properties for Frequent Queries
+
+Predicates on indexed properties are significantly faster:
+
+```swift
+@Model
+class Document {
+    // Properties frequently used in predicates should be simple types
+    var title: String          // Fast to query
+    var isArchived: Bool       // Fast to query
+    var createdAt: Date        // Fast to query
+    var tags: [String] = []    // Slower to query (transformable)
+}
+```
+
+### Predicate Complexity
+
+```swift
+// Fast - simple property comparison
+#Predicate<Task> { !$0.isCompleted }
+
+// Fast - date comparison
+let cutoff = Date.now
+#Predicate<Task> { $0.createdAt > cutoff }
+
+// Slower - string contains
+#Predicate<Task> { $0.title.localizedStandardContains(searchText) }
+
+// Slower - nested relationship traversal
+#Predicate<Task> { $0.project?.category?.name == categoryName }
+```
+
+### Optimize Search
+
+For search features, consider a denormalized search field:
+
+```swift
+@Model
+class Document {
+    var title: String
+    var content: String
+    var author: String
+
+    // Denormalized for fast search
+    var searchText: String
+
+    init(title: String, content: String, author: String) {
+        self.title = title
+        self.content = content
+        self.author = author
+        self.searchText = "\(title) \(content) \(author)".lowercased()
+    }
+}
+
+// Fast single-field search instead of multi-field predicate
+let query = searchText.lowercased()
+#Predicate<Document> { $0.searchText.contains(query) }
+```
+
+## Common Performance Issues
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Fetching too many objects | High memory, slow scroll | Use fetchLimit, pagination |
+| Main thread saves | UI freezes on save | Use @ModelActor for writes |
+| N+1 queries | Slow list rendering | Batch fetch relationships |
+| No fetch limits | Memory growth | Always set fetchLimit for bounded UI |
+| Frequent small saves | Disk I/O bottleneck | Batch saves (every N items) |
+| Context never reset | Memory growth in loops | Call modelContext.reset() after batches |
+
+## Best Practices
+
+1. **Measure before optimizing** - Use Instruments, not intuition
+2. **Use @ModelActor for background work** - Never block the main thread
+3. **Batch saves** - Save every 100-1000 items, not every single insert
+4. **Reset context in batch loops** - Free memory from processed objects
+5. **Use fetchCount for counts** - Don't materialize objects just to count
+6. **Set fetchLimit for bounded UI** - A "top 10" list shouldn't fetch 10,000 records
+7. **Paginate large datasets** - Load on-demand as the user scrolls
+8. **Keep predicates simple** - Complex nested predicates are slower
+9. **Denormalize for search** - A single searchText field beats multi-field predicates

--- a/.claude/skills/macos-development/swiftdata-architecture/query-patterns.md
+++ b/.claude/skills/macos-development/swiftdata-architecture/query-patterns.md
@@ -1,0 +1,326 @@
+# SwiftData Query Patterns
+
+Efficient use of @Query, FetchDescriptor, predicates, and sorting for optimal performance.
+
+## @Query in SwiftUI Views
+
+The `@Query` property wrapper fetches data reactively — the view updates automatically when data changes.
+
+### Basic Usage
+
+```swift
+struct TaskListView: View {
+    // Simple fetch with sorting
+    @Query(sort: \.createdAt, order: .reverse)
+    private var tasks: [Task]
+
+    var body: some View {
+        List(tasks) { task in
+            TaskRow(task: task)
+        }
+    }
+}
+```
+
+### With Predicates
+
+```swift
+struct ActiveTasksView: View {
+    // Static predicate
+    @Query(filter: #Predicate<Task> { !$0.isCompleted },
+           sort: \.dueDate)
+    private var activeTasks: [Task]
+
+    var body: some View {
+        List(activeTasks) { task in
+            TaskRow(task: task)
+        }
+    }
+}
+```
+
+### Dynamic Filtering
+
+Use init to create dynamic queries based on parameters:
+
+```swift
+struct FilteredTasksView: View {
+    @Query private var tasks: [Task]
+
+    init(projectID: UUID, showCompleted: Bool) {
+        let predicate: Predicate<Task>
+        if showCompleted {
+            predicate = #Predicate { $0.project?.id == projectID }
+        } else {
+            predicate = #Predicate { $0.project?.id == projectID && !$0.isCompleted }
+        }
+        _tasks = Query(filter: predicate, sort: \.createdAt, order: .reverse)
+    }
+
+    var body: some View {
+        List(tasks) { task in
+            TaskRow(task: task)
+        }
+    }
+}
+```
+
+### Multiple Sort Descriptors
+
+```swift
+@Query(sort: [
+    SortDescriptor(\Task.priority, order: .reverse),  // High priority first
+    SortDescriptor(\Task.dueDate),                     // Then by due date
+    SortDescriptor(\Task.title)                         // Then alphabetical
+])
+private var tasks: [Task]
+```
+
+### Fetch Limit
+
+```swift
+// Only show the 10 most recent
+@Query(sort: \.createdAt, order: .reverse)
+private var recentTasks: [Task]
+
+init() {
+    var descriptor = FetchDescriptor<Task>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
+    descriptor.fetchLimit = 10
+    _recentTasks = Query(descriptor)
+}
+```
+
+## FetchDescriptor (In ViewModels/Services)
+
+Use `FetchDescriptor` for programmatic fetches outside SwiftUI views.
+
+### Basic Fetch
+
+```swift
+func fetchAllProjects(context: ModelContext) throws -> [Project] {
+    let descriptor = FetchDescriptor<Project>(
+        sortBy: [SortDescriptor(\.name)]
+    )
+    return try context.fetch(descriptor)
+}
+```
+
+### With Predicate
+
+```swift
+func fetchOverdueTasks(context: ModelContext) throws -> [Task] {
+    let now = Date.now
+    let descriptor = FetchDescriptor<Task>(
+        predicate: #Predicate { $0.dueDate != nil && $0.dueDate! < now && !$0.isCompleted },
+        sortBy: [SortDescriptor(\.dueDate)]
+    )
+    return try context.fetch(descriptor)
+}
+```
+
+### Pagination
+
+```swift
+func fetchTasks(page: Int, pageSize: Int, context: ModelContext) throws -> [Task] {
+    var descriptor = FetchDescriptor<Task>(
+        sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+    )
+    descriptor.fetchOffset = page * pageSize
+    descriptor.fetchLimit = pageSize
+    return try context.fetch(descriptor)
+}
+```
+
+### Count Without Fetching
+
+```swift
+func countActiveTasks(context: ModelContext) throws -> Int {
+    let descriptor = FetchDescriptor<Task>(
+        predicate: #Predicate { !$0.isCompleted }
+    )
+    return try context.fetchCount(descriptor)
+}
+```
+
+### Fetch Specific Properties Only
+
+Reduce memory by fetching only needed properties:
+
+```swift
+func fetchTaskTitles(context: ModelContext) throws -> [Task] {
+    var descriptor = FetchDescriptor<Task>()
+    descriptor.propertiesToFetch = [\.title, \.isCompleted]
+    return try context.fetch(descriptor)
+}
+```
+
+### Fetch Identifiers Only
+
+For even lighter fetches:
+
+```swift
+func fetchTaskIDs(context: ModelContext) throws -> [PersistentIdentifier] {
+    let descriptor = FetchDescriptor<Task>(
+        predicate: #Predicate { $0.isCompleted }
+    )
+    return try context.fetchIdentifiers(descriptor)
+}
+```
+
+## Predicate Patterns
+
+### String Matching
+
+```swift
+// Contains (case-sensitive)
+#Predicate<Task> { $0.title.contains("urgent") }
+
+// Starts with
+#Predicate<Task> { $0.title.starts(with: "Bug:") }
+
+// Case-insensitive contains
+#Predicate<Task> { $0.title.localizedStandardContains(searchText) }
+```
+
+### Date Ranges
+
+```swift
+// Tasks due this week
+let startOfWeek = Calendar.current.startOfWeek(for: .now)
+let endOfWeek = Calendar.current.date(byAdding: .weekOfYear, value: 1, to: startOfWeek)!
+
+#Predicate<Task> {
+    $0.dueDate != nil &&
+    $0.dueDate! >= startOfWeek &&
+    $0.dueDate! < endOfWeek
+}
+```
+
+### Optional Handling
+
+```swift
+// Tasks with no due date
+#Predicate<Task> { $0.dueDate == nil }
+
+// Tasks with a due date
+#Predicate<Task> { $0.dueDate != nil }
+
+// Safe optional comparison
+#Predicate<Task> {
+    if let dueDate = $0.dueDate {
+        dueDate < Date.now
+    } else {
+        false
+    }
+}
+```
+
+### Relationship Queries
+
+```swift
+// Tasks belonging to a specific project
+let projectID = someProject.id
+#Predicate<Task> { $0.project?.id == projectID }
+
+// Projects that have overdue tasks
+let now = Date.now
+#Predicate<Project> {
+    $0.tasks.contains(where: { !$0.isCompleted && $0.dueDate != nil && $0.dueDate! < now })
+}
+```
+
+### Enum Comparisons
+
+```swift
+// Tasks with high priority
+let highPriority = Priority.high
+#Predicate<Task> { $0.priority == highPriority }
+
+// Note: you cannot use enum cases directly in predicates
+// Wrong: #Predicate<Task> { $0.priority == .high }
+// Right: capture the value in a local variable first
+```
+
+### Compound Predicates
+
+```swift
+// Combine multiple conditions
+func buildPredicate(
+    searchText: String,
+    showCompleted: Bool,
+    priority: Priority?
+) -> Predicate<Task> {
+    #Predicate<Task> { task in
+        (searchText.isEmpty || task.title.localizedStandardContains(searchText)) &&
+        (showCompleted || !task.isCompleted) &&
+        (priority == nil || task.priority == priority)
+    }
+}
+```
+
+## @Query vs FetchDescriptor
+
+| Feature | @Query | FetchDescriptor |
+|---------|--------|-----------------|
+| Where to use | SwiftUI views | ViewModels, services |
+| Auto-updates | Yes | No (manual re-fetch) |
+| Dynamic filtering | Via init() | Direct property setting |
+| Pagination | Via init() | fetchOffset + fetchLimit |
+| Count queries | No | fetchCount() |
+| ID-only queries | No | fetchIdentifiers() |
+| Background context | No | Yes |
+
+## Common Mistakes
+
+### Predicate Capture Issues
+
+```swift
+// Wrong - computed property in predicate
+#Predicate<Task> { $0.dueDate! < Date.now }  // Date.now evaluated once, not live
+
+// Right - capture the date
+let now = Date.now
+#Predicate<Task> { $0.dueDate != nil && $0.dueDate! < now }
+```
+
+### Fetching in a Loop
+
+```swift
+// Wrong - N+1 query problem
+for project in projects {
+    let tasks = try context.fetch(FetchDescriptor<Task>(
+        predicate: #Predicate { $0.project?.id == project.id }
+    ))
+    // Process tasks
+}
+
+// Right - single fetch with all needed data
+let allTasks = try context.fetch(FetchDescriptor<Task>())
+let tasksByProject = Dictionary(grouping: allTasks) { $0.project?.id }
+```
+
+### Ignoring Fetch Limits
+
+```swift
+// Wrong - fetches all 100k records for a "recent" display
+@Query(sort: \.createdAt, order: .reverse)
+private var recentDocuments: [Document]
+// Then only showing first 10 in the UI
+
+// Right - limit the fetch
+init() {
+    var descriptor = FetchDescriptor<Document>(sortBy: [SortDescriptor(\.createdAt, order: .reverse)])
+    descriptor.fetchLimit = 10
+    _recentDocuments = Query(descriptor)
+}
+```
+
+## Best Practices
+
+1. **Use @Query for view data** - Auto-updates when data changes
+2. **Use FetchDescriptor for service logic** - More control, background context support
+3. **Always set fetchLimit for bounded displays** - Don't fetch 10k records for a top-10 list
+4. **Capture predicate values in local variables** - Especially dates and enum cases
+5. **Use fetchCount for existence checks** - Cheaper than fetching full objects
+6. **Avoid N+1 queries** - Fetch related data in bulk, not per-item
+7. **Use propertiesToFetch for partial loads** - Reduce memory for list views

--- a/.claude/skills/macos-development/swiftdata-architecture/repository-pattern.md
+++ b/.claude/skills/macos-development/swiftdata-architecture/repository-pattern.md
@@ -1,0 +1,378 @@
+# Repository Pattern with SwiftData
+
+Protocol-based data abstraction for testable, flexible data access. The repository sits between ViewModels and SwiftData, hiding persistence details.
+
+## Why Use a Repository
+
+| Without Repository | With Repository |
+|-------------------|-----------------|
+| ViewModel talks directly to ModelContext | ViewModel talks to a protocol |
+| Can't unit test without SwiftData | Can test with mock/in-memory implementations |
+| Locked to SwiftData | Can swap to Core Data, network, or file-based storage |
+| ModelContext leaks into view layer | Clean separation of concerns |
+
+## Basic Repository Protocol
+
+```swift
+protocol TaskRepository: Sendable {
+    func fetchAll() async throws -> [TaskDTO]
+    func fetch(id: UUID) async throws -> TaskDTO?
+    func create(_ task: TaskDTO) async throws
+    func update(_ task: TaskDTO) async throws
+    func delete(id: UUID) async throws
+    func count(matching predicate: Predicate<TaskDTO>?) async throws -> Int
+}
+```
+
+### Data Transfer Objects (DTOs)
+
+Use plain structs to decouple ViewModels from @Model classes:
+
+```swift
+struct TaskDTO: Identifiable, Sendable, Equatable {
+    let id: UUID
+    var title: String
+    var isCompleted: Bool
+    var priority: Priority
+    var dueDate: Date?
+    var projectID: UUID?
+    var createdAt: Date
+}
+```
+
+### Mapping Between @Model and DTO
+
+```swift
+extension TaskModel {
+    var toDTO: TaskDTO {
+        TaskDTO(
+            id: id,
+            title: title,
+            isCompleted: isCompleted,
+            priority: priority,
+            dueDate: dueDate,
+            projectID: project?.id,
+            createdAt: createdAt
+        )
+    }
+
+    func update(from dto: TaskDTO) {
+        title = dto.title
+        isCompleted = dto.isCompleted
+        priority = dto.priority
+        dueDate = dto.dueDate
+    }
+}
+```
+
+## SwiftData Repository Implementation
+
+```swift
+@ModelActor
+actor SwiftDataTaskRepository: TaskRepository {
+    func fetchAll() async throws -> [TaskDTO] {
+        let descriptor = FetchDescriptor<TaskModel>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor).map(\.toDTO)
+    }
+
+    func fetch(id: UUID) async throws -> TaskDTO? {
+        let descriptor = FetchDescriptor<TaskModel>(
+            predicate: #Predicate { $0.id == id }
+        )
+        return try modelContext.fetch(descriptor).first?.toDTO
+    }
+
+    func create(_ task: TaskDTO) async throws {
+        let model = TaskModel(
+            id: task.id,
+            title: task.title,
+            priority: task.priority,
+            dueDate: task.dueDate
+        )
+        modelContext.insert(model)
+        try modelContext.save()
+    }
+
+    func update(_ task: TaskDTO) async throws {
+        let id = task.id
+        let descriptor = FetchDescriptor<TaskModel>(
+            predicate: #Predicate { $0.id == id }
+        )
+        guard let model = try modelContext.fetch(descriptor).first else {
+            throw RepositoryError.notFound
+        }
+        model.update(from: task)
+        try modelContext.save()
+    }
+
+    func delete(id: UUID) async throws {
+        let descriptor = FetchDescriptor<TaskModel>(
+            predicate: #Predicate { $0.id == id }
+        )
+        guard let model = try modelContext.fetch(descriptor).first else {
+            throw RepositoryError.notFound
+        }
+        modelContext.delete(model)
+        try modelContext.save()
+    }
+
+    func count(matching predicate: Predicate<TaskDTO>?) async throws -> Int {
+        let descriptor = FetchDescriptor<TaskModel>()
+        return try modelContext.fetchCount(descriptor)
+    }
+}
+```
+
+### @ModelActor
+
+The `@ModelActor` macro (macOS 14+) creates an actor with its own `ModelContext`, enabling safe background data operations:
+
+```swift
+@ModelActor
+actor DataWorker {
+    // modelContext is automatically provided
+    // modelExecutor is automatically provided
+
+    func importData(_ items: [ImportItem]) async throws {
+        for item in items {
+            let model = TaskModel(from: item)
+            modelContext.insert(model)
+        }
+        try modelContext.save()
+    }
+}
+
+// Create with a ModelContainer
+let worker = DataWorker(modelContainer: container)
+try await worker.importData(items)
+```
+
+## In-Memory Repository for Testing
+
+```swift
+actor InMemoryTaskRepository: TaskRepository {
+    private var tasks: [UUID: TaskDTO] = [:]
+
+    func fetchAll() async throws -> [TaskDTO] {
+        Array(tasks.values).sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func fetch(id: UUID) async throws -> TaskDTO? {
+        tasks[id]
+    }
+
+    func create(_ task: TaskDTO) async throws {
+        tasks[task.id] = task
+    }
+
+    func update(_ task: TaskDTO) async throws {
+        guard tasks[task.id] != nil else { throw RepositoryError.notFound }
+        tasks[task.id] = task
+    }
+
+    func delete(id: UUID) async throws {
+        guard tasks[id] != nil else { throw RepositoryError.notFound }
+        tasks[id] = nil
+    }
+
+    func count(matching predicate: Predicate<TaskDTO>?) async throws -> Int {
+        tasks.count
+    }
+
+    // Test helpers
+    func seed(_ seedTasks: [TaskDTO]) {
+        for task in seedTasks {
+            tasks[task.id] = task
+        }
+    }
+
+    func reset() {
+        tasks.removeAll()
+    }
+}
+```
+
+## ViewModel Using Repository
+
+```swift
+@Observable
+@MainActor
+class TaskListViewModel {
+    private let repository: TaskRepository
+
+    var tasks: [TaskDTO] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    init(repository: TaskRepository) {
+        self.repository = repository
+    }
+
+    func loadTasks() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            tasks = try await repository.fetchAll()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleCompletion(_ task: TaskDTO) async {
+        var updated = task
+        updated.isCompleted.toggle()
+
+        do {
+            try await repository.update(updated)
+            if let index = tasks.firstIndex(where: { $0.id == task.id }) {
+                tasks[index] = updated
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func deleteTask(_ task: TaskDTO) async {
+        do {
+            try await repository.delete(id: task.id)
+            tasks.removeAll { $0.id == task.id }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+## Dependency Injection
+
+### Via SwiftUI Environment
+
+```swift
+// Environment key
+struct TaskRepositoryKey: EnvironmentKey {
+    static let defaultValue: TaskRepository = InMemoryTaskRepository()
+}
+
+extension EnvironmentValues {
+    var taskRepository: TaskRepository {
+        get { self[TaskRepositoryKey.self] }
+        set { self[TaskRepositoryKey.self] = newValue }
+    }
+}
+
+// In the app
+@main
+struct MyApp: App {
+    let container: ModelContainer
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environment(\.taskRepository, SwiftDataTaskRepository(modelContainer: container))
+        }
+    }
+}
+
+// In previews
+#Preview {
+    let repo = InMemoryTaskRepository()
+    // seed with sample data
+    ContentView()
+        .environment(\.taskRepository, repo)
+}
+```
+
+### Via Initializer
+
+```swift
+struct TaskListView: View {
+    @State private var viewModel: TaskListViewModel
+
+    init(repository: TaskRepository) {
+        _viewModel = State(initialValue: TaskListViewModel(repository: repository))
+    }
+
+    var body: some View {
+        List(viewModel.tasks) { task in
+            TaskRow(task: task)
+        }
+        .task { await viewModel.loadTasks() }
+    }
+}
+```
+
+## Testing
+
+```swift
+import Testing
+
+@Suite struct TaskListViewModelTests {
+    let repository = InMemoryTaskRepository()
+
+    @Test func loadTasks() async {
+        let sampleTasks = [
+            TaskDTO(id: UUID(), title: "Task 1", isCompleted: false, priority: .medium, createdAt: .now),
+            TaskDTO(id: UUID(), title: "Task 2", isCompleted: true, priority: .high, createdAt: .now),
+        ]
+        await repository.seed(sampleTasks)
+
+        let viewModel = await TaskListViewModel(repository: repository)
+        await viewModel.loadTasks()
+
+        await #expect(viewModel.tasks.count == 2)
+        await #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test func toggleCompletion() async {
+        let task = TaskDTO(id: UUID(), title: "Test", isCompleted: false, priority: .medium, createdAt: .now)
+        await repository.seed([task])
+
+        let viewModel = await TaskListViewModel(repository: repository)
+        await viewModel.loadTasks()
+        await viewModel.toggleCompletion(task)
+
+        let updated = try? await repository.fetch(id: task.id)
+        #expect(updated?.isCompleted == true)
+    }
+
+    @Test func deleteTask() async {
+        let task = TaskDTO(id: UUID(), title: "Delete me", isCompleted: false, priority: .low, createdAt: .now)
+        await repository.seed([task])
+
+        let viewModel = await TaskListViewModel(repository: repository)
+        await viewModel.loadTasks()
+        await viewModel.deleteTask(task)
+
+        await #expect(viewModel.tasks.isEmpty)
+        let count = try? await repository.count(matching: nil)
+        #expect(count == 0)
+    }
+}
+```
+
+## When to Use (and Not Use) Repository Pattern
+
+### Use When
+- You need unit-testable ViewModels
+- You might swap data sources (SwiftData, network, file)
+- Multiple ViewModels access the same data
+- You want to add caching or transformation layers
+
+### Skip When
+- Simple CRUD app with 1-2 screens
+- @Query in views is sufficient
+- You won't write tests for the data layer
+- Prototyping or MVPs
+
+## Best Practices
+
+1. **Use DTOs** - Don't leak @Model types outside the repository
+2. **Use @ModelActor for background work** - Thread-safe by design
+3. **Keep repository methods focused** - One operation per method
+4. **Return DTOs, not models** - Prevents accidental mutations outside the repository
+5. **Use actor isolation** - Repository should be an actor for thread safety
+6. **Seed test repositories** - Provide helper methods for setting up test data
+7. **Save explicitly** - Don't rely on auto-save; call `modelContext.save()` after mutations

--- a/.claude/skills/macos-development/swiftdata-architecture/schema-design.md
+++ b/.claude/skills/macos-development/swiftdata-architecture/schema-design.md
@@ -1,0 +1,351 @@
+# SwiftData Schema Design
+
+Best practices for @Model design, relationships, and attributes. Focus on normalization, cascade rules, and unique constraints.
+
+## @Model Basics
+
+```swift
+import SwiftData
+
+@Model
+class Project {
+    var name: String
+    var createdAt: Date
+    var isArchived: Bool
+
+    // Optional properties
+    var notes: String?
+    var dueDate: Date?
+
+    // Relationships
+    var tasks: [Task]
+
+    init(name: String, createdAt: Date = .now) {
+        self.name = name
+        self.createdAt = createdAt
+        self.isArchived = false
+        self.tasks = []
+    }
+}
+```
+
+## Attributes
+
+### @Attribute Options
+
+```swift
+@Model
+class Document {
+    // Unique constraint (macOS 15+ / iOS 18+)
+    #Unique<Document>([\.slug])
+
+    var title: String
+    var slug: String
+
+    // Stored as external binary data (large blobs)
+    @Attribute(.externalStorage) var imageData: Data?
+
+    // Spotlight indexable
+    @Attribute(.spotlight) var searchableTitle: String
+
+    // Encrypted at rest (preserves value through transforms)
+    @Attribute(.allowsCloudEncryption) var sensitiveNotes: String?
+
+    // Transient - not persisted
+    @Transient var isSelected = false
+
+    // Transformable custom types (must conform to Codable)
+    var metadata: [String: String] = [:]
+    var tags: [String] = []
+
+    init(title: String) {
+        self.title = title
+        self.slug = title.slugified()
+        self.searchableTitle = title
+    }
+}
+```
+
+### Supported Property Types
+
+| Type | Supported | Notes |
+|------|-----------|-------|
+| String, Int, Double, Bool | Yes | Native support |
+| Date, UUID, URL, Data | Yes | Native support |
+| Optional versions | Yes | Maps to nullable columns |
+| Arrays of value types | Yes | Stored as transformable |
+| Dictionaries | Yes | Must be Codable |
+| Enums | Yes | Must be Codable |
+| Other @Model classes | Yes | Relationships |
+| Custom Codable structs | Yes | Stored as transformable |
+
+### Enums in Models
+
+```swift
+enum Priority: Int, Codable, CaseIterable {
+    case low = 0
+    case medium = 1
+    case high = 2
+    case urgent = 3
+}
+
+enum Status: String, Codable {
+    case draft, active, completed, archived
+}
+
+@Model
+class Task {
+    var title: String
+    var priority: Priority
+    var status: Status
+
+    init(title: String, priority: Priority = .medium) {
+        self.title = title
+        self.priority = priority
+        self.status = .draft
+    }
+}
+```
+
+## Relationships
+
+### One-to-Many
+
+```swift
+@Model
+class Author {
+    var name: String
+    // Inverse relationship inferred automatically
+    var books: [Book]
+
+    init(name: String) {
+        self.name = name
+        self.books = []
+    }
+}
+
+@Model
+class Book {
+    var title: String
+    // SwiftData infers inverse from Author.books
+    var author: Author?
+
+    init(title: String, author: Author? = nil) {
+        self.title = title
+        self.author = author
+    }
+}
+```
+
+### Many-to-Many
+
+```swift
+@Model
+class Student {
+    var name: String
+    var courses: [Course]
+
+    init(name: String) {
+        self.name = name
+        self.courses = []
+    }
+}
+
+@Model
+class Course {
+    var title: String
+    var students: [Student]
+
+    init(title: String) {
+        self.title = title
+        self.students = []
+    }
+}
+
+// Usage
+let student = Student(name: "Alice")
+let course = Course(title: "Swift 101")
+student.courses.append(course)
+// SwiftData manages the join table automatically
+```
+
+### Cascade Delete Rules
+
+```swift
+@Model
+class Project {
+    var name: String
+
+    // Delete project → delete all tasks (cascade)
+    @Relationship(deleteRule: .cascade)
+    var tasks: [Task]
+
+    // Delete project → set task.project to nil (nullify)
+    @Relationship(deleteRule: .nullify)
+    var optionalTasks: [Task]
+
+    // Delete project → block if tasks exist (deny)
+    @Relationship(deleteRule: .deny)
+    var requiredTasks: [Task]
+
+    init(name: String) {
+        self.name = name
+        self.tasks = []
+        self.optionalTasks = []
+        self.requiredTasks = []
+    }
+}
+```
+
+### Choosing Delete Rules
+
+| Rule | Behavior | Use When |
+|------|----------|----------|
+| `.cascade` | Delete children when parent deleted | Children have no meaning without parent |
+| `.nullify` (default) | Set reference to nil | Children can exist independently |
+| `.deny` | Prevent parent deletion if children exist | Children must be handled first |
+| `.noAction` | Do nothing (leaves orphans) | Rarely appropriate |
+
+## Unique Constraints (macOS 15+ / iOS 18+)
+
+Prevent duplicate records:
+
+```swift
+@Model
+class Contact {
+    #Unique<Contact>([\.email])
+
+    var email: String
+    var name: String
+    var phone: String?
+
+    init(email: String, name: String) {
+        self.email = email
+        self.name = name
+    }
+}
+
+// Multi-property uniqueness
+@Model
+class Enrollment {
+    #Unique<Enrollment>([\.studentID, \.courseID])
+
+    var studentID: UUID
+    var courseID: UUID
+    var enrolledAt: Date
+
+    init(studentID: UUID, courseID: UUID) {
+        self.studentID = studentID
+        self.courseID = courseID
+        self.enrolledAt = .now
+    }
+}
+```
+
+### Upsert Behavior
+
+When inserting a model that violates a unique constraint, SwiftData performs an upsert (update existing record):
+
+```swift
+// First insert creates the record
+let contact = Contact(email: "alice@example.com", name: "Alice")
+modelContext.insert(contact)
+
+// Second insert with same email updates the existing record
+let updated = Contact(email: "alice@example.com", name: "Alice Smith")
+modelContext.insert(updated)  // Updates the existing record, doesn't create duplicate
+try modelContext.save()
+```
+
+## Schema Versioning and Migration
+
+### Lightweight Migration (Automatic)
+
+SwiftData handles these automatically:
+- Adding new properties with default values
+- Making a required property optional
+- Renaming properties (with `@Attribute(originalName:)`)
+
+```swift
+@Model
+class Task {
+    @Attribute(originalName: "name") var title: String  // Renamed from "name"
+    var priority: Priority
+    var createdAt: Date  // New property with default
+    var notes: String?   // New optional property
+
+    init(title: String, priority: Priority = .medium) {
+        self.title = title
+        self.priority = priority
+        self.createdAt = .now
+    }
+}
+```
+
+### Custom Migration
+
+For complex changes, use VersionedSchema and SchemaMigrationPlan:
+
+```swift
+enum SchemaV1: VersionedSchema {
+    static var versionIdentifier = Schema.Version(1, 0, 0)
+    static var models: [any PersistentModel.Type] { [TaskV1.self] }
+
+    @Model class TaskV1 {
+        var name: String
+        init(name: String) { self.name = name }
+    }
+}
+
+enum SchemaV2: VersionedSchema {
+    static var versionIdentifier = Schema.Version(2, 0, 0)
+    static var models: [any PersistentModel.Type] { [TaskV2.self] }
+
+    @Model class TaskV2 {
+        var title: String
+        var priority: Int
+        init(title: String, priority: Int = 0) {
+            self.title = title
+            self.priority = priority
+        }
+    }
+}
+
+enum TaskMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] { [SchemaV1.self, SchemaV2.self] }
+
+    static var stages: [MigrationStage] {
+        [migrateV1toV2]
+    }
+
+    static let migrateV1toV2 = MigrationStage.custom(
+        fromVersion: SchemaV1.self,
+        toVersion: SchemaV2.self
+    ) { context in
+        let tasks = try context.fetch(FetchDescriptor<SchemaV1.TaskV1>())
+        for task in tasks {
+            // Transform data during migration
+        }
+        try context.save()
+    }
+}
+```
+
+## Design Guidelines
+
+### Do
+
+- Use value types (enums, Codable structs) for embedded data
+- Set sensible defaults in initializers
+- Use optional for truly optional data
+- Add unique constraints for natural keys (email, slug, etc.)
+- Use cascade delete for owned children
+- Keep models focused — avoid god objects
+
+### Don't
+
+- Don't store computed values that can be derived from other properties
+- Don't use @Model for value-type data (use Codable structs instead)
+- Don't create circular cascade deletes
+- Don't store large binary data inline — use `@Attribute(.externalStorage)`
+- Don't add business logic to @Model classes — keep them pure data

--- a/.claude/skills/macos-development/swiftdata-architecture/skill.md
+++ b/.claude/skills/macos-development/swiftdata-architecture/skill.md
@@ -1,0 +1,142 @@
+---
+name: swiftdata-architecture
+description: Deep dive into SwiftData design patterns and best practices. Covers schema design, query patterns, repository pattern, and performance optimization. Use when designing data models or improving SwiftData usage.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# SwiftData Architecture Expert
+
+You are a macOS development expert specializing in SwiftData persistence. You help developers design efficient data models, write performant queries, and build testable data layers.
+
+## Your Role
+
+Guide developers through SwiftData architecture decisions, from schema design to query optimization to data layer abstraction. Focus on patterns that work well with SwiftUI and modern Swift concurrency.
+
+## Core Focus Areas
+
+1. **Schema Design** - @Model classes, relationships, attributes, unique constraints
+2. **Query Patterns** - @Query, FetchDescriptor, predicates, sorting, pagination
+3. **Repository Pattern** - Protocol-based data abstraction, dependency injection, testing
+4. **Performance** - Batch operations, background contexts, lazy loading, memory management
+
+## When This Skill Activates
+
+- Designing data models for a new app
+- Migrating from Core Data to SwiftData
+- Optimizing slow queries or high memory usage
+- Building a testable data layer
+- Reviewing SwiftData usage patterns
+
+## Quick Decision Guide
+
+| Question | Answer |
+|----------|--------|
+| Should I use SwiftData or Core Data? | SwiftData for macOS 14+ / iOS 17+ targets |
+| @Query or FetchDescriptor? | @Query in views, FetchDescriptor in services |
+| Should I use a repository pattern? | Yes, if you need testability or data source flexibility |
+| How to handle large datasets? | Pagination + background context + batch operations |
+| Relationships: optional or required? | Default to optional unless the model is invalid without it |
+
+## Common Pitfalls
+
+### 1. Missing Unique Constraints
+```swift
+// Wrong - duplicate entries on re-import
+@Model class Contact {
+    var email: String
+    var name: String
+}
+
+// Right - prevent duplicates
+@Model class Contact {
+    #Unique<Contact>([\.email])
+    var email: String
+    var name: String
+}
+```
+
+### 2. Fetching Too Much Data
+```swift
+// Wrong - loads all properties of all records
+let descriptor = FetchDescriptor<Document>()
+let allDocs = try modelContext.fetch(descriptor)
+
+// Right - fetch only what you need
+var descriptor = FetchDescriptor<Document>()
+descriptor.propertiesToFetch = [\.title, \.createdAt]
+descriptor.fetchLimit = 50
+let docs = try modelContext.fetch(descriptor)
+```
+
+### 3. Modifying Models on Wrong Context
+```swift
+// Wrong - model from main context modified on background
+let doc = documents.first!
+Task.detached {
+    doc.title = "Updated"  // Thread safety violation!
+}
+
+// Right - use background ModelContext
+let container = modelContext.container
+Task.detached {
+    let bgContext = ModelContext(container)
+    let descriptor = FetchDescriptor<Document>(predicate: #Predicate { $0.id == docID })
+    if let doc = try bgContext.fetch(descriptor).first {
+        doc.title = "Updated"
+        try bgContext.save()
+    }
+}
+```
+
+## How to Conduct Reviews
+
+### Step 1: Understand the Data Model
+- What entities exist and how do they relate?
+- What's the expected data volume?
+- What are the primary query patterns?
+
+### Step 2: Review Against Module Guidelines
+- Schema design (see schema-design.md)
+- Query patterns (see query-patterns.md)
+- Repository pattern (see repository-pattern.md)
+- Performance (see performance.md)
+
+### Step 3: Provide Structured Feedback
+
+For each issue found:
+1. **Issue**: Describe the data layer problem
+2. **Impact**: Data corruption, performance, memory, testability
+3. **Fix**: Correct implementation with code
+4. **Migration**: Note if schema changes require migration
+
+## Module References
+
+Load these modules as needed:
+
+1. **Schema Design**: `schema-design.md`
+   - @Model design and attributes
+   - Relationships and cascade rules
+   - Unique constraints and indexes
+
+2. **Query Patterns**: `query-patterns.md`
+   - @Query in SwiftUI views
+   - FetchDescriptor for services
+   - Predicates, sorting, pagination
+
+3. **Repository Pattern**: `repository-pattern.md`
+   - Protocol-based abstraction
+   - Dependency injection
+   - Testing with mock repositories
+
+4. **Performance**: `performance.md`
+   - Batch operations
+   - Background contexts
+   - Memory optimization
+
+## Response Guidelines
+
+- Always specify minimum deployment target (macOS 14+ for SwiftData)
+- Warn about schema migration implications for model changes
+- Prefer @Query for simple view data, FetchDescriptor for complex logic
+- Recommend repository pattern for testable code
+- Note thread safety requirements for ModelContext

--- a/.claude/skills/macos-development/ui-review-tahoe/accessibility.md
+++ b/.claude/skills/macos-development/ui-review-tahoe/accessibility.md
@@ -1,0 +1,483 @@
+# Accessibility Best Practices
+
+VoiceOver, keyboard navigation, Dynamic Type, and accessibility standards for macOS.
+
+## VoiceOver Support
+
+### SwiftUI Accessibility
+
+```swift
+// ✅ GOOD: Accessibility labels
+Button(action: save) {
+    Image(systemName: "square.and.arrow.down")
+}
+.accessibilityLabel("Save document")
+.accessibilityHint("Saves the current document to disk")
+
+// ✅ GOOD: Combining elements
+HStack {
+    Image(systemName: "person.fill")
+    Text("John Doe")
+    Text("john@example.com")
+}
+.accessibilityElement(children: .combine)
+.accessibilityLabel("John Doe, john@example.com")
+
+// ✅ GOOD: Custom accessibility for complex views
+struct ArticleCard: View {
+    let article: Article
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(article.title)
+                .font(.headline)
+            Text(article.subtitle)
+                .font(.subheadline)
+            Text(article.date, style: .date)
+                .font(.caption)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(article.title), \(article.subtitle)")
+        .accessibilityHint("Published \(article.date, style: .date)")
+        .accessibilityAddTraits(.isButton)
+    }
+}
+```
+
+### AppKit Accessibility
+
+```swift
+// ✅ GOOD: Accessibility in AppKit
+final class CustomButton: NSButton {
+    override func accessibilityLabel() -> String? {
+        "Save document"
+    }
+
+    override func accessibilityHelp() -> String? {
+        "Saves the current document to disk"
+    }
+
+    override func accessibilityRole() -> NSAccessibility.Role? {
+        .button
+    }
+
+    override func isAccessibilityElement() -> Bool {
+        true
+    }
+}
+
+// ✅ GOOD: Setting accessibility programmatically
+imageView.setAccessibilityLabel("Profile picture")
+imageView.setAccessibilityRole(.image)
+
+textField.setAccessibilityLabel("Username")
+textField.setAccessibilityPlaceholderValue("Enter your username")
+```
+
+### Accessibility Traits
+
+```swift
+// ✅ GOOD: Adding traits
+.accessibilityAddTraits(.isButton)
+.accessibilityAddTraits(.isSelected)
+.accessibilityAddTraits(.isHeader)
+.accessibilityAddTraits(.startsMediaSession)
+
+// ✅ GOOD: Removing default traits
+.accessibilityRemoveTraits(.isImage)
+
+// ✅ GOOD: Custom actions
+.accessibilityAction(named: "Mark as Read") {
+    markAsRead()
+}
+.accessibilityAction(named: "Delete") {
+    delete()
+}
+```
+
+### Hidden Elements
+
+```swift
+// ✅ GOOD: Hide decorative elements from VoiceOver
+Image(decorative: "background-pattern")
+    .accessibilityHidden(true)
+
+// ✅ GOOD: Skip navigation elements
+Divider()
+    .accessibilityHidden(true)
+
+Spacer()
+    .accessibilityHidden(true)
+```
+
+## Keyboard Navigation
+
+### Focus Management
+
+```swift
+// ✅ GOOD: Focus state
+struct LoginView: View {
+    @FocusState private var focusedField: Field?
+
+    enum Field {
+        case username, password
+    }
+
+    var body: some View {
+        Form {
+            TextField("Username", text: $username)
+                .focused($focusedField, equals: .username)
+
+            SecureField("Password", text: $password)
+                .focused($focusedField, equals: .password)
+
+            Button("Login") {
+                login()
+            }
+            .disabled(!isFormValid)
+        }
+        .onAppear {
+            focusedField = .username
+        }
+        .onSubmit {
+            switch focusedField {
+            case .username:
+                focusedField = .password
+            case .password:
+                if isFormValid {
+                    login()
+                }
+            default:
+                break
+            }
+        }
+    }
+}
+```
+
+### Keyboard Shortcuts
+
+```swift
+// ✅ GOOD: Keyboard shortcuts with VoiceOver announcements
+Button("New Document") {
+    createDocument()
+}
+.keyboardShortcut("n", modifiers: .command)
+.accessibilityLabel("New Document")
+.accessibilityHint("Keyboard shortcut: Command N")
+
+// ✅ GOOD: Custom key equivalent in AppKit
+button.keyEquivalent = "n"
+button.keyEquivalentModifierMask = .command
+button.setAccessibilityHelp("Keyboard shortcut: Command N")
+```
+
+### Tab Navigation
+
+```swift
+// ✅ GOOD: Ensure proper tab order
+.focusable(true)  // Make view focusable
+.defaultFocus($focusedField, .username)  // Set initial focus
+
+// AppKit: Use nextKeyView
+usernameField.nextKeyView = passwordField
+passwordField.nextKeyView = loginButton
+loginButton.nextKeyView = usernameField
+```
+
+## Dynamic Type
+
+### SwiftUI Text Scaling
+
+```swift
+// ✅ GOOD: Dynamic Type support
+Text("Heading")
+    .font(.title)  // Automatically scales
+
+Text("Body")
+    .font(.body)
+
+// ✅ GOOD: Custom font with Dynamic Type
+Text("Custom")
+    .font(.custom("MyFont", size: 17, relativeTo: .body))
+
+// ❌ BAD: Fixed font size
+Text("Fixed")
+    .font(.system(size: 14))  // Won't scale!
+
+// ✅ GOOD: Fixed size when necessary, but allow scaling
+Text("Fixed")
+    .font(.system(size: 14))
+    .dynamicTypeSize(...DynamicTypeSize.xxxLarge)  // Limit maximum size
+```
+
+### Custom Scaling
+
+```swift
+// ✅ GOOD: Scale custom elements
+@ScaledMetric private var iconSize: CGFloat = 24
+
+Image(systemName: "star")
+    .font(.system(size: iconSize))
+
+// ✅ GOOD: Responsive layouts
+@Environment(\.dynamicTypeSize) var dynamicTypeSize
+
+var body: some View {
+    Group {
+        if dynamicTypeSize >= .xxxLarge {
+            VStack {  // Stack vertically for large text
+                icon
+                label
+            }
+        } else {
+            HStack {  // Stack horizontally for normal text
+                icon
+                label
+            }
+        }
+    }
+}
+```
+
+## Color Contrast
+
+### WCAG Compliance
+
+```swift
+// ✅ GOOD: Use semantic colors with sufficient contrast
+.foregroundStyle(.primary)     // Always has good contrast
+.foregroundStyle(.secondary)   // Good contrast for secondary text
+
+// ✅ GOOD: Check custom color contrast
+// Minimum contrast ratio: 4.5:1 for normal text, 3:1 for large text
+
+// ❌ BAD: Low contrast
+Text("Important")
+    .foregroundColor(.gray)  // May not have sufficient contrast
+
+// ✅ GOOD: High contrast with background
+Text("Important")
+    .foregroundColor(.white)
+    .padding()
+    .background(.blue)  // Sufficient contrast
+```
+
+### Increase Contrast Mode
+
+```swift
+// ✅ GOOD: Support increased contrast
+@Environment(\.colorSchemeContrast) var contrast
+
+var body: some View {
+    Text("Content")
+        .foregroundStyle(
+            contrast == .increased ? .primary : .secondary
+        )
+}
+
+// ✅ GOOD: Adjust border thickness
+.border(
+    .primary,
+    width: contrast == .increased ? 2 : 1
+)
+```
+
+## Reduce Motion
+
+### Respecting Motion Preferences
+
+```swift
+// ✅ GOOD: Respect reduce motion
+@Environment(\.accessibilityReduceMotion) var reduceMotion
+
+func animate() {
+    if reduceMotion {
+        // Instant transition
+        isExpanded = true
+    } else {
+        // Animated transition
+        withAnimation(.spring()) {
+            isExpanded = true
+        }
+    }
+}
+
+// ✅ GOOD: Conditional animation
+.animation(reduceMotion ? .none : .spring(), value: isExpanded)
+```
+
+### Alternative Feedback
+
+```swift
+// ✅ GOOD: Provide alternative feedback for motion
+if reduceMotion {
+    // Use color change or haptic instead of animation
+    backgroundColor = .accentColor
+} else {
+    withAnimation {
+        scale = 1.1
+    }
+}
+```
+
+## VoiceOver Testing
+
+### Testing Checklist
+
+```swift
+// Test VoiceOver with:
+// 1. Enable VoiceOver: Cmd+F5
+// 2. Navigate with VO+arrow keys
+// 3. Interact with VO+Space
+// 4. Use rotor: VO+U
+
+// ✅ Verify:
+// - All interactive elements are accessible
+// - Labels are descriptive and clear
+// - Images have appropriate descriptions or are hidden
+// - Custom controls have proper roles
+// - Table views announce correctly
+// - Forms can be filled out completely
+// - Buttons announce their action
+```
+
+### VoiceOver Debugging
+
+```swift
+// ✅ GOOD: Debug accessibility in Xcode
+// 1. Run app in Simulator
+// 2. Settings > Accessibility > VoiceOver
+// 3. Use Accessibility Inspector
+
+// Print accessibility tree (debugging)
+#if DEBUG
+view.accessibilityElements?.forEach { element in
+    print("Label: \((element as? NSObject)?.accessibilityLabel() ?? "none")")
+}
+#endif
+```
+
+## Accessibility in Tables and Lists
+
+### SwiftUI Lists
+
+```swift
+// ✅ GOOD: Accessible list items
+List(articles) { article in
+    ArticleRow(article: article)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(article.title)
+        .accessibilityValue("By \(article.author), \(article.date, style: .date)")
+        .accessibilityHint("Double-tap to open")
+        .accessibilityAddTraits(.isButton)
+}
+.accessibilityLabel("Articles")
+.accessibilityHint("\(articles.count) articles")
+```
+
+### AppKit Tables
+
+```swift
+// ✅ GOOD: Accessible table cells
+extension ArticleViewController: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let article = articles[row]
+        let cell = tableView.makeView(withIdentifier: cellIdentifier, owner: self) as! ArticleCellView
+
+        cell.configure(with: article)
+
+        // Accessibility
+        cell.setAccessibilityLabel(article.title)
+        cell.setAccessibilityValue("By \(article.author)")
+        cell.setAccessibilityRole(.cell)
+
+        return cell
+    }
+}
+```
+
+## Custom Controls
+
+### Accessible Custom Button
+
+```swift
+// ✅ GOOD: Custom button with full accessibility
+struct CustomIconButton: View {
+    let icon: String
+    let label: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.title2)
+        }
+        .buttonStyle(.borderless)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityHint("Double-tap to activate")
+    }
+}
+```
+
+### Accessible Custom Slider
+
+```swift
+// ✅ GOOD: Custom slider with accessibility
+struct CustomSlider: View {
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            // Custom slider UI
+            Rectangle()
+                .gesture(dragGesture)
+        }
+        .accessibilityElement()
+        .accessibilityLabel("Volume")
+        .accessibilityValue("\(Int(value * 100)) percent")
+        .accessibilityAdjustableAction { direction in
+            switch direction {
+            case .increment:
+                value = min(value + step, range.upperBound)
+            case .decrement:
+                value = max(value - step, range.lowerBound)
+            @unknown default:
+                break
+            }
+        }
+    }
+}
+```
+
+## Accessibility Checklist
+
+- [ ] All interactive elements have labels
+- [ ] Images have descriptions or are marked decorative
+- [ ] Buttons announce their action
+- [ ] Forms can be completed with VoiceOver
+- [ ] Keyboard navigation works throughout app
+- [ ] Tab order is logical
+- [ ] Keyboard shortcuts are accessible
+- [ ] Text supports Dynamic Type
+- [ ] Custom fonts scale with system settings
+- [ ] Color contrast meets WCAG AA (4.5:1)
+- [ ] Important info not conveyed by color alone
+- [ ] Increased contrast mode supported
+- [ ] Reduce motion preference respected
+- [ ] Alternative feedback for animations
+- [ ] Custom controls have proper roles
+- [ ] Tables and lists are navigable
+- [ ] Test with VoiceOver enabled
+- [ ] Test with keyboard only
+- [ ] Test with increased text sizes
+
+## Resources
+
+- [Accessibility on macOS](https://developer.apple.com/accessibility/macos/)
+- [VoiceOver Testing Guide](https://developer.apple.com/documentation/accessibility/voiceover)
+- [WCAG 2.1 Guidelines](https://www.w3.org/WAI/WCAG21/quickref/)
+- [WWDC: Creating Accessible Apps](https://developer.apple.com/videos/accessibility)

--- a/.claude/skills/macos-development/ui-review-tahoe/appkit-modern.md
+++ b/.claude/skills/macos-development/ui-review-tahoe/appkit-modern.md
@@ -1,0 +1,443 @@
+# Modern AppKit Patterns
+
+AppKit best practices for macOS 26 (Tahoe) with Liquid Glass design integration.
+
+## When to Use AppKit
+
+- Complex table views with custom cells
+- Advanced text editing (NSTextView)
+- Custom drawing with precise control
+- Legacy code migration
+- Features not yet available in SwiftUI
+- Performance-critical UI components
+
+## Modern NSViewController Patterns
+
+```swift
+// ✅ GOOD: Modern view controller
+final class ArticleViewController: NSViewController {
+    // MARK: - Properties
+    private let viewModel: ArticleViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - UI Elements
+    private lazy var tableView: NSTableView = {
+        let table = NSTableView()
+        table.delegate = self
+        table.dataSource = self
+        table.style = .automatic
+        return table
+    }()
+
+    // MARK: - Initialization
+    init(viewModel: ArticleViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func loadView() {
+        view = NSView()
+        setupUI()
+        setupConstraints()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        bindViewModel()
+    }
+
+    // MARK: - Setup
+    private func setupUI() {
+        // Setup UI elements
+    }
+
+    private func setupConstraints() {
+        // Use Auto Layout
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func bindViewModel() {
+        viewModel.$articles
+            .sink { [weak self] _ in
+                self?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+}
+```
+
+## Liquid Glass in AppKit
+
+### Visual Effect Views
+
+```swift
+// ✅ GOOD: Use NSVisualEffectView for Liquid Glass
+final class GlassPanel: NSView {
+    private let visualEffectView: NSVisualEffectView = {
+        let view = NSVisualEffectView()
+        view.material = .sidebar  // or .headerView, .menu, .popover
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }()
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        addSubview(visualEffectView)
+        visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            visualEffectView.topAnchor.constraint(equalTo: topAnchor),
+            visualEffectView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            visualEffectView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            visualEffectView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        // Round corners
+        wantsLayer = true
+        layer?.cornerRadius = 12
+        layer?.masksToBounds = true
+    }
+}
+```
+
+### Transparent Window Background
+
+```swift
+// ✅ GOOD: Window with transparency
+final class TransparentWindow: NSWindow {
+    override init(
+        contentRect: NSRect,
+        styleMask style: NSWindow.StyleMask,
+        backing backingStoreType: NSWindow.BackingStoreType,
+        defer flag: Bool
+    ) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: backingStoreType,
+            defer: flag
+        )
+
+        titlebarAppearsTransparent = true
+        titleVisibility = .hidden
+        isOpaque = false
+        backgroundColor = .clear
+
+        // Modern appearance
+        if let contentView = contentView {
+            let visualEffect = NSVisualEffectView()
+            visualEffect.material = .underWindowBackground
+            visualEffect.blendingMode = .behindWindow
+            visualEffect.state = .active
+            visualEffect.frame = contentView.bounds
+            visualEffect.autoresizingMask = [.width, .height]
+            contentView.addSubview(visualEffect, positioned: .below, relativeTo: nil)
+        }
+    }
+}
+```
+
+## Modern Table Views
+
+```swift
+// ✅ GOOD: Cell-based table view
+extension ArticleViewController: NSTableViewDataSource {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        viewModel.articles.count
+    }
+}
+
+extension ArticleViewController: NSTableViewDelegate {
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let article = viewModel.articles[row]
+
+        guard let cellView = tableView.makeView(
+            withIdentifier: ArticleCellView.identifier,
+            owner: self
+        ) as? ArticleCellView else {
+            let cellView = ArticleCellView()
+            cellView.identifier = ArticleCellView.identifier
+            return cellView
+        }
+
+        cellView.configure(with: article)
+        return cellView
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        60
+    }
+}
+
+// ✅ GOOD: Custom cell view
+final class ArticleCellView: NSTableCellView {
+    static let identifier = NSUserInterfaceItemIdentifier("ArticleCell")
+
+    private let titleLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 14, weight: .medium)
+        label.lineBreakMode = .byTruncatingTail
+        return label
+    }()
+
+    private let subtitleLabel: NSTextField = {
+        let label = NSTextField(labelWithString: "")
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = .secondaryLabelColor
+        return label
+    }()
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    private func setup() {
+        // Add subviews and constraints
+    }
+
+    func configure(with article: Article) {
+        titleLabel.stringValue = article.title
+        subtitleLabel.stringValue = article.subtitle
+    }
+}
+```
+
+## Window Management
+
+```swift
+// ✅ GOOD: Modern window controller
+final class DocumentWindowController: NSWindowController {
+    convenience init() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        window.center()
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+
+        self.init(window: window)
+    }
+
+    override func windowDidLoad() {
+        super.windowDidLoad()
+
+        // Setup toolbar
+        let toolbar = NSToolbar(identifier: "MainToolbar")
+        toolbar.delegate = self
+        toolbar.displayMode = .iconOnly
+        window?.toolbar = toolbar
+    }
+}
+
+extension DocumentWindowController: NSToolbarDelegate {
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        // Return toolbar items
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.flexibleSpace, .add, .share]
+    }
+}
+```
+
+## Split View Controllers
+
+```swift
+// ✅ GOOD: Modern split view
+final class MainSplitViewController: NSSplitViewController {
+    private let sidebarViewController: SidebarViewController
+    private let detailViewController: DetailViewController
+
+    init(
+        sidebarViewController: SidebarViewController,
+        detailViewController: DetailViewController
+    ) {
+        self.sidebarViewController = sidebarViewController
+        self.detailViewController = detailViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Sidebar item
+        let sidebarItem = NSSplitViewItem(sidebarWithViewController: sidebarViewController)
+        sidebarItem.minimumThickness = 200
+        sidebarItem.maximumThickness = 300
+        addSplitViewItem(sidebarItem)
+
+        // Detail item
+        let detailItem = NSSplitViewItem(viewController: detailViewController)
+        addSplitViewItem(detailItem)
+
+        splitView.autosaveName = "MainSplitView"
+    }
+}
+```
+
+## Menu Bar Apps with AppKit
+
+```swift
+// ✅ GOOD: Modern menu bar app
+@main
+class AppDelegate: NSObject, NSApplicationDelegate {
+    private var statusItem: NSStatusItem?
+    private var popover: NSPopover?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Create status item
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+
+        if let button = statusItem?.button {
+            button.image = NSImage(systemSymbolName: "star.fill", accessibilityDescription: "App")
+            button.action = #selector(togglePopover)
+        }
+
+        // Create popover
+        let popover = NSPopover()
+        popover.contentViewController = MenuViewController()
+        popover.behavior = .transient
+        self.popover = popover
+    }
+
+    @objc private func togglePopover() {
+        guard let button = statusItem?.button else { return }
+
+        if let popover = popover {
+            if popover.isShown {
+                popover.performClose(nil)
+            } else {
+                popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+            }
+        }
+    }
+}
+```
+
+## Responder Chain and Events
+
+```swift
+// ✅ GOOD: Handling key events
+override func keyDown(with event: NSEvent) {
+    switch event.keyCode {
+    case 51:  // Delete
+        deleteSelected()
+    case 36:  // Return
+        editSelected()
+    default:
+        super.keyDown(with: event)
+    }
+}
+
+// ✅ GOOD: Validating menu items
+extension ViewController: NSMenuItemValidation {
+    func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        switch menuItem.action {
+        case #selector(delete(_:)):
+            return selectedItems.count > 0
+        case #selector(duplicate(_:)):
+            return selectedItems.count == 1
+        default:
+            return true
+        }
+    }
+}
+```
+
+## Animations in AppKit
+
+```swift
+// ✅ GOOD: NSAnimationContext
+NSAnimationContext.runAnimationGroup { context in
+    context.duration = 0.3
+    context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+    view.animator().alphaValue = 0.5
+    view.animator().frame = newFrame
+}
+
+// ✅ GOOD: Core Animation layers
+view.wantsLayer = true
+view.layer?.add(animation, forKey: "transform")
+```
+
+## AppKit + SwiftUI Integration
+
+```swift
+// ✅ GOOD: Hosting SwiftUI in AppKit
+final class SwiftUIHostingController: NSViewController {
+    init() {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    override func loadView() {
+        let swiftUIView = ContentView()
+        let hostingView = NSHostingView(rootView: swiftUIView)
+        self.view = hostingView
+    }
+}
+
+// ✅ GOOD: Embedding AppKit in SwiftUI (see swiftui-macos.md)
+```
+
+## Modern AppKit Checklist
+
+- [ ] Use NSVisualEffectView for Liquid Glass effects
+- [ ] Implement transparent window backgrounds
+- [ ] Use Auto Layout constraints
+- [ ] Follow MVVM pattern with ViewModels
+- [ ] Use Combine for reactive bindings
+- [ ] Implement proper responder chain
+- [ ] Support dark mode and accent colors
+- [ ] Use NSToolbar for window toolbars
+- [ ] Implement NSSplitViewController for sidebars
+- [ ] Support keyboard shortcuts and menu validation
+- [ ] Use smooth animations
+- [ ] Integrate SwiftUI where beneficial
+
+## Resources
+
+- [AppKit Documentation](https://developer.apple.com/documentation/appkit)
+- [NSVisualEffectView Guide](https://developer.apple.com/documentation/appkit/nsvisualeffectview)
+- [Modern AppKit Patterns](https://developer.apple.com/videos/)

--- a/.claude/skills/macos-development/ui-review-tahoe/liquid-glass-design.md
+++ b/.claude/skills/macos-development/ui-review-tahoe/liquid-glass-design.md
@@ -1,0 +1,377 @@
+# Liquid Glass Design System
+
+Modern design language for macOS 26 (Tahoe), iOS 26, and iPadOS 26.
+
+> **Note:** For the new `.glassEffect()` API introduced in iOS/macOS 26, see the updated skill at `skills/design/liquid-glass/SKILL.md` which covers GlassEffectContainer, morphing transitions, and interactive effects.
+
+## Core Principles
+
+### 1. Transparency and Depth
+
+Liquid Glass uses transparency to create visual hierarchy and depth.
+
+```swift
+// ✅ GOOD: Transparent background with blur
+struct ContentView: View {
+    var body: some View {
+        ZStack {
+            // Background content
+            Image("background")
+                .resizable()
+                .ignoresSafeArea()
+
+            // Foreground panel with Liquid Glass effect
+            VStack {
+                Text("Content")
+                    .font(.largeTitle)
+            }
+            .padding()
+            .background(.ultraThinMaterial)  // Liquid Glass material
+            .cornerRadius(20)
+            .shadow(radius: 10)
+        }
+    }
+}
+
+// ❌ BAD: Opaque solid colors (old style)
+VStack {
+    Text("Content")
+}
+.background(Color.white)  // Not Liquid Glass
+```
+
+### 2. Menu Bar Transparency
+
+macOS Tahoe features a fully transparent menu bar with subtle drop shadow.
+
+```swift
+// ✅ GOOD: App embracing transparent menu bar
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.hiddenTitleBar)  // Clean integration
+        .windowToolbarStyle(.unified)
+    }
+}
+
+struct ContentView: View {
+    var body: some View {
+        NavigationSplitView {
+            // Sidebar
+        } detail: {
+            // Main content that flows under menu bar
+            ScrollView {
+                // Content
+            }
+            .ignoresSafeArea(edges: .top)  // Extend under menu bar
+        }
+    }
+}
+
+// ⚠️ Ensure content doesn't clash with menu bar
+// Add proper padding for interactive elements
+```
+
+### 3. Materials and Vibrancy
+
+Use system materials for platform consistency.
+
+```swift
+// ✅ GOOD: System materials
+.background(.regularMaterial)    // Standard material
+.background(.thickMaterial)      // More opaque
+.background(.thinMaterial)       // More transparent
+.background(.ultraThinMaterial)  // Highly transparent
+
+// ✅ GOOD: Adaptive materials (respect appearance)
+.background(.bar)         // For toolbars and bars
+.background(.sidebar)     // For sidebar backgrounds
+.background(.selection)   // For selected items
+
+// ❌ BAD: Hardcoded colors
+.background(Color(red: 0.9, green: 0.9, blue: 0.9))
+```
+
+### 4. Visual Hierarchy
+
+Create clear hierarchy through depth, size, and contrast.
+
+```swift
+// ✅ GOOD: Clear hierarchy
+struct DashboardView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            // Primary card - most prominent
+            PrimaryCard()
+                .shadow(radius: 12)
+                .zIndex(2)
+
+            // Secondary cards - less prominent
+            HStack {
+                SecondaryCard()
+                    .shadow(radius: 6)
+
+                SecondaryCard()
+                    .shadow(radius: 6)
+            }
+            .zIndex(1)
+
+            // Background elements - least prominent
+            BackgroundInfo()
+                .opacity(0.7)
+        }
+    }
+}
+```
+
+## Redesigned Folder Icons
+
+macOS Tahoe features customizable folder icons.
+
+```swift
+// ✅ Using custom folder colors
+// In Finder: Right-click → Get Info → Icon customization
+
+// SwiftUI file icon display
+struct FileIcon: View {
+    let file: File
+
+    var body: some View {
+        Image(systemName: file.iconName)
+            .symbolRenderingMode(.multicolor)  // Use SF Symbols multicolor
+            .font(.system(size: 64))
+            .foregroundStyle(file.accentColor)  // Respect accent color
+    }
+}
+
+// Folder icons can now:
+// - Have custom colors
+// - Include custom emblems
+// - Display emoji overlays
+// - Respect system accent color
+```
+
+## Redesigned Control Center
+
+Control Center follows Liquid Glass design with modular cards.
+
+```swift
+// ✅ GOOD: Control Center-style cards
+struct ControlCard: View {
+    let title: String
+    let icon: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.title)
+                    .symbolRenderingMode(.hierarchical)
+
+                Text(title)
+                    .font(.caption)
+            }
+            .frame(width: 100, height: 100)
+            .background(.ultraThinMaterial)
+            .cornerRadius(16)
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(.white.opacity(0.2), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// Usage - Grid of control cards
+LazyVGrid(columns: [GridItem(.adaptive(minimum: 100))]) {
+    ControlCard(title: "Wi-Fi", icon: "wifi") { }
+    ControlCard(title: "Bluetooth", icon: "bluetooth") { }
+    ControlCard(title: "AirDrop", icon: "airplayaudio") { }
+}
+```
+
+## Animation Guidelines
+
+Liquid Glass emphasizes smooth, fluid animations.
+
+```swift
+// ✅ GOOD: Smooth spring animations
+.animation(.spring(response: 0.3, dampingFraction: 0.8), value: isExpanded)
+
+// ✅ GOOD: Interpolating spring for natural motion
+.animation(.interactiveSpring(response: 0.3, dampingFraction: 0.7), value: offset)
+
+// ✅ GOOD: Easing for simple transitions
+.animation(.easeInOut(duration: 0.2), value: isVisible)
+
+// ❌ BAD: Abrupt linear animations
+.animation(.linear, value: isExpanded)
+
+// ❌ BAD: Too long or too bouncy
+.animation(.spring(response: 2.0, dampingFraction: 0.3), value: isExpanded)
+```
+
+### Common Animation Patterns
+
+```swift
+// ✅ GOOD: Card expansion
+struct ExpandableCard: View {
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack {
+            Text("Title")
+            if isExpanded {
+                Text("Details")
+                    .transition(.asymmetric(
+                        insertion: .scale.combined(with: .opacity),
+                        removal: .opacity
+                    ))
+            }
+        }
+        .frame(maxWidth: isExpanded ? .infinity : 200)
+        .background(.ultraThinMaterial)
+        .cornerRadius(16)
+        .animation(.spring(response: 0.4, dampingFraction: 0.8), value: isExpanded)
+        .onTapGesture {
+            isExpanded.toggle()
+        }
+    }
+}
+
+// ✅ GOOD: List item appearance
+.transition(.move(edge: .trailing).combined(with: .opacity))
+
+// ✅ GOOD: Modal presentation
+.transition(.asymmetric(
+    insertion: .scale(scale: 0.9).combined(with: .opacity),
+    removal: .opacity
+))
+```
+
+## Color and Theming
+
+### Adaptive Colors
+
+```swift
+// ✅ GOOD: Semantic colors (adapt to light/dark mode)
+.foregroundStyle(.primary)      // Primary text
+.foregroundStyle(.secondary)    // Secondary text
+.foregroundStyle(.tertiary)     // Tertiary text
+
+// ✅ GOOD: Accent color
+.foregroundStyle(.tint)         // System accent color
+.tint(.blue)                    // Custom accent
+
+// ✅ GOOD: Semantic backgrounds
+.background(.background)
+.background(.secondaryBackground)
+
+// ❌ BAD: Hardcoded colors that don't adapt
+.foregroundColor(.black)        // Won't adapt to dark mode
+.background(Color.white)
+```
+
+### Vibrancy Effects
+
+```swift
+// ✅ GOOD: Vibrancy for content over materials
+struct GlassCard: View {
+    var body: some View {
+        VStack {
+            Text("Title")
+                .font(.headline)
+                .foregroundStyle(.primary)
+
+            Text("Subtitle")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .background(.regularMaterial)
+        .backgroundStyle(.blue)  // Tint the material
+        .cornerRadius(16)
+    }
+}
+```
+
+## Depth and Shadows
+
+```swift
+// ✅ GOOD: Subtle shadows for depth
+.shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+
+// ✅ GOOD: Layered shadows for cards
+.shadow(color: .black.opacity(0.05), radius: 2, y: 1)
+.shadow(color: .black.opacity(0.1), radius: 12, y: 6)
+
+// ❌ BAD: Heavy shadows (outdated style)
+.shadow(color: .black.opacity(0.5), radius: 20)
+
+// ❌ BAD: No shadow on floating elements
+// Cards and panels should have subtle shadows for depth
+```
+
+## Glass Morphism Effects
+
+```swift
+// ✅ GOOD: Full glass morphism card
+struct GlassMorphCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "star.fill")
+                    .foregroundStyle(.yellow)
+                Text("Featured")
+                    .font(.headline)
+            }
+
+            Text("Content goes here")
+                .font(.body)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(.white.opacity(0.2), lineWidth: 1)
+        )
+        .cornerRadius(16)
+        .shadow(color: .black.opacity(0.1), radius: 10, y: 5)
+    }
+}
+```
+
+## Liquid Glass Checklist
+
+- [ ] Use system materials (.ultraThinMaterial, .regularMaterial, etc.)
+- [ ] Embrace transparent menu bar design
+- [ ] Apply subtle shadows for depth hierarchy
+- [ ] Use smooth spring animations
+- [ ] Support light and dark modes with semantic colors
+- [ ] Create visual hierarchy through depth and transparency
+- [ ] Use vibrancy for content over materials
+- [ ] Follow Control Center card design patterns (if applicable)
+- [ ] Support customizable folder icons (if file management)
+- [ ] Ensure smooth 60fps animations
+
+## macOS 26 Tahoe Specific
+
+- Menu bar is fully transparent by default
+- Control Center redesigned with modular cards
+- Folder icons support custom colors and emblems
+- Liquid Glass materials are primary design element
+- Smooth animations are expected throughout
+- Depth through transparency, not heavy shadows
+
+## Resources
+
+- [Apple Design Resources](https://developer.apple.com/design/resources/)
+- [macOS Tahoe HIG](https://developer.apple.com/design/human-interface-guidelines/macos)
+- [WWDC 2025: Design for macOS Tahoe](https://developer.apple.com/videos/)

--- a/.claude/skills/macos-development/ui-review-tahoe/macos-tahoe-hig.md
+++ b/.claude/skills/macos-development/ui-review-tahoe/macos-tahoe-hig.md
@@ -1,0 +1,495 @@
+# macOS Tahoe Human Interface Guidelines
+
+Platform-specific design guidelines for macOS 26 (Tahoe).
+
+## Window Management
+
+### Window Chrome
+
+```swift
+// ✅ GOOD: Modern window with unified toolbar
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .windowStyle(.hiddenTitleBar)
+        .windowToolbarStyle(.unified)
+    }
+}
+
+// ✅ GOOD: Toolbar with standard controls
+struct ContentView: View {
+    var body: some View {
+        NavigationSplitView {
+            SidebarView()
+        } detail: {
+            DetailView()
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: toggleSidebar) {
+                    Label("Toggle Sidebar", systemImage: "sidebar.left")
+                }
+            }
+
+            ToolbarItem(placement: .primaryAction) {
+                Button("New") {
+                    // Action
+                }
+            }
+        }
+    }
+}
+
+// ❌ BAD: Custom window chrome (avoid unless necessary)
+```
+
+### Window Sizing and Constraints
+
+```swift
+// ✅ GOOD: Appropriate size constraints
+WindowGroup {
+    ContentView()
+}
+.defaultSize(width: 800, height: 600)
+.windowResizability(.contentSize)  // or .automatic
+
+// Document windows
+DocumentGroup(newDocument: { MyDocument() }) { file in
+    DocumentView(document: file.$document)
+}
+.defaultSize(width: 1024, height: 768)
+```
+
+### Multiple Windows
+
+```swift
+// ✅ GOOD: Supporting multiple windows
+@main
+struct MyApp: App {
+    var body: some Scene {
+        // Main window
+        WindowGroup {
+            ContentView()
+        }
+        .commands {
+            CommandGroup(replacing: .newItem) {
+                Button("New Window") {
+                    // Create new window
+                }
+                .keyboardShortcut("n", modifiers: .command)
+            }
+        }
+
+        // Settings window
+        Settings {
+            SettingsView()
+        }
+    }
+}
+```
+
+## Toolbar Design
+
+### Standard Toolbar Items
+
+```swift
+// ✅ GOOD: Well-organized toolbar
+.toolbar(id: "main") {
+    // Leading items
+    ToolbarItem(id: "sidebar", placement: .navigation) {
+        Button(action: toggleSidebar) {
+            Label("Sidebar", systemImage: "sidebar.left")
+        }
+    }
+
+    // Flexible space
+    ToolbarItem(placement: .automatic) {
+        Spacer()
+    }
+
+    // Center items (search, filters)
+    ToolbarItem(id: "search", placement: .automatic) {
+        TextField("Search", text: $searchText)
+            .textFieldStyle(.roundedBorder)
+            .frame(width: 200)
+    }
+
+    // Trailing items
+    ToolbarItem(id: "share", placement: .primaryAction) {
+        ShareLink(item: currentItem)
+    }
+
+    ToolbarItem(id: "add", placement: .primaryAction) {
+        Button(action: addNew) {
+            Label("Add", systemImage: "plus")
+        }
+    }
+}
+.toolbarRole(.editor)
+```
+
+### Customizable Toolbars
+
+```swift
+// ✅ GOOD: Allow toolbar customization
+.toolbar(id: "customizable-toolbar") {
+    ToolbarItem(id: "action1", placement: .automatic, showsByDefault: true) {
+        Button("Action 1") { }
+    }
+
+    ToolbarItem(id: "action2", placement: .automatic, showsByDefault: false) {
+        Button("Action 2") { }
+    }
+}
+.toolbarRole(.editor)
+```
+
+## Menu Bar Organization
+
+### Standard Menu Structure
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .commands {
+            // Replace standard commands
+            CommandGroup(replacing: .newItem) {
+                Button("New Document") {
+                    // Action
+                }
+                .keyboardShortcut("n")
+            }
+
+            // Add after File menu
+            CommandGroup(after: .newItem) {
+                Button("Import...") {
+                    // Action
+                }
+                .keyboardShortcut("i")
+            }
+
+            // Custom menu
+            CommandMenu("Tools") {
+                Button("Refresh") {
+                    // Action
+                }
+                .keyboardShortcut("r")
+
+                Divider()
+
+                Button("Export...") {
+                    // Action
+                }
+                .keyboardShortcut("e", modifiers: [.command, .shift])
+            }
+        }
+    }
+}
+```
+
+### Keyboard Shortcuts
+
+```swift
+// ✅ GOOD: Standard keyboard shortcuts
+.keyboardShortcut("n", modifiers: .command)           // ⌘N
+.keyboardShortcut("s", modifiers: .command)           // ⌘S
+.keyboardShortcut("w", modifiers: .command)           // ⌘W
+.keyboardShortcut("z", modifiers: .command)           // ⌘Z
+.keyboardShortcut("z", modifiers: [.command, .shift]) // ⇧⌘Z
+
+// ⚠️ Don't override system shortcuts
+// Avoid: ⌘Q, ⌘H, ⌘M, ⌘Tab, etc.
+
+// ✅ GOOD: Function key shortcuts
+.keyboardShortcut(.return, modifiers: .command)       // ⌘↩
+.keyboardShortcut(.delete, modifiers: .command)       // ⌘⌫
+.keyboardShortcut(.escape)                            // ⎋
+```
+
+## Navigation Patterns
+
+### Sidebar Navigation
+
+```swift
+// ✅ GOOD: Three-column layout
+struct ContentView: View {
+    @State private var selectedCategory: Category?
+    @State private var selectedItem: Item?
+
+    var body: some View {
+        NavigationSplitView {
+            // Primary sidebar
+            List(categories, selection: $selectedCategory) { category in
+                Label(category.name, systemImage: category.icon)
+            }
+            .navigationSplitViewColumnWidth(min: 180, ideal: 200)
+        } content: {
+            // Secondary sidebar
+            if let category = selectedCategory {
+                List(category.items, selection: $selectedItem) { item in
+                    Text(item.name)
+                }
+            }
+            .navigationSplitViewColumnWidth(min: 200, ideal: 250)
+        } detail: {
+            // Detail view
+            if let item = selectedItem {
+                ItemDetailView(item: item)
+            } else {
+                Text("Select an item")
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// ✅ GOOD: Two-column layout
+NavigationSplitView {
+    List(items, selection: $selectedItem) { item in
+        NavigationLink(value: item) {
+            Label(item.name, systemImage: item.icon)
+        }
+    }
+} detail: {
+    if let item = selectedItem {
+        DetailView(item: item)
+    }
+}
+```
+
+### Tab Navigation
+
+```swift
+// ✅ GOOD: TabView for distinct sections
+TabView {
+    DashboardView()
+        .tabItem {
+            Label("Dashboard", systemImage: "chart.bar")
+        }
+
+    ProjectsView()
+        .tabItem {
+            Label("Projects", systemImage: "folder")
+        }
+
+    SettingsView()
+        .tabItem {
+            Label("Settings", systemImage: "gear")
+        }
+}
+.frame(minWidth: 600, minHeight: 400)
+```
+
+## Control Patterns
+
+### Buttons
+
+```swift
+// ✅ GOOD: Appropriate button styles
+Button("Primary Action") {
+    // Action
+}
+.buttonStyle(.borderedProminent)  // Primary CTA
+
+Button("Secondary Action") {
+    // Action
+}
+.buttonStyle(.bordered)  // Secondary action
+
+Button("Cancel") {
+    // Action
+}
+.buttonStyle(.borderless)  // Tertiary action
+
+// ✅ GOOD: Destructive actions
+Button("Delete", role: .destructive) {
+    // Action
+}
+.buttonStyle(.bordered)
+```
+
+### Forms and Fields
+
+```swift
+// ✅ GOOD: Form layout
+Form {
+    Section("General") {
+        TextField("Name", text: $name)
+        TextField("Email", text: $email)
+            .textContentType(.emailAddress)
+
+        Picker("Role", selection: $role) {
+            ForEach(roles) { role in
+                Text(role.name).tag(role)
+            }
+        }
+    }
+
+    Section("Preferences") {
+        Toggle("Enable notifications", isOn: $notificationsEnabled)
+        Toggle("Dark mode", isOn: $darkModeEnabled)
+
+        Picker("Theme", selection: $theme) {
+            Text("Light").tag(Theme.light)
+            Text("Dark").tag(Theme.dark)
+            Text("Auto").tag(Theme.auto)
+        }
+        .pickerStyle(.segmented)
+    }
+
+    Section {
+        HStack {
+            Spacer()
+            Button("Cancel") {
+                dismiss()
+            }
+            .buttonStyle(.bordered)
+
+            Button("Save") {
+                save()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+}
+.formStyle(.grouped)
+.frame(minWidth: 400, minHeight: 300)
+```
+
+### Lists and Tables
+
+```swift
+// ✅ GOOD: List with context menu
+List(items, selection: $selection) { item in
+    ItemRow(item: item)
+        .contextMenu {
+            Button("Open") { openItem(item) }
+            Button("Duplicate") { duplicateItem(item) }
+            Divider()
+            Button("Delete", role: .destructive) {
+                deleteItem(item)
+            }
+        }
+}
+.listStyle(.sidebar)
+
+// ✅ GOOD: Table view
+Table(items, selection: $selection) {
+    TableColumn("Name") { item in
+        Text(item.name)
+    }
+    TableColumn("Date") { item in
+        Text(item.date, style: .date)
+    }
+    TableColumn("Size") { item in
+        Text(item.size, format: .byteCount(style: .file))
+    }
+}
+```
+
+## Alerts and Sheets
+
+### Alerts
+
+```swift
+// ✅ GOOD: Simple alert
+.alert("Delete Item?", isPresented: $showingAlert) {
+    Button("Cancel", role: .cancel) { }
+    Button("Delete", role: .destructive) {
+        deleteItem()
+    }
+} message: {
+    Text("This action cannot be undone.")
+}
+
+// ✅ GOOD: Confirmation dialog
+.confirmationDialog("Export Options", isPresented: $showingExport) {
+    Button("PDF") { exportPDF() }
+    Button("HTML") { exportHTML() }
+    Button("Markdown") { exportMarkdown() }
+    Button("Cancel", role: .cancel) { }
+}
+```
+
+### Sheets and Popovers
+
+```swift
+// ✅ GOOD: Sheet presentation
+.sheet(isPresented: $showingSheet) {
+    SettingsView()
+        .frame(minWidth: 500, minHeight: 400)
+}
+
+// ✅ GOOD: Popover
+.popover(isPresented: $showingPopover) {
+    FilterOptionsView()
+        .frame(width: 300)
+}
+```
+
+## Touch Bar (Legacy)
+
+```swift
+// ⚠️ Touch Bar removed on newer Macs
+// Don't rely on Touch Bar for essential functionality
+// Provide alternative toolbar/menu access to all features
+```
+
+## macOS Tahoe-Specific Features
+
+### Spotlight Integration
+
+```swift
+// ✅ GOOD: Make content searchable
+// Implement NSUserActivity for Spotlight indexing
+func makeUserActivity() -> NSUserActivity {
+    let activity = NSUserActivity(activityType: "com.app.viewArticle")
+    activity.title = "View Article"
+    activity.userInfo = ["articleID": article.id.uuidString]
+    activity.isEligibleForSearch = true
+
+    let attributes = CSSearchableItemAttributeSet(itemContentType: kUTTypeContent as String)
+    attributes.title = article.title
+    attributes.contentDescription = article.excerpt
+    activity.contentAttributeSet = attributes
+
+    return activity
+}
+```
+
+### Phone App on Mac
+
+```swift
+// ✅ GOOD: Support phone links for Phone app integration
+Link("Call Support", destination: URL(string: "tel:1-800-555-0123")!)
+
+// Continuity features automatically handled by system
+```
+
+## Platform Conventions Checklist
+
+- [ ] Use standard window chrome (unified toolbar)
+- [ ] Appropriate window size constraints
+- [ ] Support multiple windows (if applicable)
+- [ ] Well-organized toolbar with standard items
+- [ ] Standard menu structure with shortcuts
+- [ ] Keyboard shortcut consistency
+- [ ] Appropriate navigation pattern (sidebar, tabs)
+- [ ] Platform-standard controls and buttons
+- [ ] Proper alert and dialog usage
+- [ ] Context menus for list items
+- [ ] Spotlight integration (if applicable)
+- [ ] No reliance on Touch Bar
+
+## Resources
+
+- [macOS HIG](https://developer.apple.com/design/human-interface-guidelines/macos)
+- [macOS Tahoe Design Resources](https://developer.apple.com/design/resources/)
+- [WWDC 2025: What's new in macOS](https://developer.apple.com/videos/)

--- a/.claude/skills/macos-development/ui-review-tahoe/skill.md
+++ b/.claude/skills/macos-development/ui-review-tahoe/skill.md
@@ -1,0 +1,207 @@
+---
+name: ui-review-tahoe
+description: Comprehensive UI/UX review for macOS Tahoe apps. Covers Liquid Glass design, HIG compliance, SwiftUI patterns, and accessibility. Use when reviewing macOS UI or checking HIG compliance.
+allowed-tools: [Read, Glob, Grep, WebFetch]
+---
+
+# UI Review for macOS Tahoe
+
+You are a macOS UI/UX expert specializing in the Liquid Glass design system and macOS 26 (Tahoe) Human Interface Guidelines.
+
+## When This Skill Activates
+
+- User asks to review macOS UI or UX
+- User wants to check macOS HIG compliance
+- User asks about Liquid Glass usage or design consistency
+- User wants an accessibility audit of a macOS app
+- User is modernizing an AppKit UI with Liquid Glass
+
+## Your Role
+
+Conduct comprehensive UI/UX reviews of macOS applications, focusing on design consistency, accessibility, and adherence to macOS Tahoe design principles.
+
+## Core Focus Areas
+
+1. **Liquid Glass Design System** - Modern design language for macOS 26
+2. **macOS Tahoe HIG Compliance** - Platform-specific guidelines
+3. **SwiftUI for macOS** - Modern UI patterns and best practices
+4. **AppKit Modernization** - AppKit with Liquid Glass design
+5. **Accessibility** - VoiceOver, keyboard navigation, Dynamic Type
+
+## How to Conduct Reviews
+
+### Step 1: Understand the Application
+- Ask about the app's purpose and target audience
+- Identify the UI framework (SwiftUI, AppKit, or hybrid)
+- Understand the minimum macOS version supported
+- Review the app's design goals and constraints
+
+### Step 2: Systematic UI Audit
+
+Review the interface against each module's guidelines:
+- Liquid Glass design implementation (see liquid-glass-design.md)
+- macOS Tahoe HIG compliance (see macos-tahoe-hig.md)
+- SwiftUI patterns for macOS (see swiftui-macos.md)
+- AppKit modernization (see appkit-modern.md)
+- Accessibility standards (see accessibility.md)
+
+### Step 3: Provide Structured Feedback
+
+For each UI issue found:
+1. **Issue**: Clearly describe the problem
+2. **Guideline Violated**: Reference specific HIG or Liquid Glass principle
+3. **Impact**: Explain effect on user experience
+4. **Fix**: Provide concrete code or design example
+5. **Resources**: Link to relevant Apple documentation
+
+### Step 4: Prioritize Recommendations
+
+Categorize feedback:
+- 🔴 **Critical**: Breaks platform conventions, accessibility failures
+- 🟡 **Important**: Inconsistent with HIG, poor UX
+- 🟢 **Nice-to-have**: Polish improvements, advanced features
+
+## Review Checklist
+
+Before completing review, ensure you've checked:
+
+### Visual Design
+- [ ] Follows Liquid Glass design principles
+- [ ] Transparent menu bar implementation
+- [ ] Proper use of depth and hierarchy
+- [ ] Consistent spacing and alignment
+- [ ] Appropriate color usage (accent colors, semantic colors)
+- [ ] Custom folder icons (if applicable)
+- [ ] Animation quality and smoothness
+
+### Layout & Navigation
+- [ ] Proper window chrome and toolbar design
+- [ ] Navigation patterns (NavigationSplitView, tabs)
+- [ ] Responsive to window resizing
+- [ ] Proper sidebar/main content split
+- [ ] Control Center integration (if applicable)
+- [ ] Menu bar organization
+
+### Controls & Interactions
+- [ ] Platform-appropriate controls
+- [ ] Proper button styles and placement
+- [ ] Form design and validation
+- [ ] Keyboard shortcuts
+- [ ] Drag and drop support (where appropriate)
+- [ ] Context menus
+
+### Accessibility
+- [ ] VoiceOver support
+- [ ] Keyboard navigation
+- [ ] Focus indicators
+- [ ] Dynamic Type support
+- [ ] Color contrast (WCAG AA minimum)
+- [ ] Accessibility labels and hints
+
+### Performance
+- [ ] Smooth animations (60fps)
+- [ ] Responsive UI updates
+- [ ] No SwiftUI layout bugs (Tahoe-specific issues)
+- [ ] Proper NSHostingView usage (if hybrid)
+
+### Platform Integration
+- [ ] System appearance (light/dark mode)
+- [ ] Accent color support
+- [ ] Spotlight integration
+- [ ] Share extensions
+- [ ] Quick Look (if applicable)
+
+## Module References
+
+Load these modules as needed during review:
+
+1. **Liquid Glass Design**: `skills/ui-review-tahoe/liquid-glass-design.md`
+   - Design language principles
+   - Visual hierarchy and depth
+   - Transparency and materials
+   - Animation guidelines
+
+2. **macOS Tahoe HIG**: `skills/ui-review-tahoe/macos-tahoe-hig.md`
+   - Human Interface Guidelines
+   - Platform conventions
+   - Window management
+   - Toolbar and menu design
+
+3. **SwiftUI for macOS**: `skills/ui-review-tahoe/swiftui-macos.md`
+   - SwiftUI patterns and components
+   - macOS-specific modifiers
+   - Known Tahoe SwiftUI issues
+   - Layout best practices
+
+4. **AppKit Modernization**: `skills/ui-review-tahoe/appkit-modern.md`
+   - Modern AppKit patterns
+   - Liquid Glass in AppKit
+   - NSViewController best practices
+   - AppKit + SwiftUI hybrid
+
+5. **Accessibility**: `skills/ui-review-tahoe/accessibility.md`
+   - VoiceOver testing
+   - Keyboard navigation
+   - Dynamic Type
+   - Accessibility API usage
+
+## Example Review Format
+
+```markdown
+# UI Review: [App Name]
+
+## Summary
+Brief overview of the app and its current UI state.
+
+## Critical Issues 🔴
+1. **VoiceOver Cannot Navigate Main List**
+   - Guideline: Accessibility - VoiceOver support required
+   - Impact: App unusable for blind users
+   - Fix: [code example with accessibility labels]
+
+## Important Issues 🟡
+1. **Window Toolbar Not Following Tahoe HIG**
+   - Guideline: macOS Tahoe HIG - Toolbar design
+   - Impact: Feels out of place on macOS 26
+   - Fix: [code example with proper toolbar]
+
+## Suggestions 🟢
+1. **Consider Adding Liquid Glass Transparency**
+   - Guideline: Liquid Glass - Visual hierarchy
+   - Benefit: More native macOS 26 appearance
+   - Example: [code example]
+
+## Overall Assessment
+[Summary and priority recommendations]
+
+## Tahoe-Specific Considerations
+[Any macOS 26-specific issues or opportunities]
+```
+
+## Response Guidelines
+
+- Be constructive and specific
+- Provide visual examples when describing issues
+- Reference Apple's HIG and WWDC sessions
+- Consider both SwiftUI and AppKit contexts
+- Acknowledge good design choices already made
+- Balance ideal design with practical constraints
+- Highlight Tahoe-specific issues and opportunities
+
+## When to Load Modules
+
+- Load modules on-demand as specific topics arise
+- Don't load all modules upfront
+- Reference module filenames when providing guidance
+- Suggest reading specific modules for deeper understanding
+
+## Screenshot Analysis
+
+If provided with screenshots:
+- Analyze visual hierarchy and spacing
+- Check color contrast and accessibility
+- Verify alignment and consistency
+- Identify HIG violations
+- Suggest improvements
+
+Begin reviews by asking to see the UI code or screenshots, and understanding the app's context.

--- a/.claude/skills/macos-development/ui-review-tahoe/swiftui-macos.md
+++ b/.claude/skills/macos-development/ui-review-tahoe/swiftui-macos.md
@@ -1,0 +1,487 @@
+# SwiftUI for macOS Best Practices
+
+macOS-specific SwiftUI patterns, modifiers, and known Tahoe issues.
+
+## macOS-Specific Views
+
+### NavigationSplitView
+
+```swift
+// ✅ GOOD: Sidebar layout for macOS
+struct ContentView: View {
+    @State private var selection: Item?
+
+    var body: some View {
+        NavigationSplitView {
+            // Sidebar
+            List(items, selection: $selection) { item in
+                NavigationLink(value: item) {
+                    Label(item.name, systemImage: item.icon)
+                }
+            }
+            .navigationSplitViewColumnWidth(min: 200, ideal: 250, max: 300)
+        } detail: {
+            // Detail
+            if let item = selection {
+                ItemDetailView(item: item)
+            } else {
+                ContentUnavailableView("Select an Item", systemImage: "doc")
+            }
+        }
+        .navigationSplitViewStyle(.balanced)
+    }
+}
+```
+
+### Table View
+
+```swift
+// ✅ GOOD: Native Table view
+struct DocumentsTable: View {
+    @State private var documents: [Document]
+    @State private var selection = Set<Document.ID>()
+    @State private var sortOrder = [KeyPathComparator(\Document.name)]
+
+    var body: some View {
+        Table(documents, selection: $selection, sortOrder: $sortOrder) {
+            TableColumn("Name", value: \.name) { document in
+                HStack {
+                    Image(systemName: document.icon)
+                    Text(document.name)
+                }
+            }
+
+            TableColumn("Modified", value: \.modifiedDate) { document in
+                Text(document.modifiedDate, style: .date)
+            }
+            .width(min: 100, ideal: 150)
+
+            TableColumn("Size", value: \.size) { document in
+                Text(document.size, format: .byteCount(style: .file))
+            }
+            .width(ideal: 100)
+        }
+        .onChange(of: sortOrder) {
+            documents.sort(using: sortOrder)
+        }
+    }
+}
+```
+
+## macOS-Specific Modifiers
+
+### Context Menus
+
+```swift
+// ✅ GOOD: Rich context menus
+.contextMenu {
+    Button("Open") {
+        openItem()
+    }
+    Button("Open in New Window") {
+        openInNewWindow()
+    }
+
+    Divider()
+
+    Button("Rename") {
+        startRename()
+    }
+    Button("Duplicate") {
+        duplicateItem()
+    }
+
+    Divider()
+
+    Menu("Share") {
+        ShareLink(item: shareableItem)
+    }
+
+    Divider()
+
+    Button("Delete", role: .destructive) {
+        deleteItem()
+    }
+}
+```
+
+### Help Tags (Tooltips)
+
+```swift
+// ✅ GOOD: Helpful tooltips
+Button(action: save) {
+    Image(systemName: "square.and.arrow.down")
+}
+.help("Save document")  // Tooltip on hover
+
+Toggle("Enable feature", isOn: $isEnabled)
+    .help("This feature improves performance by...")
+```
+
+### Focus Management
+
+```swift
+// ✅ GOOD: Keyboard focus handling
+struct LoginView: View {
+    @FocusState private var focusedField: Field?
+
+    enum Field: Hashable {
+        case username
+        case password
+    }
+
+    var body: some View {
+        Form {
+            TextField("Username", text: $username)
+                .focused($focusedField, equals: .username)
+
+            SecureField("Password", text: $password)
+                .focused($focusedField, equals: .password)
+                .onSubmit {
+                    login()
+                }
+        }
+        .onAppear {
+            focusedField = .username
+        }
+    }
+}
+```
+
+## Known macOS Tahoe SwiftUI Issues
+
+### Layout Bugs
+
+```swift
+// ⚠️ ISSUE: SwiftUI layout broken in some cases on Tahoe
+// Workaround: Use explicit frames and spacing
+
+// ❌ May break on Tahoe
+VStack {
+    Text("Title")
+    Text("Subtitle")
+}
+.frame(maxWidth: .infinity)
+
+// ✅ WORKAROUND: Be explicit
+VStack(spacing: 8) {
+    Text("Title")
+        .frame(maxWidth: .infinity, alignment: .leading)
+    Text("Subtitle")
+        .frame(maxWidth: .infinity, alignment: .leading)
+}
+.fixedSize(horizontal: false, vertical: true)
+```
+
+### NSHostingView Animation Issues
+
+```swift
+// ⚠️ ISSUE: Frame changes don't animate smoothly in NSHostingView
+// Workaround: Use explicit animation timing
+
+// ❌ May not animate smoothly
+.frame(width: isExpanded ? 300 : 100)
+.animation(.default, value: isExpanded)
+
+// ✅ WORKAROUND: Use specific timing
+.frame(width: isExpanded ? 300 : 100)
+.animation(.easeInOut(duration: 0.2), value: isExpanded)
+
+// Or avoid NSHostingView for animated content
+// Use pure SwiftUI windows instead
+```
+
+### Transparency Issues
+
+```swift
+// ⚠️ ISSUE: Some transparency effects may not render correctly
+// Workaround: Test on actual macOS Tahoe
+
+// ✅ GOOD: Use tested materials
+.background(.regularMaterial)
+.background(.ultraThinMaterial)
+
+// ⚠️ Test custom transparency
+.background(Color.white.opacity(0.5))  // May not work as expected
+```
+
+## Window Management
+
+### Custom Windows
+
+```swift
+// ✅ GOOD: Create auxiliary windows
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+
+        // Inspector window
+        Window("Inspector", id: "inspector") {
+            InspectorView()
+        }
+        .defaultSize(width: 300, height: 600)
+        .windowResizability(.contentSize)
+
+        // Preferences
+        Settings {
+            SettingsView()
+        }
+    }
+}
+
+// Open window from code
+@Environment(\.openWindow) var openWindow
+
+Button("Show Inspector") {
+    openWindow(id: "inspector")
+}
+```
+
+### Window Toolbar Customization
+
+```swift
+// ✅ GOOD: Unified toolbar style
+.windowStyle(.hiddenTitleBar)
+.windowToolbarStyle(.unified)
+
+// ✅ GOOD: Expanded toolbar
+.windowToolbarStyle(.expanded)
+
+// ✅ GOOD: Automatic based on content
+.windowToolbarStyle(.automatic)
+```
+
+## Menus and Commands
+
+### MenuBarExtra
+
+```swift
+// ✅ GOOD: Menu bar app
+@main
+struct MenuBarApp: App {
+    var body: some Scene {
+        MenuBarExtra("My App", systemImage: "star.fill") {
+            Button("Action 1") {
+                // Action
+            }
+
+            Button("Action 2") {
+                // Action
+            }
+
+            Divider()
+
+            Button("Quit") {
+                NSApplication.shared.terminate(nil)
+            }
+            .keyboardShortcut("q")
+        }
+    }
+}
+```
+
+### Context Menu for Menu Bar
+
+```swift
+// ✅ GOOD: Menu bar extra with label
+MenuBarExtra("Status", systemImage: statusIcon) {
+    VStack {
+        Text("Status: \(currentStatus)")
+        Divider()
+        Button("Refresh") {
+            refresh()
+        }
+    }
+}
+.menuBarExtraStyle(.window)  // Shows as popover
+```
+
+## Observation Framework
+
+### Using @Observable (macOS 14+)
+
+```swift
+// ✅ GOOD: New Observation framework
+import Observation
+
+@Observable
+final class ArticleViewModel {
+    var articles: [Article] = []
+    var isLoading = false
+    var error: Error?
+
+    func loadArticles() async {
+        isLoading = true
+        // Load articles...
+        isLoading = false
+    }
+}
+
+// Usage in view - automatic updates
+struct ArticleListView: View {
+    let viewModel: ArticleViewModel
+
+    var body: some View {
+        List(viewModel.articles) { article in
+            Text(article.title)
+        }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+            }
+        }
+        .task {
+            await viewModel.loadArticles()
+        }
+    }
+}
+
+// ❌ OLD: ObservableObject (still works, but @Observable is preferred)
+class ArticleViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+}
+```
+
+## Gestures and Interactions
+
+### Mouse Events
+
+```swift
+// ✅ GOOD: Hover effects
+.onHover { isHovered in
+    withAnimation {
+        self.isHovered = isHovered
+    }
+}
+.scaleEffect(isHovered ? 1.05 : 1.0)
+
+// ✅ GOOD: Right-click handling
+.onTapGesture(count: 1, perform: leftClick)
+.gesture(
+    TapGesture(count: 1)
+        .modifiers(.control)
+        .onEnded { _ in
+            showContextMenu()
+        }
+)
+```
+
+### Drag and Drop
+
+```swift
+// ✅ GOOD: Draggable items
+Text(item.name)
+    .draggable(item)
+
+// ✅ GOOD: Drop destination
+List {
+    // Items
+}
+.dropDestination(for: Item.self) { items, location in
+    handleDrop(items, at: location)
+    return true
+}
+```
+
+## Performance Optimization
+
+### LazyVStack vs VStack
+
+```swift
+// ✅ GOOD: Use LazyVStack for long lists
+ScrollView {
+    LazyVStack(spacing: 8) {
+        ForEach(items) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+
+// ❌ BAD: Regular VStack loads all items
+ScrollView {
+    VStack {
+        ForEach(items) { item in  // Loads everything!
+            ItemRow(item: item)
+        }
+    }
+}
+```
+
+### Drawing Performance
+
+```swift
+// ✅ GOOD: Use drawingGroup for complex graphics
+Canvas { context, size in
+    // Complex drawing
+}
+.drawingGroup()  // Offloads to Metal
+
+// ✅ GOOD: Cache expensive calculations
+.backgroundStyle(
+    LinearGradient(...)
+        .drawingGroup()
+)
+```
+
+## SwiftUI + AppKit Bridge
+
+### NSViewRepresentable
+
+```swift
+// ✅ GOOD: Wrap NSTextField for advanced features
+struct AdvancedTextField: NSViewRepresentable {
+    @Binding var text: String
+
+    func makeNSView(context: Context) -> NSTextField {
+        let textField = NSTextField()
+        textField.delegate = context.coordinator
+        return textField
+    }
+
+    func updateNSView(_ nsView: NSTextField, context: Context) {
+        nsView.stringValue = text
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    class Coordinator: NSObject, NSTextFieldDelegate {
+        @Binding var text: String
+
+        init(text: Binding<String>) {
+            _text = text
+        }
+
+        func controlTextDidChange(_ notification: Notification) {
+            if let textField = notification.object as? NSTextField {
+                text = textField.stringValue
+            }
+        }
+    }
+}
+```
+
+## SwiftUI Checklist for macOS
+
+- [ ] Use NavigationSplitView for sidebar layouts
+- [ ] Use Table for tabular data
+- [ ] Provide rich context menus
+- [ ] Add help tags (tooltips) to controls
+- [ ] Manage keyboard focus appropriately
+- [ ] Use @Observable for view models (macOS 14+)
+- [ ] Handle hover interactions
+- [ ] Support drag and drop where appropriate
+- [ ] Use LazyVStack for long lists
+- [ ] Test layout on actual macOS Tahoe
+- [ ] Verify animations in NSHostingView
+- [ ] Use proper window toolbar styles
+
+## Resources
+
+- [SwiftUI Documentation](https://developer.apple.com/documentation/swiftui)
+- [WWDC 2024: What's new in SwiftUI](https://developer.apple.com/videos/swiftui)
+- [macOS SwiftUI Tutorials](https://developer.apple.com/tutorials/swiftui)

--- a/.claude/skills/monetization/SKILL.md
+++ b/.claude/skills/monetization/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: monetization
+description: Monetization strategy for iOS/macOS apps. Covers readiness assessment, pricing model selection, tier structuring, free trial strategy, and implementation guidance. Use when deciding what to charge, how to price, or planning monetization end-to-end.
+allowed-tools: [Read, Write, Edit, Glob, Grep, WebSearch, AskUserQuestion]
+---
+
+# Monetization Strategy
+
+End-to-end monetization guidance for Apple platform apps — from "should I charge?" to "here's your pricing page structure."
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Asks "should I monetize my app?" or "is my app ready to charge?"
+- Wants help choosing between freemium, subscription, or one-time purchase
+- Needs pricing tier recommendations
+- Asks about free trial strategy
+- Wants to plan monetization for a specific app type (kids, therapy, productivity, etc.)
+- Mentions "pricing", "revenue model", or "how to make money from my app"
+- Wants to understand Apple's commission structure
+
+## Process
+
+### Phase 1: Readiness Assessment
+
+Before recommending a pricing model, evaluate whether the app is ready to monetize. Ask these questions via AskUserQuestion:
+
+**1. App Stage**
+- Pre-launch (idea/prototype)
+- Beta / TestFlight
+- Live with users (< 1K)
+- Live with traction (1K+ users)
+
+**2. Value Proposition**
+- What problem does your app solve?
+- Who is the target user?
+- What alternatives exist (including doing nothing)?
+
+**3. Current State**
+- Do you have active users?
+- What's your retention like? (Day 1, Day 7, Day 30)
+- Are users asking for features / willing to pay?
+
+#### Readiness Scorecard
+
+Evaluate against these criteria:
+
+| Signal | Ready | Not Ready |
+|--------|-------|-----------|
+| Core value | Clear, differentiated | Still finding product-market fit |
+| User retention | D7 > 20% | D7 < 10% |
+| User feedback | "I'd pay for this" | Silence or complaints |
+| Feature depth | Enough for free + paid split | Everything feels essential |
+| Competition | You offer something unique | Commodity feature set |
+| Polish | Professional quality | Rough edges everywhere |
+
+**Recommendation thresholds:**
+- 5-6 Ready signals → Monetize now
+- 3-4 Ready signals → Soft-launch pricing (low price, gather data)
+- 0-2 Ready signals → Focus on product first, monetize later
+
+### Phase 2: Pricing Model Selection
+
+Based on app type and user behavior, recommend the right model.
+
+#### Decision Framework
+
+```
+Is the app used daily/weekly?
+├── YES → Does it provide ongoing value?
+│   ├── YES → SUBSCRIPTION
+│   └── NO → ONE-TIME PURCHASE (with optional tip jar)
+└── NO → Is it a utility/tool?
+    ├── YES → ONE-TIME PURCHASE or FREEMIUM
+    └── NO → Is it content-based?
+        ├── YES → SUBSCRIPTION or CONSUMABLE IAP
+        └── NO → FREEMIUM with premium unlock
+```
+
+#### Model Comparison
+
+Read **pricing-models.md** for detailed comparison of each model:
+- Subscriptions (auto-renewable)
+- One-time purchase (paid upfront or freemium unlock)
+- Consumable IAP (credits, tokens)
+- Non-consumable IAP (feature unlock)
+- Tip jar / patronage
+- Ad-supported with premium upgrade
+
+#### App-Type Recommendations
+
+Read **app-type-guides.md** for specific guidance by app category:
+- Productivity / task management
+- Health / therapy / wellness
+- Kids / education
+- Creative tools
+- Social / community
+- Developer tools
+- Finance / budgeting
+
+### Phase 3: Tier Structure
+
+Once a model is selected, design the tier structure.
+
+#### Subscription Tiers (if applicable)
+
+**Two-tier structure** (recommended for most indie apps):
+```
+FREE                    PRO ($X.99/mo or $XX.99/yr)
+─────────────────────   ─────────────────────────────
+Core functionality      Everything in Free
+Limited usage/storage   Unlimited usage
+Basic features          Advanced features
+                        Priority support (optional)
+                        Early access to new features
+```
+
+**Three-tier structure** (for apps with clear user segments):
+```
+FREE          PLUS ($X.99/mo)     PRO ($XX.99/mo)
+────────────  ──────────────────  ──────────────────
+Basic use     Power user          Professional/team
+Ads/limits    No ads, more quota  Unlimited + extras
+```
+
+#### Pricing Psychology
+
+- **Anchor pricing**: Show yearly first to make monthly look expensive
+- **Price ending**: Use .99 for < $10, round numbers for premium ($19, $29)
+- **Yearly discount**: 15-40% off monthly equivalent (sweet spot: ~30%)
+- **Decoy effect**: Three tiers where middle looks like best value
+- **Regional pricing**: Use App Store price tiers for automatic localization
+
+#### Free vs. Paid Feature Split
+
+The hardest decision. Follow these principles:
+
+**Free tier should:**
+- Demonstrate the core value proposition
+- Be genuinely useful (not a crippled demo)
+- Create natural upgrade moments ("you've hit the limit")
+- Let users invest time/data before hitting the paywall
+
+**Paid tier should:**
+- Unlock power/convenience, not basic functionality
+- Feel like "more of what you love" not "removing annoyances"
+- Include at least one "hero feature" worth paying for alone
+
+**❌ Bad splits:**
+- Free: Can view data → Paid: Can edit data (feels hostile)
+- Free: 3-day trial → Paid: Everything (no ongoing free value)
+- Free: Everything → Paid: Remove ads (weak value prop)
+
+**✅ Good splits:**
+- Free: 5 projects → Paid: Unlimited projects + templates
+- Free: Basic tracking → Paid: Insights, trends, export
+- Free: Single device → Paid: Sync across devices + widgets
+
+### Phase 4: Free Trial Strategy
+
+#### Trial Types
+
+| Type | Best For | Apple Support |
+|------|----------|---------------|
+| Introductory offer (free) | Subscriptions | Built-in via App Store |
+| Introductory offer (discounted) | High-value subscriptions | Built-in via App Store |
+| Feature-limited free tier | Freemium apps | N/A (your logic) |
+| Time-limited full access | Productivity apps | Built-in via App Store |
+
+#### Trial Duration Recommendations
+
+| App Type | Trial Length | Reason |
+|----------|-------------|--------|
+| Daily-use productivity | 7 days | Quick to see value |
+| Health/fitness tracking | 14 days | Need time to build habit |
+| Creative tools | 7 days | One project cycle |
+| Business/professional | 14-30 days | Need to integrate into workflow |
+| Education/learning | 7 days | One learning cycle |
+
+#### Trial Conversion Tactics
+
+1. **Onboard to premium features** during trial (not free features)
+2. **Show "trial ending" reminder** 2-3 days before expiration
+3. **Highlight value received** ("You tracked 47 workouts this month")
+4. **Offer annual option** at trial end (bigger commitment but better price)
+5. **Win-back offer** if they don't convert (promotional offer after 30 days)
+
+### Phase 5: Implementation Guidance
+
+After strategy is set, guide implementation.
+
+#### Apple Commission Structure
+
+| Scenario | Apple's Cut | You Keep |
+|----------|-------------|----------|
+| Standard (Year 1) | 30% | 70% |
+| After Year 1 of subscription | 15% | 85% |
+| Small Business Program (< $1M/yr) | 15% | 85% |
+| Small Business + Year 2 subscription | 15% | 85% |
+
+**Important:** Revenue calculations should always account for Apple's cut. A $9.99/mo subscription with Small Business Program = ~$8.49/mo to you.
+
+#### StoreKit 2 Implementation
+
+For code generation, refer users to the **paywall-generator** skill:
+```
+Use the paywall-generator skill to create:
+- StoreKit 2 subscription management
+- Paywall UI (SwiftUI)
+- Receipt validation
+- Subscription status tracking
+```
+
+#### Paywall UI Patterns (HIG-Compliant)
+
+**Do:**
+- Show feature comparison (free vs. paid)
+- Display price per period clearly
+- Highlight savings on annual plan
+- Include "Restore Purchases" button
+- Show terms of service and privacy policy links
+- Use system subscription views where available (iOS 18.4+)
+
+**Don't:**
+- Block the app immediately on launch
+- Use dark patterns (hidden close button, confusing language)
+- Make it hard to dismiss the paywall
+- Misrepresent subscription terms
+- Auto-select the most expensive option
+
+#### App Store Review Guidelines (Monetization)
+
+Key rules to follow:
+- **3.1.1**: In-app purchase required for digital content/features
+- **3.1.2**: Subscriptions must provide ongoing value
+- **3.1.3**: "Reader" apps can link to web for account management
+- **3.2.2**: Unacceptable business models (bait-and-switch, etc.)
+- **5.6**: Developer Code of Conduct (no manipulative tactics)
+
+## Output Format
+
+Present monetization strategy as:
+
+```markdown
+# Monetization Strategy: [App Name]
+
+## Readiness Assessment
+**Score**: X/6 — [Ready to monetize / Soft-launch / Focus on product]
+
+| Signal | Status | Notes |
+|--------|--------|-------|
+| Core value | ✅/❌ | ... |
+| Retention | ✅/❌ | ... |
+| User demand | ✅/❌ | ... |
+| Feature depth | ✅/❌ | ... |
+| Differentiation | ✅/❌ | ... |
+| Polish | ✅/❌ | ... |
+
+## Recommended Model
+**[Model Name]** — [One-line rationale]
+
+## Tier Structure
+
+| Feature | Free | Pro ($X.99/mo) |
+|---------|------|-----------------|
+| ... | ✅ | ✅ |
+| ... | Limited | Unlimited |
+| ... | ❌ | ✅ |
+
+**Annual pricing**: $XX.99/yr (XX% savings)
+
+## Free Trial
+**Type**: [Introductory offer / Feature-limited / etc.]
+**Duration**: [X days]
+**Conversion tactics**: [Bullet list]
+
+## Revenue Projections (Conservative)
+
+| Metric | Estimate |
+|--------|----------|
+| Monthly price | $X.99 |
+| Annual price | $XX.99 |
+| Conversion rate (free→paid) | X-X% |
+| Revenue per 1K MAU | $XXX-$XXX/mo |
+
+## Implementation Checklist
+- [ ] Configure products in App Store Connect
+- [ ] Implement StoreKit 2 (use paywall-generator skill)
+- [ ] Design paywall UI
+- [ ] Set up introductory offers
+- [ ] Add analytics for conversion tracking
+- [ ] Test with StoreKit Configuration file
+- [ ] Submit for review
+
+## Next Steps
+1. [First action item]
+2. [Second action item]
+3. [Third action item]
+```
+
+## References
+
+- **pricing-models.md** — Detailed comparison of all pricing models
+- **app-type-guides.md** — Category-specific monetization recommendations
+- **paywall-generator** skill — For StoreKit 2 code generation
+- **app-store** skill — For App Store description optimization
+- Apple App Store Review Guidelines §3 (Business)
+- Apple StoreKit 2 documentation

--- a/.claude/skills/monetization/app-type-guides.md
+++ b/.claude/skills/monetization/app-type-guides.md
@@ -1,0 +1,322 @@
+# App-Type Monetization Guides
+
+Category-specific monetization strategies based on user behavior patterns, willingness to pay, and industry benchmarks.
+
+---
+
+## Productivity / Task Management
+
+**Examples:** Todoist, Things, Notion, Bear
+
+**Recommended model:** Freemium + Subscription or One-time purchase
+
+**Why:** Daily-use apps with clear ongoing value. Users build data and habits that create switching costs.
+
+**Tier structure:**
+```
+FREE                        PRO ($4.99/mo or $39.99/yr)
+──────────────────────────  ──────────────────────────────
+Unlimited basic tasks       Everything in Free
+1 list/project              Unlimited lists/projects
+Local storage only          Cloud sync across devices
+Basic themes                Custom themes + icons
+                            Widgets
+                            CSV/PDF export
+                            Reminders + notifications
+```
+
+**Key insight:** The sync paywall is powerful — users want their data everywhere. But make sure the free tier is genuinely useful on a single device.
+
+**Pricing range:** $3.99-6.99/mo or $29.99-49.99/yr or $29.99-79.99 lifetime
+
+---
+
+## Health / Therapy / Wellness
+
+**Examples:** Calm, Headspace, Woebot, Bearable
+
+**Recommended model:** Subscription (with generous trial)
+
+**Why:** Ongoing engagement is the value. Health outcomes improve with consistency. Users associate subscription with commitment to self-improvement.
+
+**Tier structure:**
+```
+FREE                        PREMIUM ($6.99/mo or $49.99/yr)
+──────────────────────────  ──────────────────────────────────
+Daily check-in              Everything in Free
+3 guided exercises          Full exercise library
+Basic mood tracking         Advanced insights + trends
+7-day history               Unlimited history + export
+                            Personalized recommendations
+                            Therapist/coach tools
+                            Apple Health integration
+                            Family sharing (5 members)
+```
+
+**Key insights:**
+- **Free trial is essential** (14 days minimum) — users need time to feel the benefit
+- **Don't gate crisis/safety features** behind paywall (ethical + legal risk)
+- **Show progress** during trial ("You've meditated 8 days in a row")
+- Wellness users are sensitive to "paying for mental health" — frame as investment, not transaction
+- Consider **annual-only** pricing to encourage long-term commitment
+
+**Pricing range:** $5.99-12.99/mo or $39.99-79.99/yr
+
+**Special considerations:**
+- Accessibility: offer reduced pricing for students/low-income (promotional offers)
+- HIPAA: if handling health data, consult compliance requirements
+- Apple Health: integration adds significant perceived value at low dev cost
+
+---
+
+## Kids / Education
+
+**Examples:** Khan Academy Kids, Duolingo, Toca Boca
+
+**Recommended model:** Subscription (family-friendly) or One-time purchase per content pack
+
+**Why:** Parents are the buyers, kids are the users. Parents want safe, ad-free experiences and are willing to pay for educational value.
+
+**Tier structure (subscription):**
+```
+FREE                        FAMILY ($6.99/mo or $49.99/yr)
+──────────────────────────  ──────────────────────────────────
+5 lessons/activities free   Unlimited access
+Basic content library       Full content library
+1 child profile             Up to 4 child profiles
+Progress for current week   Full progress history + reports
+                            Offline downloads
+                            New content monthly
+                            No ads (required for kids apps)
+                            Parent dashboard
+```
+
+**Tier structure (content packs):**
+```
+FREE                        PACKS ($2.99-4.99 each)
+──────────────────────────  ──────────────────────────────
+Starter content pack        Theme packs (animals, space, etc.)
+Core features               Activity packs
+                            Level expansions
+                            ALL ACCESS ($14.99 one-time)
+```
+
+**Key insights:**
+- **COPPA compliance is mandatory** — no behavioral advertising for under-13
+- **Family Sharing is expected** — parents don't want to pay per device
+- **No ads in kids apps** — Apple explicitly prohibits third-party ads in kids category
+- Parents prefer **annual subscriptions** or **one-time purchases** over monthly
+- **Show learning outcomes** to parents to justify price
+- **Gift-ability matters** — grandparents buy educational apps
+
+**Pricing range:** $4.99-9.99/mo family or $2.99-4.99 per content pack
+
+**App Store category note:** Apps in the "Kids" category have stricter review guidelines (§1.3). No links out of the app, no IAP without parental gate.
+
+---
+
+## Creative Tools
+
+**Examples:** Procreate, Pixelmator, Affinity, Ferrite
+
+**Recommended model:** One-time purchase or Freemium + Subscription
+
+**Why:** Creative professionals value ownership. They want to pay once and own the tool. But subscription works if you offer a robust content library (brushes, templates, fonts).
+
+**Tier structure (one-time):**
+```
+FULL APP ($9.99-29.99)
+─────────────────────────
+All features included
+Free updates for current major version
+Export in all formats
+iCloud sync
+No subscription required
+```
+
+**Tier structure (freemium + subscription):**
+```
+FREE                        PRO ($4.99/mo or $29.99/yr)
+──────────────────────────  ──────────────────────────────
+Basic tools                 Advanced tools + effects
+3 export formats            All export formats
+5 projects                  Unlimited projects
+Low-res export              Full-resolution export
+                            Cloud storage + sync
+                            Premium templates/assets
+                            Priority rendering
+```
+
+**Key insights:**
+- **Procreate proved one-time purchase works** at scale ($12.99, 40M+ downloads)
+- Creative users are vocal about anti-subscription sentiment
+- If subscription, the content library (templates, brushes, fonts) must justify ongoing cost
+- Consider **"All Tools" one-time unlock + optional content subscription** hybrid
+- **Export quality** as paywall is well-accepted (low-res free, full-res paid)
+
+**Pricing range:** $9.99-49.99 one-time, or $3.99-9.99/mo subscription
+
+---
+
+## Social / Community
+
+**Examples:** Discord, Mastodon clients, community forums
+
+**Recommended model:** Freemium + Subscription (or Ad-supported + Premium)
+
+**Why:** Network effects require a large free user base. Monetize power users who want enhanced experience.
+
+**Tier structure:**
+```
+FREE                        PREMIUM ($2.99/mo or $19.99/yr)
+──────────────────────────  ──────────────────────────────────
+Full social features        Everything in Free
+Standard profile            Custom profile + badge
+Basic notifications         Advanced notification filters
+Standard media uploads      Higher upload limits
+                            Custom themes/icons
+                            Ad-free experience
+                            Early access to features
+```
+
+**Key insights:**
+- **Never paywall core social features** (posting, messaging, following)
+- Cosmetic upgrades (badges, themes) are high-margin, low-controversy
+- Power users (moderators, content creators) will pay for tools
+- Social apps live or die on engagement — free tier must be excellent
+
+**Pricing range:** $1.99-4.99/mo (keep low — social users are price-sensitive)
+
+---
+
+## Developer Tools
+
+**Examples:** Proxyman, Charles, PastePal, DevUtils
+
+**Recommended model:** One-time purchase with paid major updates, or Subscription
+
+**Why:** Developers understand the value of good tools and will pay for productivity gains. They also strongly prefer ownership.
+
+**Tier structure (one-time + updates):**
+```
+V1 ($19.99-49.99)          V2 ($14.99 upgrade / $49.99 new)
+──────────────────────────  ──────────────────────────────────
+All V1 features             All V1 features
+Free minor updates          Major new features
+                            Free minor updates
+```
+
+**Tier structure (subscription):**
+```
+FREE                        PRO ($4.99-9.99/mo)
+──────────────────────────  ──────────────────────────────
+Basic tools                 Full toolset
+Limited sessions            Unlimited sessions
+Community support           Priority support
+                            Team features (shared configs)
+                            CLI integration
+                            API access
+```
+
+**Key insights:**
+- **Developers respect paid software** — don't race to the bottom
+- SetApp distribution can supplement App Store revenue
+- Consider **education discount** (student/teacher)
+- **License key + direct distribution** as alternative to App Store (keep 100%)
+- B2B pricing is 3-5x consumer pricing for team features
+
+**Pricing range:** $19.99-99.99 one-time, or $4.99-14.99/mo
+
+---
+
+## Finance / Budgeting
+
+**Examples:** YNAB, Copilot, Monarch
+
+**Recommended model:** Subscription
+
+**Why:** Financial data is ongoing, users need continuous access, and the value proposition (saving money) directly justifies the cost.
+
+**Tier structure:**
+```
+FREE                        PREMIUM ($4.99/mo or $39.99/yr)
+──────────────────────────  ──────────────────────────────────
+Manual transaction entry    Bank sync (Plaid/MX)
+Basic categories            Custom categories + rules
+Monthly summary             Trends, insights, projections
+1 account                   Unlimited accounts
+                            Bill reminders
+                            CSV/PDF export
+                            Shared budgets (couples/families)
+```
+
+**Key insights:**
+- **"This app saves you $X/month"** is the strongest conversion argument
+- Bank sync (Plaid) is expensive — subscription justifies the per-user cost
+- Users trust paid apps more with financial data (paradoxically)
+- Annual pricing works well — aligns with yearly financial planning
+- **Free tier should prove value first** (manual entry → show insights → upgrade for sync)
+
+**Pricing range:** $4.99-12.99/mo or $39.99-99.99/yr
+
+---
+
+## Utility / Simple Tools
+
+**Examples:** Weather apps, calculators, unit converters, QR scanners
+
+**Recommended model:** Freemium (one-time IAP) or Ad-supported + Premium
+
+**Why:** Low engagement frequency, clear bounded value, users expect utilities to be cheap or free.
+
+**Tier structure:**
+```
+FREE (with ads)             PRO ($2.99-4.99 one-time)
+──────────────────────────  ──────────────────────────────
+Core functionality          Everything in Free
+Banner ads                  Ad-free
+Basic widget                Premium widgets
+Standard theme              All themes
+                            Apple Watch complication
+```
+
+**Key insights:**
+- **Keep it cheap** — utilities are commodity products
+- Widgets and Watch complications are strong upsell features
+- One-time purchase feels right for utilities (no ongoing relationship)
+- Consider **tip jar** as alternative if app is simple but beloved
+
+**Pricing range:** $0.99-4.99 one-time, or free with ads
+
+---
+
+## AI-Powered Apps
+
+**Examples:** ChatGPT, GitHub Copilot, AI photo editors
+
+**Recommended model:** Freemium + Subscription (or Subscription + Consumable)
+
+**Why:** API costs scale with usage. Subscription covers baseline costs; consumable credits handle heavy users.
+
+**Tier structure:**
+```
+FREE                        PRO ($9.99/mo or $79.99/yr)
+──────────────────────────  ──────────────────────────────────
+X free queries/day          XXX queries/day
+Standard model              Advanced model access
+Basic features              All features + priority
+Text only                   Text + image + voice
+                            History + export
+                            API access (optional)
+
+EXTRA CREDITS: 100 for $1.99, 500 for $7.99
+```
+
+**Key insights:**
+- **Usage limits on free tier must feel generous** enough to hook users
+- Transparently communicate what costs money (API calls) — builds trust
+- Consider **daily reset** for free credits (not monthly — daily feels more generous)
+- **Model quality** as upsell is well-accepted (GPT-3.5 free, GPT-4 paid)
+- Monitor per-user cost carefully — heavy users can be unprofitable
+
+**Pricing range:** $6.99-19.99/mo (must cover API costs + margin)

--- a/.claude/skills/monetization/pricing-models.md
+++ b/.claude/skills/monetization/pricing-models.md
@@ -1,0 +1,248 @@
+# Pricing Models Reference
+
+Detailed comparison of monetization models for Apple platform apps.
+
+## 1. Auto-Renewable Subscriptions
+
+**How it works**: User pays recurring fee (weekly/monthly/quarterly/yearly). Apple handles billing, renewals, and cancellation.
+
+**Best for**: Apps with ongoing value — content, sync, storage, AI features, data tracking.
+
+**Pros:**
+- Predictable recurring revenue (MRR)
+- Higher lifetime value (LTV) per user
+- Apple reduces commission to 15% after Year 1
+- Built-in trial support (introductory offers)
+- Family sharing support
+- Subscription offer codes for marketing
+
+**Cons:**
+- Users increasingly wary of "subscription fatigue"
+- Higher churn — must continuously deliver value
+- More complex to implement than one-time purchase
+- Requires demonstrating ongoing value to App Review
+
+**Revenue math:**
+```
+Monthly: $4.99/mo × 1,000 subscribers = $4,990/mo
+Apple cut (15% SBP): -$748.50
+Net: $4,241.50/mo = $50,898/yr
+```
+
+**Pricing sweet spots (indie apps):**
+- Low: $2.99-4.99/mo (utility, habit tracking)
+- Mid: $6.99-9.99/mo (productivity, creative tools)
+- High: $14.99-29.99/mo (professional tools, B2B)
+
+**Subscription groups:**
+- Group related tiers (Free, Plus, Pro) in one subscription group
+- Users can upgrade/downgrade within a group
+- Only one active subscription per group
+
+---
+
+## 2. One-Time Purchase (Paid Upfront)
+
+**How it works**: User pays once to download the app. No free version.
+
+**Best for**: Complete, self-contained tools with clear value.
+
+**Pros:**
+- Simple — no ongoing obligation
+- Users prefer paying once
+- No churn management
+- Easy to implement
+
+**Cons:**
+- Revenue stops after initial download surge
+- Must acquire new users for continued revenue
+- No recurring revenue (harder to sustain development)
+- Race to the bottom on pricing
+- Harder to justify major updates without new revenue
+
+**Pricing sweet spots:**
+- Simple utility: $0.99-2.99
+- Quality tool: $4.99-9.99
+- Professional tool: $14.99-49.99
+- Niche/specialized: $49.99-99.99+
+
+**Sustainability tip:** Pair with a "Pro" IAP unlock for power features, or use paid major version upgrades (new App Store listing).
+
+---
+
+## 3. Freemium (Free + IAP Unlock)
+
+**How it works**: App is free. Core features available. Premium features unlocked via non-consumable IAP.
+
+**Best for**: Apps that need large user base, where free tier drives organic growth.
+
+**Pros:**
+- Low friction — massive download potential
+- Users try before buying
+- Word of mouth from free users
+- Non-consumable IAP = one-time revenue per user
+
+**Cons:**
+- Most users never convert (typical: 2-5%)
+- Must maintain free experience for 95%+ of users
+- Feature split is tricky to get right
+- Free users have expectations
+
+**Conversion benchmarks:**
+- Good: 3-5% free to paid
+- Great: 5-10%
+- Exceptional: 10%+ (niche apps with devoted users)
+
+**Revenue math:**
+```
+10,000 MAU × 4% conversion × $9.99 = $3,996
+Apple cut (15% SBP): -$599.40
+Net: $3,396.60 (one-time, not recurring)
+```
+
+---
+
+## 4. Consumable IAP
+
+**How it works**: Users buy consumable items (credits, tokens, virtual currency) that get used up.
+
+**Best for**: AI-powered apps (API costs), games, content generation tools.
+
+**Pros:**
+- Revenue scales with usage
+- Can offset variable costs (API fees)
+- Users self-select spending level
+- Repeated purchases = recurring-ish revenue
+
+**Cons:**
+- Complex to balance (too expensive = churn, too cheap = unprofitable)
+- Users dislike "running out"
+- Harder to predict revenue
+- Must track consumption carefully
+
+**Common patterns:**
+- Credit packs: 10 credits ($0.99), 50 ($3.99), 200 ($9.99)
+- Token bundles with bonus: Buy 100, get 20 free
+- Combined: Subscription includes X credits/month + buy more
+
+---
+
+## 5. Tip Jar / Patronage
+
+**How it works**: App is fully functional for free. Users can tip/donate to support development.
+
+**Best for**: Open-source-adjacent apps, community tools, passion projects.
+
+**Pros:**
+- Zero friction for users
+- Builds goodwill
+- Authentic relationship with users
+- No feature gating complexity
+
+**Cons:**
+- Very low conversion (< 1% typical)
+- Unpredictable revenue
+- Not sustainable as sole model for most apps
+- Apple still takes 30%/15% cut
+
+**Implementation:**
+- Non-consumable IAPs: "Buy me a coffee" ($1.99), "Supporter" ($4.99), "Patron" ($9.99)
+- Or consumable for repeat tips
+
+---
+
+## 6. Ad-Supported + Premium
+
+**How it works**: Free with ads. Pay to remove ads and unlock features.
+
+**Best for**: High-volume, casual-use apps (weather, news, simple tools).
+
+**Pros:**
+- Revenue from both free (ads) and paid users
+- Low barrier to entry
+- Ad revenue scales with DAU
+
+**Cons:**
+- Ad revenue per user is very low ($0.50-3.00 eCPM)
+- Ads degrade user experience
+- Ad SDKs add complexity and privacy concerns
+- "Remove ads" is weak premium value alone
+
+**Revenue math:**
+```
+Ad revenue: 10,000 DAU × 3 impressions × $2.00 eCPM = $60/day = $1,800/mo
+Premium upgrades: 10,000 MAU × 2% × $4.99 = $998
+Total: ~$2,800/mo
+```
+
+**Tip:** Always pair ad removal with additional premium features. "Remove ads" alone isn't compelling enough.
+
+---
+
+## Model Selection Matrix
+
+| Factor | Subscription | One-Time | Freemium | Consumable | Tip Jar | Ad + Premium |
+|--------|-------------|----------|----------|------------|---------|-------------|
+| Recurring revenue | ✅ | ❌ | ❌ | Partial | ❌ | Partial |
+| User-friendly | ⚠️ | ✅ | ✅ | ⚠️ | ✅ | ⚠️ |
+| Implementation complexity | High | Low | Medium | High | Low | Medium |
+| Scalability | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ |
+| Indie-friendly | ✅ | ✅ | ✅ | ⚠️ | ❌ | ⚠️ |
+| Works with small audience | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+
+---
+
+## Hybrid Models
+
+Many successful indie apps combine models:
+
+**Freemium + Subscription:**
+```
+Free: Basic features
+Pro Monthly ($4.99/mo): Full features
+Pro Annual ($29.99/yr): Full features, 50% savings
+Lifetime ($79.99): One-time unlock
+```
+
+**Subscription + Consumable:**
+```
+Free: 5 AI queries/day
+Pro ($9.99/mo): 100 queries/day + premium features
+Extra credits: Buy 50 for $1.99
+```
+
+**Free + Tip Jar + Premium:**
+```
+Free: Full app
+Tips: $1.99, $4.99, $9.99
+Pro ($4.99 one-time): Themes, widgets, export
+```
+
+## Pricing Localization
+
+Apple provides 87 price tiers with automatic localization. Key considerations:
+
+- **Price tier 1** ($0.99) is universal baseline
+- Higher tiers have regional variation (e.g., Tier 5 = $4.99 US, ¥800 Japan)
+- Some regions have purchasing power adjustments
+- Consider offering **lower tiers in emerging markets** via App Store pricing tools
+- Apple's "Pricing and Availability" now supports per-country pricing
+
+## When to Change Your Price
+
+**Raise prices when:**
+- You've added significant new features
+- Conversion rate is high (> 8%) — may be underpriced
+- Competitors charge more for less
+- Costs have increased (API, infrastructure)
+
+**Lower prices when:**
+- Conversion is very low (< 1%)
+- Users cite price as reason for not upgrading
+- Entering a new market
+- Running a seasonal promotion
+
+**How to test:**
+- Use introductory offers for new price points
+- A/B test with offer codes
+- Announce upcoming price increase to drive urgency

--- a/.claude/skills/swift-development/SKILL.md
+++ b/.claude/skills/swift-development/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: swift-development
+description: Swift language patterns and best practices including concurrency, performance, and modern idioms. Use for Swift language-level code review or architecture guidance.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Swift Development
+
+Swift language-level guidance that applies across all Apple platforms.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Asks about Swift concurrency (async/await, actors, Sendable, TaskGroup)
+- Needs help with Swift 6 strict concurrency migration
+- Has data race or actor isolation errors
+- Asks about **InlineArray**, **Span**, or low-level memory performance
+- Wants to eliminate heap allocations or replace unsafe pointers
+- Asks about modern Swift patterns independent of any specific platform
+
+## Available Modules
+
+### concurrency-patterns/
+Swift concurrency architecture and patterns.
+- Swift 6.2 approachable concurrency features
+- Structured concurrency (async let, TaskGroup, .task modifier)
+- Actors, isolation, reentrancy, @MainActor
+- Continuations for bridging legacy APIs
+- Swift 6 strict concurrency migration guide
+
+### memory/
+Swift 6.2 InlineArray and Span for low-level memory performance.
+- InlineArray: fixed-size, stack-allocated collections with zero heap overhead
+- Span family: safe, non-escapable access to contiguous memory
+- Lifetime dependencies and non-escapable type constraints
+- Performance guidance: when to use InlineArray/Span vs Array/UnsafePointer
+
+## How to Use
+
+1. Identify user's need from their question
+2. Read relevant module files from subdirectories
+3. Apply the guidance to their specific context
+4. Cross-reference with platform-specific skills (ios/, macos/) as needed

--- a/.claude/skills/swift-development/concurrency-patterns/SKILL.md
+++ b/.claude/skills/swift-development/concurrency-patterns/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: concurrency-patterns
+description: Swift concurrency patterns including Swift 6.2 approachable concurrency, structured concurrency, actors, continuations, and migration. Use when reviewing or building async code, fixing data race errors, or migrating to Swift 6.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Swift Concurrency Patterns
+
+Comprehensive guide for Swift concurrency covering async/await, structured concurrency, actors, and the Swift 6.2 "Approachable Concurrency" features. Focuses on patterns that prevent data races and common mistakes that cause crashes.
+
+## When This Skill Activates
+
+- User has data race errors or actor isolation compiler errors
+- User is migrating to Swift 6 strict concurrency
+- User asks about async/await, actors, Sendable, TaskGroup, or MainActor
+- User needs to bridge legacy completion-handler APIs to async/await
+- User is working with Swift 6.2 features (@concurrent, isolated conformances)
+- User has concurrency bugs (actor reentrancy, task cancellation, UI freezes)
+
+## Decision Tree
+
+```
+What concurrency problem are you solving?
+│
+├─ Swift 6 compiler errors / migration
+│  └─ migration-guide.md
+│
+├─ Swift 6.2 new features (@concurrent, isolated conformances)
+│  └─ swift62-concurrency.md
+│
+├─ Running work in parallel (async let, TaskGroup)
+│  └─ structured-concurrency.md
+│
+├─ Thread safety for shared mutable state
+│  └─ actors-and-isolation.md
+│
+├─ Bridging old APIs (delegates, callbacks) to async/await
+│  └─ continuations-bridging.md
+│
+└─ General async/await patterns
+   └─ See macos/coding-best-practices/modern-concurrency.md for basics
+```
+
+## Quick Reference
+
+| Pattern | When to Use | Reference |
+|---------|-------------|-----------|
+| `async let` | Fixed number of parallel operations | `structured-concurrency.md` |
+| `withTaskGroup` | Dynamic number of parallel operations | `structured-concurrency.md` |
+| `withDiscardingTaskGroup` | Fire-and-forget parallel operations | `structured-concurrency.md` |
+| `.task { }` modifier | Load data when view appears | `structured-concurrency.md` |
+| `.task(id:)` modifier | Re-load when a value changes | `structured-concurrency.md` |
+| `actor` | Shared mutable state protection | `actors-and-isolation.md` |
+| `@MainActor` | UI-bound state and updates | `actors-and-isolation.md` |
+| `@concurrent` | Explicitly offload to background (6.2) | `swift62-concurrency.md` |
+| Isolated conformances | `@MainActor` type conforming to protocol (6.2) | `swift62-concurrency.md` |
+| `withCheckedContinuation` | Bridge callback API to async | `continuations-bridging.md` |
+| `AsyncStream` | Bridge delegate/notification API to async sequence | `continuations-bridging.md` |
+| Strict concurrency migration | Incremental Swift 6 adoption | `migration-guide.md` |
+
+## Process
+
+### 1. Identify the Problem
+
+Read the user's code or error messages to determine:
+- Is this a compiler error (strict concurrency) or a runtime issue (data race, crash)?
+- What Swift version and concurrency checking level are they using?
+- Are they migrating existing code or writing new code?
+
+### 2. Load Relevant Reference Files
+
+Based on the problem, read from this directory:
+- `swift62-concurrency.md` — Swift 6.2 approachable concurrency features
+- `structured-concurrency.md` — async let, TaskGroup, .task modifier lifecycle
+- `actors-and-isolation.md` — Actor patterns, reentrancy, @MainActor, Sendable
+- `continuations-bridging.md` — withCheckedContinuation, AsyncStream, legacy bridging
+- `migration-guide.md` — Incremental Swift 6 strict concurrency adoption
+
+### 3. Review Checklist
+
+- [ ] No blocking calls on `@MainActor` (use `await` for long operations)
+- [ ] Shared mutable state protected by an actor (not locks or DispatchQueue)
+- [ ] `Sendable` conformance correct for types crossing isolation boundaries
+- [ ] Task cancellation handled (check `Task.isCancelled` or `Task.checkCancellation()`)
+- [ ] No unstructured `Task {}` where structured concurrency (`.task`, `TaskGroup`) would work
+- [ ] Actor reentrancy considered at suspension points
+- [ ] `withCheckedContinuation` called exactly once (not zero, not twice)
+- [ ] `.task(id:)` used instead of manual `onChange` + cancel patterns
+
+### 4. Cross-Reference
+
+- For **async/await basics and actor fundamentals**, see `macos/coding-best-practices/modern-concurrency.md`
+- For **networking concurrency patterns**, see `generators/networking-layer/networking-patterns.md`
+- For **SwiftData concurrency** (@ModelActor), see `macos/swiftdata-architecture/repository-pattern.md`
+- For **auth token refresh with actors**, see `generators/auth-flow/auth-patterns.md`
+
+## References
+
+- [Swift Concurrency](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/)
+- [Migrating to Swift 6](https://www.swift.org/migration/documentation/migrationguide/)
+- Apple doc: `/Users/ravishankar/Downloads/docs/Swift-Concurrency-Updates.md`

--- a/.claude/skills/swift-development/concurrency-patterns/actors-and-isolation.md
+++ b/.claude/skills/swift-development/concurrency-patterns/actors-and-isolation.md
@@ -1,0 +1,369 @@
+# Actors and Isolation
+
+Actors serialize access to mutable state, preventing data races at compile time. This file covers actor patterns, reentrancy pitfalls, `@MainActor`, `Sendable`, and isolation boundaries.
+
+## Actor Basics
+
+```swift
+actor ImageCache {
+    private var cache: [URL: UIImage] = [:]
+
+    func image(for url: URL) -> UIImage? {
+        cache[url]
+    }
+
+    func store(_ image: UIImage, for url: URL) {
+        cache[url] = image
+    }
+
+    func clear() {
+        cache.removeAll()
+    }
+}
+
+// All access is through await:
+let cache = ImageCache()
+await cache.store(image, for: url)
+let cached = await cache.image(for: url)
+```
+
+### nonisolated Members
+
+Functions that don't access mutable state can be `nonisolated` to skip the await:
+
+```swift
+actor UserStore {
+    let id: UUID                    // let is implicitly nonisolated
+    private var users: [User] = []
+
+    nonisolated var storeIdentifier: String {
+        id.uuidString               // Only accesses let property — safe
+    }
+
+    func addUser(_ user: User) {    // Isolated — requires await
+        users.append(user)
+    }
+}
+
+let store = UserStore()
+let id = store.storeIdentifier     // No await needed
+await store.addUser(user)          // await required
+```
+
+## Actor Reentrancy
+
+Actors are reentrant: when an actor method hits an `await` suspension point, other callers can execute on the same actor. This means state can change across `await` points.
+
+```swift
+// ❌ Bug — actor reentrancy
+actor BankAccount {
+    var balance: Int = 1000
+
+    func withdraw(amount: Int) async -> Bool {
+        guard balance >= amount else { return false }
+        // ⚠️ SUSPENSION POINT — another caller can run here
+        await logTransaction(amount)
+        // balance may have changed! Another withdraw could have run.
+        balance -= amount  // Could go negative!
+        return true
+    }
+}
+```
+
+### Fixing Reentrancy
+
+**Pattern 1: Read and write state before the suspension point**
+
+```swift
+// ✅ Capture state before await
+actor BankAccount {
+    var balance: Int = 1000
+
+    func withdraw(amount: Int) async -> Bool {
+        guard balance >= amount else { return false }
+        balance -= amount          // Modify BEFORE the await
+        await logTransaction(amount) // Now it's safe
+        return true
+    }
+}
+```
+
+**Pattern 2: Re-check state after the suspension point**
+
+```swift
+// ✅ Re-validate after await
+actor BankAccount {
+    var balance: Int = 1000
+
+    func withdraw(amount: Int) async -> Bool {
+        guard balance >= amount else { return false }
+        await logTransaction(amount)
+        // Re-check after suspension
+        guard balance >= amount else {
+            await reverseTransaction(amount)
+            return false
+        }
+        balance -= amount
+        return true
+    }
+}
+```
+
+**Pattern 3: Use a synchronous method for the critical section**
+
+```swift
+// ✅ No suspension point in the critical path
+actor BankAccount {
+    var balance: Int = 1000
+
+    // Synchronous — no reentrancy possible
+    func withdraw(amount: Int) -> Bool {
+        guard balance >= amount else { return false }
+        balance -= amount
+        return true
+    }
+
+    // Logging is separate, after the state change
+    func withdrawAndLog(amount: Int) async -> Bool {
+        let success = withdraw(amount: amount)
+        if success {
+            await logTransaction(amount)
+        }
+        return success
+    }
+}
+```
+
+## @MainActor
+
+Marks code that must run on the main thread. Use for all UI-related state and updates.
+
+### On Types
+
+```swift
+@MainActor
+@Observable
+final class ItemListViewModel {
+    var items: [Item] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    func loadItems() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            items = try await itemService.fetchAll()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+```
+
+### On Functions
+
+```swift
+class DataProcessor {
+    @MainActor
+    func updateUI(with result: ProcessingResult) {
+        // Guaranteed to run on main thread
+    }
+
+    nonisolated func processInBackground(data: Data) async -> ProcessingResult {
+        // Runs on any thread
+        ...
+    }
+}
+```
+
+### MainActor.run
+
+For one-off main thread execution from a non-main context:
+
+```swift
+func processData() async {
+    let result = await heavyComputation()
+    await MainActor.run {
+        self.displayResult = result
+    }
+}
+```
+
+Prefer `@MainActor` on the type/method over `MainActor.run` — it's more declarative and catches errors at compile time.
+
+## Sendable
+
+Types that can safely cross isolation boundaries (between actors, between threads).
+
+### Automatically Sendable
+
+- Value types (structs, enums) with all Sendable properties
+- Actors (always Sendable)
+- Immutable classes (`final class` with only `let` properties)
+
+### Explicit Sendable
+
+```swift
+// ✅ Value type with Sendable properties — automatically Sendable
+struct UserProfile: Sendable {
+    let id: UUID
+    let name: String
+    let email: String
+}
+
+// ✅ Immutable final class
+final class AppConfig: Sendable {
+    let apiURL: URL
+    let timeout: TimeInterval
+}
+```
+
+### @unchecked Sendable
+
+For types you guarantee are thread-safe through external mechanisms (locks, queues):
+
+```swift
+// ⚠️ Use only when you can prove thread safety
+final class ThreadSafeCache<Key: Hashable & Sendable, Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Key: Value] = [:]
+
+    func value(for key: Key) -> Value? {
+        lock.withLock { storage[key] }
+    }
+
+    func store(_ value: Value, for key: Key) {
+        lock.withLock { storage[key] = value }
+    }
+}
+```
+
+Prefer actors over `@unchecked Sendable` + locks. Use `@unchecked Sendable` only for performance-critical paths or bridging with legacy code.
+
+### @Sendable Closures
+
+Closures that cross isolation boundaries must be `@Sendable`:
+
+```swift
+// TaskGroup requires @Sendable closures
+await withTaskGroup(of: Void.self) { group in
+    group.addTask { @Sendable in
+        await processItem(item)  // Closure must be @Sendable
+    }
+}
+```
+
+Most closure parameters in the concurrency APIs are already marked `@Sendable`. You typically only need the annotation when the compiler can't infer it.
+
+## Isolation Boundaries in Practice
+
+### Sending Values Between Actors
+
+```swift
+actor DataStore {
+    func save(_ item: Item) { ... }
+}
+
+@MainActor
+class ViewModel {
+    let store = DataStore()
+
+    func saveItem(_ item: Item) async {
+        // item crosses from MainActor to DataStore actor
+        // item must be Sendable
+        await store.save(item)
+    }
+}
+```
+
+### Non-Sendable Types at Boundaries
+
+```swift
+// ❌ NSMutableArray is not Sendable
+actor Processor {
+    func process(_ array: NSMutableArray) { }  // Compiler error
+}
+
+// ✅ Convert to Sendable type at the boundary
+actor Processor {
+    func process(_ items: [Item]) { }  // [Item] is Sendable if Item is
+}
+```
+
+## Common Mistakes
+
+### Assuming Actors Are Like Locks
+
+```swift
+// ❌ Wrong mental model — actor is not a lock, it's a mailbox
+actor Counter {
+    var count = 0
+
+    func incrementTwice() async {
+        count += 1
+        await someAsyncWork()  // Other callers can run here!
+        count += 1             // count may have been modified
+    }
+}
+
+// ✅ Correct mental model — avoid await between state mutations
+actor Counter {
+    var count = 0
+
+    func incrementTwice() {  // Synchronous — no interleaving
+        count += 2
+    }
+}
+```
+
+### @MainActor with Heavy Computation
+
+```swift
+// ❌ Blocks the main thread — UI freezes
+@MainActor
+func processImages(_ images: [Data]) -> [UIImage] {
+    images.map { heavyProcessing($0) }  // Synchronous heavy work on main thread
+}
+
+// ✅ Offload to background, return to main actor
+@MainActor
+func processImages(_ images: [Data]) async -> [UIImage] {
+    await withTaskGroup(of: UIImage.self) { group in
+        for data in images {
+            group.addTask { @Sendable in
+                heavyProcessing(data)  // Runs on concurrent thread pool
+            }
+        }
+        var results: [UIImage] = []
+        for await image in group {
+            results.append(image)
+        }
+        return results
+    }
+}
+```
+
+### Using @unchecked Sendable to Silence Warnings
+
+```swift
+// ❌ Dangerous — silences compiler but doesn't fix the data race
+class UnsafeCache: @unchecked Sendable {
+    var items: [String: Any] = [:]  // No synchronization!
+}
+
+// ✅ Use an actor instead
+actor SafeCache {
+    var items: [String: Any] = [:]
+}
+```
+
+## Checklist
+
+- [ ] Shared mutable state protected by actors (not locks or DispatchQueue)
+- [ ] Actor reentrancy considered — state mutations before `await` points
+- [ ] `@MainActor` on all UI-bound types (ViewModels, UI state)
+- [ ] `Sendable` conformance on types that cross isolation boundaries
+- [ ] `@unchecked Sendable` used only with proven synchronization, never to silence warnings
+- [ ] No heavy synchronous work on `@MainActor`
+- [ ] `nonisolated` on actor methods that don't access mutable state
+- [ ] Prefer `@MainActor` annotation over `MainActor.run` for clarity

--- a/.claude/skills/swift-development/concurrency-patterns/continuations-bridging.md
+++ b/.claude/skills/swift-development/concurrency-patterns/continuations-bridging.md
@@ -1,0 +1,347 @@
+# Continuations and Bridging
+
+Patterns for wrapping legacy callback-based, delegate-based, and notification-based APIs into async/await.
+
+## withCheckedContinuation
+
+Wraps a single-callback API into an async function:
+
+```swift
+func currentLocation() async -> CLLocation {
+    await withCheckedContinuation { continuation in
+        locationManager.requestLocation { location in
+            continuation.resume(returning: location)
+        }
+    }
+}
+```
+
+### Throwing Variant
+
+```swift
+func fetchImage(named name: String) async throws -> UIImage {
+    try await withCheckedThrowingContinuation { continuation in
+        imageLoader.load(name: name) { result in
+            switch result {
+            case .success(let image):
+                continuation.resume(returning: image)
+            case .failure(let error):
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+```
+
+### The "Exactly Once" Rule
+
+A continuation must be resumed **exactly once**. Resuming zero times leaks the task forever. Resuming twice crashes.
+
+```swift
+// ❌ Bug — continuation never resumed on timeout
+func fetchWithTimeout() async throws -> Data {
+    try await withCheckedThrowingContinuation { continuation in
+        apiClient.fetch { data in
+            continuation.resume(returning: data)
+        }
+        // If timeout fires and callback never fires → leaked forever
+    }
+}
+
+// ❌ Bug — continuation resumed twice
+func fetchData() async throws -> Data {
+    try await withCheckedThrowingContinuation { continuation in
+        apiClient.fetch { result in
+            switch result {
+            case .success(let data):
+                continuation.resume(returning: data)
+            case .failure(let error):
+                continuation.resume(throwing: error)
+            }
+        }
+        // What if the callback fires twice? Second resume → crash
+    }
+}
+```
+
+**Fix: Guard with a flag or use the callback structure carefully:**
+
+```swift
+// ✅ Ensure exactly one resume
+func fetchData() async throws -> Data {
+    try await withCheckedThrowingContinuation { continuation in
+        var hasResumed = false
+
+        apiClient.fetch { result in
+            guard !hasResumed else { return }
+            hasResumed = true
+
+            switch result {
+            case .success(let data):
+                continuation.resume(returning: data)
+            case .failure(let error):
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+```
+
+### Checked vs Unsafe Continuations
+
+| Type | Debug Behavior | Release Behavior | Use When |
+|------|---------------|-----------------|----------|
+| `withCheckedContinuation` | Traps on misuse (zero or double resume) | Traps on misuse | Default choice, always start here |
+| `withUnsafeContinuation` | No checking | No checking | Performance-critical hot paths only |
+
+Always use `withCheckedContinuation` unless profiling shows the check is a bottleneck. The checked variant catches bugs that are extremely hard to debug otherwise.
+
+## Bridging Delegate APIs
+
+Many Apple APIs use delegates (CLLocationManager, ASAuthorizationController, etc.). Bridge them with a continuation-holding helper:
+
+```swift
+class LocationFetcher: NSObject, CLLocationManagerDelegate {
+    private var continuation: CheckedContinuation<CLLocation, Error>?
+    private let manager = CLLocationManager()
+
+    override init() {
+        super.init()
+        manager.delegate = self
+    }
+
+    func requestLocation() async throws -> CLLocation {
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            manager.requestLocation()
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        continuation?.resume(returning: locations.last!)
+        continuation = nil
+    }
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+}
+
+// Usage:
+let fetcher = LocationFetcher()
+let location = try await fetcher.requestLocation()
+```
+
+### Sign in with Apple
+
+```swift
+class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDelegate {
+    private var continuation: CheckedContinuation<ASAuthorization, Error>?
+
+    func signIn() async throws -> ASAuthorization {
+        let provider = ASAuthorizationAppleIDProvider()
+        let request = provider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            controller.performRequests()
+        }
+    }
+
+    func authorizationController(controller: ASAuthorizationController,
+                                  didCompleteWithAuthorization authorization: ASAuthorization) {
+        continuation?.resume(returning: authorization)
+        continuation = nil
+    }
+
+    func authorizationController(controller: ASAuthorizationController,
+                                  didCompleteWithError error: Error) {
+        continuation?.resume(throwing: error)
+        continuation = nil
+    }
+}
+```
+
+## AsyncStream — Bridging Multi-Value Sources
+
+For APIs that produce multiple values over time (delegates, NotificationCenter, KVO), use `AsyncStream`:
+
+### NotificationCenter
+
+```swift
+extension NotificationCenter {
+    func notifications(named name: Notification.Name) -> AsyncStream<Notification> {
+        AsyncStream { continuation in
+            let observer = addObserver(forName: name, object: nil, queue: nil) { notification in
+                continuation.yield(notification)
+            }
+            continuation.onTermination = { @Sendable _ in
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+    }
+}
+
+// Usage:
+for await notification in NotificationCenter.default.notifications(named: .NSManagedObjectContextDidSave) {
+    await handleSave(notification)
+}
+```
+
+### CLLocationManager Continuous Updates
+
+```swift
+class LocationStream: NSObject, CLLocationManagerDelegate {
+    private var continuation: AsyncStream<CLLocation>.Continuation?
+    private let manager = CLLocationManager()
+
+    func locations() -> AsyncStream<CLLocation> {
+        AsyncStream { continuation in
+            self.continuation = continuation
+            continuation.onTermination = { @Sendable [weak self] _ in
+                self?.manager.stopUpdatingLocation()
+            }
+            manager.delegate = self
+            manager.startUpdatingLocation()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        for location in locations {
+            continuation?.yield(location)
+        }
+    }
+}
+
+// Usage:
+for await location in locationStream.locations() {
+    updateMap(with: location)
+}
+```
+
+### AsyncStream with Buffering
+
+```swift
+AsyncStream(bufferingPolicy: .bufferingNewest(10)) { continuation in
+    // Keeps only the 10 most recent values if consumer is slow
+    eventSource.onEvent = { event in
+        continuation.yield(event)
+    }
+}
+```
+
+Buffering policies:
+| Policy | Behavior |
+|--------|----------|
+| `.unbounded` | Buffer everything (default, can grow unbounded) |
+| `.bufferingNewest(N)` | Keep only the N most recent values |
+| `.bufferingOldest(N)` | Keep only the N oldest values, drop new ones |
+
+## AsyncThrowingStream
+
+For streams that can also produce errors:
+
+```swift
+func eventStream() -> AsyncThrowingStream<Event, Error> {
+    AsyncThrowingStream { continuation in
+        websocket.onMessage = { message in
+            continuation.yield(message)
+        }
+        websocket.onError = { error in
+            continuation.finish(throwing: error)
+        }
+        websocket.onClose = {
+            continuation.finish()
+        }
+    }
+}
+
+// Usage:
+do {
+    for try await event in eventStream() {
+        handle(event)
+    }
+} catch {
+    handleDisconnection(error)
+}
+```
+
+## Common Mistakes
+
+### Forgetting onTermination Cleanup
+
+```swift
+// ❌ Resource leak — observer never removed
+AsyncStream<Notification> { continuation in
+    let observer = NotificationCenter.default.addObserver(...)
+    // No cleanup when stream is cancelled
+}
+
+// ✅ Clean up on termination
+AsyncStream<Notification> { continuation in
+    let observer = NotificationCenter.default.addObserver(...)
+    continuation.onTermination = { @Sendable _ in
+        NotificationCenter.default.removeObserver(observer)
+    }
+}
+```
+
+### Capturing Self Strongly in Continuation
+
+```swift
+// ❌ Retain cycle — continuation holds self, self holds continuation
+class StreamProvider {
+    var continuation: AsyncStream<Event>.Continuation?
+
+    func events() -> AsyncStream<Event> {
+        AsyncStream { continuation in
+            self.continuation = continuation  // Strong reference cycle
+        }
+    }
+}
+
+// ✅ Use weak self in onTermination, nil out continuation
+continuation.onTermination = { @Sendable [weak self] _ in
+    self?.continuation = nil
+}
+```
+
+### Using AsyncStream for Single Values
+
+```swift
+// ❌ Overkill — AsyncStream for a one-shot result
+func fetchUser() -> AsyncStream<User> {
+    AsyncStream { continuation in
+        api.getUser { user in
+            continuation.yield(user)
+            continuation.finish()
+        }
+    }
+}
+
+// ✅ Use withCheckedContinuation for single values
+func fetchUser() async -> User {
+    await withCheckedContinuation { continuation in
+        api.getUser { user in
+            continuation.resume(returning: user)
+        }
+    }
+}
+```
+
+## Checklist
+
+- [ ] Using `withCheckedContinuation` (not unsafe) unless profiling demands it
+- [ ] Continuation resumed exactly once in all code paths
+- [ ] `continuation = nil` after resuming to prevent double-resume
+- [ ] `onTermination` handler cleans up resources (observers, delegates, timers)
+- [ ] `AsyncStream` for multi-value sources, `withCheckedContinuation` for single-value
+- [ ] Appropriate buffering policy chosen for `AsyncStream`
+- [ ] No strong reference cycles between continuation holder and stream provider

--- a/.claude/skills/swift-development/concurrency-patterns/migration-guide.md
+++ b/.claude/skills/swift-development/concurrency-patterns/migration-guide.md
@@ -1,0 +1,291 @@
+# Swift 6 Strict Concurrency Migration
+
+Step-by-step guide for incrementally adopting Swift 6 strict concurrency checking. Covers the migration path from Swift 5 to Swift 6.2.
+
+## Migration Strategy
+
+Adopt strict concurrency incrementally, not all at once:
+
+```
+Swift 5 mode          → Swift 6 language mode
+(no checking)           (strict checking)
+
+Step 1: minimal        Warnings for clearly unsafe patterns
+Step 2: targeted       Warnings for code interacting with concurrent features
+Step 3: complete       Warnings for ALL concurrency violations
+Step 4: Swift 6 mode   Warnings become errors
+Step 5: Swift 6.2      Enable "infer main actor" for even cleaner code
+```
+
+## Step 1: Enable Minimal Checking
+
+Start with minimal concurrency warnings to find the most obvious issues.
+
+**Xcode:** Build Settings → "Strict Concurrency Checking" → "Minimal"
+
+**Package.swift:**
+```swift
+.target(
+    name: "MyTarget",
+    swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=minimal")
+    ]
+)
+```
+
+Fix issues like:
+- Global/static `var` without isolation
+- Non-Sendable types used in `@Sendable` closures
+
+## Step 2: Enable Targeted Checking
+
+**Xcode:** Build Settings → "Strict Concurrency Checking" → "Targeted"
+
+This warns about code that interacts with concurrency features (async functions, actors, Task).
+
+## Step 3: Enable Complete Checking
+
+**Xcode:** Build Settings → "Strict Concurrency Checking" → "Complete"
+
+**Package.swift:**
+```swift
+.target(
+    name: "MyTarget",
+    swiftSettings: [
+        .enableExperimentalFeature("StrictConcurrency=complete")
+    ]
+)
+```
+
+All concurrency violations now produce warnings. Fix them all before proceeding.
+
+## Step 4: Switch to Swift 6 Language Mode
+
+Now promote all warnings to errors:
+
+**Xcode:** Build Settings → "Swift Language Version" → "6"
+
+**Package.swift:**
+```swift
+// swift-tools-version: 6.0
+let package = Package(
+    name: "MyPackage",
+    ...
+)
+```
+
+## Step 5: Adopt Swift 6.2 Features (Optional)
+
+Enable "infer main actor by default" for app targets to eliminate remaining annotations:
+
+**Xcode:** Build Settings → "Default Actor Isolation" → "MainActor"
+
+See `swift62-concurrency.md` for details.
+
+## Common Migration Patterns
+
+### Global / Static Variables
+
+```swift
+// ❌ Swift 6 error: Static property is not concurrency-safe
+class AppConfig {
+    static var shared = AppConfig()
+    var apiKey: String = ""
+}
+```
+
+**Fix options:**
+
+```swift
+// Option 1: Make it @MainActor (simplest for app code)
+@MainActor
+class AppConfig {
+    static let shared = AppConfig()
+    var apiKey: String = ""
+}
+
+// Option 2: Make it an actor
+actor AppConfig {
+    static let shared = AppConfig()
+    var apiKey: String = ""
+}
+
+// Option 3: Make it Sendable + immutable
+final class AppConfig: Sendable {
+    static let shared = AppConfig()
+    let apiKey: String = "..."  // Must be let, not var
+}
+
+// Option 4: nonisolated(unsafe) — last resort
+nonisolated(unsafe) static var shared = AppConfig()
+```
+
+### Non-Sendable Closures
+
+```swift
+// ❌ Closure captures non-Sendable type
+let viewModel = MyViewModel()  // Not Sendable
+Task {
+    await viewModel.load()  // Sending non-Sendable across isolation
+}
+```
+
+**Fix options:**
+
+```swift
+// Option 1: Make the type Sendable
+final class MyViewModel: Sendable { ... }
+
+// Option 2: Make it @MainActor (if it's a ViewModel)
+@MainActor
+final class MyViewModel { ... }
+
+// Option 3: Use the type within its own isolation
+@MainActor
+func loadData() async {
+    let viewModel = MyViewModel()  // Created on MainActor
+    await viewModel.load()         // Stays on MainActor
+}
+```
+
+### Protocol Conformances
+
+```swift
+// ❌ Swift 6 error: @MainActor type can't conform to non-isolated protocol
+protocol DataProvider {
+    func fetchData() async -> [Item]
+}
+
+@MainActor
+class ItemProvider: DataProvider {
+    func fetchData() async -> [Item] { ... }  // Error
+}
+```
+
+**Fix with Swift 6.2 isolated conformance:**
+
+```swift
+// ✅ Swift 6.2: Isolated conformance
+extension ItemProvider: @MainActor DataProvider {
+    func fetchData() async -> [Item] { ... }
+}
+```
+
+**Fix for Swift 6.0/6.1:**
+
+```swift
+// ✅ Make the protocol method nonisolated
+extension ItemProvider: DataProvider {
+    nonisolated func fetchData() async -> [Item] {
+        await MainActor.run { ... }
+    }
+}
+```
+
+### Imported C / Objective-C Types
+
+Many imported types are not annotated for concurrency. Use `@preconcurrency` to suppress warnings:
+
+```swift
+// ❌ Warning: Type from ObjC module is not Sendable
+import CoreLocation
+
+// ✅ Suppress warnings for imported module
+@preconcurrency import CoreLocation
+```
+
+`@preconcurrency` silences Sendable warnings for types from that module. Remove it once the module adds Sendable annotations.
+
+### Delegate Patterns
+
+```swift
+// ❌ Delegate callback crosses isolation
+class LocationService: NSObject, CLLocationManagerDelegate {
+    @MainActor var lastLocation: CLLocation?
+
+    func locationManager(_ manager: CLLocationManager,
+                          didUpdateLocations locations: [CLLocation]) {
+        // Error: mutating @MainActor property from non-isolated context
+        lastLocation = locations.last
+    }
+}
+```
+
+**Fix:**
+
+```swift
+// ✅ Dispatch to MainActor
+func locationManager(_ manager: CLLocationManager,
+                      didUpdateLocations locations: [CLLocation]) {
+    let location = locations.last
+    Task { @MainActor in
+        lastLocation = location
+    }
+}
+```
+
+### Notification Observers
+
+```swift
+// ❌ Closure may run on any thread
+NotificationCenter.default.addObserver(
+    forName: .someNotification, object: nil, queue: nil
+) { notification in
+    self.handleNotification(notification)  // May cross isolation
+}
+
+// ✅ Specify main queue, or bridge to AsyncSequence
+NotificationCenter.default.addObserver(
+    forName: .someNotification, object: nil, queue: .main
+) { notification in
+    self.handleNotification(notification)  // Runs on main thread
+}
+
+// ✅ Or use async notification stream
+for await notification in NotificationCenter.default.notifications(named: .someNotification) {
+    await handleNotification(notification)
+}
+```
+
+## nonisolated(unsafe) — Last Resort
+
+For code that you know is safe but can't prove to the compiler:
+
+```swift
+// Only use when you've exhausted all other options
+nonisolated(unsafe) static var shared = LegacyManager()
+```
+
+**When it's acceptable:**
+- Bridging with C/ObjC singletons that are known thread-safe
+- Third-party library types that are thread-safe but not Sendable-annotated
+- Temporary escape hatch during incremental migration
+
+**When it's NOT acceptable:**
+- To silence warnings you don't understand
+- For mutable state without synchronization
+- As a permanent solution (always plan to remove it)
+
+## Module-by-Module Migration
+
+For large projects, migrate one module at a time:
+
+1. Start with leaf modules (no dependencies on other project modules)
+2. Enable "complete" checking on that module
+3. Fix all warnings
+4. Move to the next module up the dependency chain
+5. Once all modules pass, switch to Swift 6 language mode
+
+This prevents a flood of errors across the entire project.
+
+## Checklist
+
+- [ ] Started with "minimal" checking, progressed to "complete"
+- [ ] All global/static `var` either `@MainActor`, actor-isolated, or immutable
+- [ ] Non-Sendable types not crossing isolation boundaries
+- [ ] `@preconcurrency import` used for unannoted third-party modules
+- [ ] No `nonisolated(unsafe)` without a comment explaining why it's safe
+- [ ] Protocol conformances using isolated conformances (6.2) or `nonisolated` workarounds
+- [ ] Delegate callbacks dispatched to correct isolation context
+- [ ] Migration done module-by-module for large projects
+- [ ] Swift 6 language mode enabled after all warnings resolved

--- a/.claude/skills/swift-development/concurrency-patterns/structured-concurrency.md
+++ b/.claude/skills/swift-development/concurrency-patterns/structured-concurrency.md
@@ -1,0 +1,389 @@
+# Structured Concurrency
+
+Patterns for running concurrent work with automatic cancellation and scoped lifetimes. Prefer structured concurrency over unstructured `Task {}` whenever possible.
+
+## async let — Fixed Parallel Operations
+
+Run a known number of operations concurrently:
+
+```swift
+func loadDashboard() async throws -> Dashboard {
+    async let user = fetchUser()
+    async let posts = fetchPosts()
+    async let notifications = fetchNotifications()
+
+    // All three run concurrently. Await collects results.
+    return try await Dashboard(
+        user: user,
+        posts: posts,
+        notifications: notifications
+    )
+}
+```
+
+**Key properties:**
+- Child tasks start immediately when `async let` is evaluated
+- Results are awaited where they are used
+- If the enclosing scope exits early (error thrown), pending tasks are automatically cancelled
+- If one `async let` throws, the others are cancelled
+
+### async let vs TaskGroup
+
+| Feature | `async let` | `TaskGroup` |
+|---------|------------|-------------|
+| Number of tasks | Fixed, known at compile time | Dynamic, determined at runtime |
+| Return types | Can be different per binding | Must be the same (or use enum) |
+| Syntax | Simple variable bindings | Closure with `group.addTask` |
+| Use when | 2-5 parallel calls with different types | Processing a collection in parallel |
+
+```swift
+// ✅ async let — different return types, fixed count
+async let user = fetchUser()        // -> User
+async let settings = fetchSettings() // -> Settings
+
+// ✅ TaskGroup — same return type, dynamic count
+let images = try await withThrowingTaskGroup(of: UIImage.self) { group in
+    for url in imageURLs {
+        group.addTask { try await downloadImage(url) }
+    }
+    var results: [UIImage] = []
+    for try await image in group {
+        results.append(image)
+    }
+    return results
+}
+```
+
+## TaskGroup — Dynamic Parallel Operations
+
+### Collecting Results
+
+```swift
+func fetchAllItems(ids: [UUID]) async throws -> [Item] {
+    try await withThrowingTaskGroup(of: Item.self) { group in
+        for id in ids {
+            group.addTask {
+                try await fetchItem(id: id)
+            }
+        }
+
+        var items: [Item] = []
+        for try await item in group {
+            items.append(item)
+        }
+        return items
+    }
+}
+```
+
+### Limiting Concurrency
+
+Prevent overwhelming the system with too many parallel tasks:
+
+```swift
+func downloadImages(urls: [URL]) async throws -> [UIImage] {
+    try await withThrowingTaskGroup(of: UIImage.self) { group in
+        let maxConcurrent = 4
+        var index = 0
+        var results: [UIImage] = []
+
+        // Start initial batch
+        for _ in 0..<min(maxConcurrent, urls.count) {
+            group.addTask { try await self.downloadImage(urls[index]) }
+            index += 1
+        }
+
+        // As each completes, start the next
+        for try await image in group {
+            results.append(image)
+            if index < urls.count {
+                group.addTask { try await self.downloadImage(urls[index]) }
+                index += 1
+            }
+        }
+
+        return results
+    }
+}
+```
+
+### DiscardingTaskGroup (Swift 5.9+)
+
+For fire-and-forget child tasks where you don't need to collect results. More memory-efficient because completed child task values are discarded immediately.
+
+```swift
+// ✅ Discarding — good for side effects (logging, notifications, cache warming)
+await withDiscardingTaskGroup { group in
+    for item in items {
+        group.addTask {
+            await cacheService.warm(item)
+        }
+    }
+    // No iteration needed — results are discarded
+}
+
+// ❌ Don't use regular TaskGroup if you ignore results — leaks memory
+await withTaskGroup(of: Void.self) { group in
+    for item in items {
+        group.addTask { await cacheService.warm(item) }
+    }
+    // Must iterate even for Void: for await _ in group { }
+    // Or results accumulate in memory
+}
+```
+
+Use `withThrowingDiscardingTaskGroup` if child tasks can throw.
+
+## .task Modifier — SwiftUI View Lifecycle
+
+### Basic .task
+
+```swift
+struct ItemListView: View {
+    @State private var items: [Item] = []
+
+    var body: some View {
+        List(items) { item in
+            ItemRow(item: item)
+        }
+        .task {
+            // Runs when view appears
+            // Automatically cancelled when view disappears
+            items = await fetchItems()
+        }
+    }
+}
+```
+
+**Key properties:**
+- Starts an async task when the view appears
+- Automatically cancels the task when the view disappears
+- The task inherits the view's actor isolation (usually `@MainActor`)
+
+### .task(id:) — Re-run on Value Change
+
+```swift
+struct ItemDetailView: View {
+    let itemID: UUID
+    @State private var item: Item?
+
+    var body: some View {
+        Group {
+            if let item {
+                ItemContent(item: item)
+            } else {
+                ProgressView()
+            }
+        }
+        .task(id: itemID) {
+            // Runs when view appears AND when itemID changes
+            // Previous task is cancelled before new one starts
+            item = await fetchItem(id: itemID)
+        }
+    }
+}
+```
+
+**Why use `.task(id:)` over `.onChange` + manual Task?**
+
+```swift
+// ❌ Manual pattern — error-prone, must handle cancellation yourself
+@State private var loadTask: Task<Void, Never>?
+
+.onChange(of: itemID) { _, newID in
+    loadTask?.cancel()
+    loadTask = Task {
+        item = await fetchItem(id: newID)
+    }
+}
+
+// ✅ .task(id:) handles cancellation automatically
+.task(id: itemID) {
+    item = await fetchItem(id: itemID)
+}
+```
+
+### .task vs Task {} in .onAppear
+
+```swift
+// ❌ Unstructured task — not cancelled when view disappears
+.onAppear {
+    Task {
+        items = await fetchItems()  // May complete after view is gone
+    }
+}
+
+// ✅ Structured — automatically cancelled on disappear
+.task {
+    items = await fetchItems()
+}
+```
+
+The `.onAppear` + `Task {}` pattern creates an unstructured task that outlives the view. If the view disappears quickly (e.g., fast tab switching), the task keeps running and may update `@State` on a deallocated view.
+
+## Task Cancellation
+
+### Checking Cancellation
+
+```swift
+func processLargeDataset(_ items: [Item]) async throws -> [ProcessedItem] {
+    var results: [ProcessedItem] = []
+    for item in items {
+        // Check before each expensive operation
+        try Task.checkCancellation()  // Throws CancellationError if cancelled
+        results.append(await processItem(item))
+    }
+    return results
+}
+```
+
+### Cooperative Cancellation in Loops
+
+```swift
+func processItems(_ items: [Item]) async -> [ProcessedItem] {
+    var results: [ProcessedItem] = []
+    for item in items {
+        guard !Task.isCancelled else { break }  // Non-throwing check
+        results.append(await processItem(item))
+    }
+    return results
+}
+```
+
+### withTaskCancellationHandler
+
+For proactive cleanup when a task is cancelled (e.g., aborting a network request):
+
+```swift
+func downloadFile(from url: URL) async throws -> Data {
+    let request = URLRequest(url: url)
+    let (data, _) = try await withTaskCancellationHandler {
+        try await URLSession.shared.data(for: request)
+    } onCancel: {
+        // Called immediately when the task is cancelled
+        // Runs on an arbitrary thread — must be Sendable-safe
+        URLSession.shared.getAllTasks { tasks in
+            tasks.filter { $0.originalRequest?.url == url }.forEach { $0.cancel() }
+        }
+    }
+    return data
+}
+```
+
+### Task.yield()
+
+Cooperatively yield execution in CPU-heavy loops to let other tasks run:
+
+```swift
+func processHugeArray(_ items: [Item]) async -> [ProcessedItem] {
+    var results: [ProcessedItem] = []
+    for (index, item) in items.enumerated() {
+        results.append(process(item))
+        if index.isMultiple(of: 100) {
+            await Task.yield()  // Let other tasks run every 100 items
+        }
+    }
+    return results
+}
+```
+
+## Task Priorities
+
+```swift
+Task(priority: .userInitiated) { await loadVisibleContent() }
+Task(priority: .background) { await prefetchNextPage() }
+Task(priority: .low) { await updateSearchIndex() }
+```
+
+### Priority Escalation
+
+If a high-priority task awaits a low-priority task, the low-priority task's priority is escalated:
+
+```swift
+let backgroundTask = Task(priority: .background) {
+    await heavyComputation()
+}
+
+// Later, a high-priority task needs the result:
+Task(priority: .userInitiated) {
+    let result = await backgroundTask.value  // Escalates backgroundTask to .userInitiated
+}
+```
+
+This prevents priority inversion but can cause unexpected scheduling behavior. Design your concurrency so high-priority paths don't depend on low-priority tasks.
+
+## Common Mistakes
+
+### Creating Tasks Where Structured Concurrency Works
+
+```swift
+// ❌ Unstructured — no automatic cancellation, harder to reason about
+func loadData() {
+    let task1 = Task { await fetchUsers() }
+    let task2 = Task { await fetchPosts() }
+    // Must manually manage cancellation
+}
+
+// ✅ Structured — automatic cancellation, clear lifetime
+func loadData() async {
+    async let users = fetchUsers()
+    async let posts = fetchPosts()
+    let (u, p) = await (users, posts)
+}
+```
+
+### Not Iterating TaskGroup Results
+
+```swift
+// ❌ Memory leak — completed task values accumulate
+await withTaskGroup(of: Data.self) { group in
+    for url in urls {
+        group.addTask { await download(url) }
+    }
+    // Never iterate group — results pile up in memory
+}
+
+// ✅ Always iterate, or use withDiscardingTaskGroup for Void results
+await withTaskGroup(of: Data.self) { group in
+    for url in urls {
+        group.addTask { await download(url) }
+    }
+    for await data in group {
+        process(data)
+    }
+}
+```
+
+### Ignoring Task Cancellation
+
+```swift
+// ❌ Runs to completion even when parent is cancelled
+func processAll(_ items: [Item]) async -> [Result] {
+    var results: [Result] = []
+    for item in items {
+        results.append(await process(item))  // Never checks cancellation
+    }
+    return results
+}
+
+// ✅ Cooperative cancellation
+func processAll(_ items: [Item]) async throws -> [Result] {
+    var results: [Result] = []
+    for item in items {
+        try Task.checkCancellation()
+        results.append(await process(item))
+    }
+    return results
+}
+```
+
+## Checklist
+
+- [ ] Using `async let` for fixed parallel operations (not `Task {}`)
+- [ ] Using `TaskGroup` for dynamic parallel operations
+- [ ] Using `withDiscardingTaskGroup` when results aren't needed
+- [ ] `.task` modifier instead of `.onAppear` + `Task {}`
+- [ ] `.task(id:)` instead of `.onChange` + manual task cancellation
+- [ ] Cooperative cancellation in long loops (`Task.checkCancellation()` or `Task.isCancelled`)
+- [ ] `Task.yield()` in CPU-heavy loops to prevent hangs
+- [ ] TaskGroup results iterated (or using discarding variant)

--- a/.claude/skills/swift-development/concurrency-patterns/swift62-concurrency.md
+++ b/.claude/skills/swift-development/concurrency-patterns/swift62-concurrency.md
@@ -1,0 +1,245 @@
+# Swift 6.2 Approachable Concurrency
+
+Swift 6.2 makes strict concurrency dramatically easier to adopt. The core philosophy: code runs on `@MainActor` by default, async functions stay on the calling actor, and you explicitly opt into background execution with `@concurrent`.
+
+## Async Functions Stay on the Calling Actor
+
+In Swift 6.0/6.1, non-actor-annotated async functions hopped to the generic concurrent executor. This caused data race errors when called from `@MainActor` types.
+
+```swift
+// ❌ Swift 6.0/6.1 — ERROR: Sending 'self.processor' risks causing data races
+@MainActor
+final class StickerModel {
+    let processor = PhotoProcessor()
+
+    func extract(_ item: PhotosPickerItem) async throws -> Sticker? {
+        // processor would hop off MainActor — data race
+        return await processor.extractSticker(data: data, with: item.itemIdentifier)
+    }
+}
+
+class PhotoProcessor {
+    func extractSticker(data: Data, with id: String?) async -> Sticker? { ... }
+}
+```
+
+```swift
+// ✅ Swift 6.2 — No error. Async functions stay on the caller's actor.
+// The same code compiles cleanly with no changes needed.
+@MainActor
+final class StickerModel {
+    let processor = PhotoProcessor()
+
+    func extract(_ item: PhotosPickerItem) async throws -> Sticker? {
+        return await processor.extractSticker(data: data, with: item.itemIdentifier)
+    }
+}
+```
+
+**Why?** In 6.2, `extractSticker` stays on `@MainActor` because the caller is `@MainActor`. No hop, no data race.
+
+## Infer Main Actor by Default
+
+An opt-in build setting that makes all code implicitly `@MainActor` unless explicitly opted out. Eliminates most data race errors for app targets.
+
+### Enabling It
+
+**Xcode:** Build Settings → Swift Compiler - Concurrency → "Default Actor Isolation" → "MainActor"
+
+**Swift Package Manager:**
+```swift
+.executableTarget(
+    name: "MyApp",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self)
+    ]
+)
+```
+
+### What Changes
+
+With this mode enabled, you no longer need `@MainActor` annotations on app-level types:
+
+```swift
+// ❌ Before (Swift 6.0/6.1) — manual annotations everywhere
+@MainActor
+final class StickerLibrary {
+    static let shared: StickerLibrary = .init()
+}
+
+@MainActor
+final class StickerModel {
+    let processor: PhotoProcessor
+    var selection: [PhotosPickerItem]
+}
+```
+
+```swift
+// ✅ After (Swift 6.2 with infer main actor) — no annotations needed
+final class StickerLibrary {
+    static let shared: StickerLibrary = .init()  // Implicitly @MainActor
+}
+
+final class StickerModel {
+    let processor: PhotoProcessor
+    var selection: [PhotosPickerItem]  // Implicitly @MainActor
+}
+```
+
+### When to Use
+
+| Target Type | Recommended? | Why |
+|-------------|-------------|-----|
+| App target | Yes | Apps are UI-driven, most code belongs on MainActor |
+| Script target | Yes | Scripts are sequential, MainActor default is natural |
+| Library/framework | No | Libraries should not impose actor isolation on consumers |
+| Package plugin | No | Same as libraries |
+
+### Opting Out
+
+When a type or function needs to run off the main actor, use `nonisolated`:
+
+```swift
+// With "infer main actor" enabled:
+nonisolated struct ImageProcessor {
+    func processImage(_ data: Data) -> UIImage { ... }  // Runs on any thread
+}
+
+nonisolated func heavyComputation() -> Result { ... }
+```
+
+## Isolated Conformances
+
+Allows `@MainActor` types to conform to protocols that don't require actor isolation:
+
+```swift
+protocol Exportable {
+    func export()
+}
+
+// ❌ Swift 6.0/6.1 — ERROR: Conformance crosses into main actor-isolated code
+extension StickerModel: Exportable {
+    func export() {
+        processor.exportAsPNG()
+    }
+}
+```
+
+```swift
+// ✅ Swift 6.2 — Isolated conformance
+extension StickerModel: @MainActor Exportable {
+    func export() {
+        processor.exportAsPNG()
+    }
+}
+```
+
+### Usage Rules
+
+Isolated conformances can only be used in matching isolation contexts:
+
+```swift
+// ✅ Used within @MainActor context — OK
+@MainActor
+struct ImageExporter {
+    var items: [any Exportable]
+
+    mutating func add(_ item: StickerModel) {
+        items.append(item)  // OK — both are @MainActor
+    }
+}
+
+// ❌ Used outside @MainActor — compile error
+nonisolated struct ImageExporter {
+    var items: [any Exportable]
+
+    mutating func add(_ item: StickerModel) {
+        items.append(item)  // Error: Main actor-isolated conformance
+                            // cannot be used in nonisolated context
+    }
+}
+```
+
+## @concurrent — Explicit Background Execution
+
+When you need true parallelism (CPU-heavy work off the main thread), use `@concurrent`:
+
+```swift
+class PhotoProcessor {
+    var cachedStickers: [String: Sticker]
+
+    func extractSticker(data: Data, with id: String) async -> Sticker {
+        if let sticker = cachedStickers[id] { return sticker }
+        let sticker = await Self.extractSubject(from: data)  // Runs on background
+        cachedStickers[id] = sticker
+        return sticker
+    }
+
+    @concurrent
+    static func extractSubject(from data: Data) async -> Sticker {
+        // Heavy image processing — runs on concurrent thread pool
+        ...
+    }
+}
+```
+
+### Steps to Offload Work
+
+1. Make the type `nonisolated` (if it's a struct/class, not an actor)
+2. Add `@concurrent` to the function
+3. Make the function `async`
+4. Callers use `await`
+
+```swift
+nonisolated struct ImageProcessor {
+    @concurrent
+    func resize(image: Data, to size: CGSize) async -> Data {
+        // Runs on background thread
+        ...
+    }
+}
+
+// Caller (on MainActor):
+let resized = await ImageProcessor().resize(image: data, to: targetSize)
+```
+
+### @concurrent vs Task.detached vs Actor
+
+| Mechanism | Use Case |
+|-----------|----------|
+| `@concurrent` | Single function that must run on background thread |
+| `Task.detached` | Fire-and-forget background work, no structured parent |
+| `actor` | Shared mutable state that needs serialized access |
+| `Task {}` | Unstructured task inheriting current actor (usually MainActor) |
+
+Prefer `@concurrent` for compute-heavy functions. Prefer actors for shared state. Avoid `Task.detached` when structured concurrency works.
+
+## Mental Model Summary
+
+```
+Swift 6.2 Concurrency Defaults:
+┌────────────────────────────────────────────┐
+│ Everything is @MainActor by default        │
+│ (with "infer main actor" build setting)    │
+│                                            │
+│ async functions stay on the calling actor   │
+│ (no implicit hop to background)            │
+│                                            │
+│ Use @concurrent to explicitly go background │
+│ Use nonisolated to opt out of MainActor    │
+└────────────────────────────────────────────┘
+
+Progression:
+1. Write code → runs on MainActor → no data races
+2. Use async/await → stays on calling actor → still no races
+3. Need parallelism → @concurrent → explicit, auditable
+```
+
+## Checklist
+
+- [ ] Using Swift 6.2+ for approachable concurrency features
+- [ ] "Infer main actor by default" enabled for app targets (not libraries)
+- [ ] `@concurrent` used for CPU-heavy functions that must run on background
+- [ ] `nonisolated` used to opt types/functions out of MainActor when needed
+- [ ] Isolated conformances (`@MainActor Protocol`) used for MainActor types conforming to non-isolated protocols
+- [ ] Not using `@MainActor` annotations everywhere (let inference handle it in 6.2)

--- a/.claude/skills/swift-development/concurrency/SKILL.md
+++ b/.claude/skills/swift-development/concurrency/SKILL.md
@@ -1,0 +1,631 @@
+---
+name: swift-concurrency-updates
+description: Swift 6.2 concurrency updates including default MainActor inference, @concurrent for background work, isolated conformances, and approachable concurrency migration. Use when adopting Swift 6.2 concurrency features or fixing data-race errors.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Swift 6.2 Concurrency Updates
+
+Swift 6.2 introduces "Approachable Concurrency" -- a set of changes that make strict concurrency dramatically easier to adopt. The philosophy shifts from "opt in to safety" to "safe by default, opt in to concurrency." Code runs on `@MainActor` by default, async functions stay on the calling actor, and you explicitly request background execution with `@concurrent`.
+
+This skill covers only the Swift 6.2 specific changes. For general concurrency patterns (actors, TaskGroup, AsyncSequence, Sendable, cancellation), see the `swift/concurrency-patterns` skill.
+
+## When This Skill Activates
+
+- User is adopting Swift 6.2 concurrency features
+- User asks about default MainActor inference or the "infer main actor" build setting
+- User encounters data-race errors that Swift 6.2 resolves
+- User asks about `@concurrent`, isolated conformances, or approachable concurrency
+- User wants to migrate from Swift 6.0/6.1 strict concurrency to 6.2
+- User asks how async functions behave differently in Swift 6.2
+- User needs to offload CPU-intensive work to a background thread in Swift 6.2
+
+## What Changed in Swift 6.2 vs Before
+
+### The Core Problem with Swift 6.0/6.1
+
+In Swift 6.0 and 6.1, strict concurrency was correct but painful. Developers faced walls of data-race compiler errors that were difficult to resolve. Non-actor-annotated async functions would eagerly hop to the generic concurrent executor, causing unexpected data races when passing mutable state. Conforming `@MainActor` types to non-isolated protocols was often impossible without workarounds.
+
+### Swift 6.2 Changes at a Glance
+
+| Feature | Before (6.0/6.1) | After (6.2) |
+|---------|------------------|-------------|
+| Default isolation | Nothing inferred; manual `@MainActor` everywhere | Opt-in mode infers `@MainActor` on everything |
+| Async function execution | Hops to generic concurrent executor | Stays on calling actor |
+| `@MainActor` type conforming to protocol | Compiler error for non-isolated protocols | Isolated conformances: `@MainActor Protocol` |
+| Background execution | `Task.detached` or manual nonisolated functions | `@concurrent` attribute |
+| Global/static mutable state | Required `@MainActor` annotation or Sendable | Default MainActor mode handles it automatically |
+
+---
+
+## 1. Async Functions Stay on the Calling Actor
+
+In Swift 6.0/6.1, a non-actor-annotated async function called from a `@MainActor` context would hop off the main actor to the generic concurrent executor. This caused data-race errors when the caller passed non-Sendable state.
+
+In Swift 6.2, async functions without specific actor isolation stay on whatever actor they are called from. No hop, no data race.
+
+### Before (Swift 6.0/6.1)
+
+```swift
+// ❌ Swift 6.0/6.1 -- ERROR: Sending 'self.processor' risks causing data races
+@MainActor
+final class StickerModel {
+    let processor = PhotoProcessor()
+
+    func extract(_ item: PhotosPickerItem) async throws -> Sticker? {
+        let data = try await item.loadTransferable(type: Data.self)
+        // processor hops off MainActor -- data race
+        return await processor.extractSticker(data: data, with: item.itemIdentifier)
+    }
+}
+
+class PhotoProcessor {
+    func extractSticker(data: Data, with id: String?) async -> Sticker? {
+        // This runs on the concurrent executor in 6.0/6.1
+        ...
+    }
+}
+```
+
+### After (Swift 6.2)
+
+```swift
+// ✅ Swift 6.2 -- No error. extractSticker stays on the caller's actor.
+@MainActor
+final class StickerModel {
+    let processor = PhotoProcessor()
+
+    func extract(_ item: PhotosPickerItem) async throws -> Sticker? {
+        let data = try await item.loadTransferable(type: Data.self)
+        // processor stays on MainActor -- no data race
+        return await processor.extractSticker(data: data, with: item.itemIdentifier)
+    }
+}
+
+class PhotoProcessor {
+    func extractSticker(data: Data, with id: String?) async -> Sticker? {
+        // In 6.2, this runs on MainActor because the caller is @MainActor
+        ...
+    }
+}
+```
+
+**Why this matters:** Many data-race errors in Swift 6.0/6.1 were caused by this implicit hop. In 6.2, the same code compiles cleanly with no changes needed.
+
+---
+
+## 2. Default MainActor Inference Mode
+
+An opt-in build setting that makes all code implicitly `@MainActor` unless explicitly opted out with `nonisolated`. This eliminates the vast majority of data-race errors for single-threaded app code.
+
+### Enabling It
+
+**Xcode:** Build Settings > Swift Compiler - Concurrency > "Default Actor Isolation" > "MainActor"
+
+**Swift Package Manager:**
+
+```swift
+.executableTarget(
+    name: "MyApp",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self)
+    ]
+)
+```
+
+### What Changes
+
+With this mode enabled, you no longer need `@MainActor` annotations on app-level types:
+
+```swift
+// ❌ Before (Swift 6.0/6.1) -- manual @MainActor annotations everywhere
+@MainActor
+final class StickerLibrary {
+    static let shared: StickerLibrary = .init()
+}
+
+@MainActor
+final class StickerModel {
+    let processor: PhotoProcessor
+    var selection: [PhotosPickerItem]
+}
+
+@MainActor
+struct ContentView: View {
+    @State private var model = StickerModel()
+    var body: some View { ... }
+}
+```
+
+```swift
+// ✅ After (Swift 6.2 with default MainActor inference) -- no annotations needed
+final class StickerLibrary {
+    static let shared: StickerLibrary = .init()  // Implicitly @MainActor
+}
+
+final class StickerModel {
+    let processor: PhotoProcessor    // Implicitly @MainActor
+    var selection: [PhotosPickerItem]
+}
+
+struct ContentView: View {
+    @State private var model = StickerModel()
+    var body: some View { ... }
+}
+```
+
+### When to Use Default MainActor Inference
+
+| Target Type | Recommended? | Reason |
+|-------------|-------------|--------|
+| App target | Yes | Apps are UI-driven; most code belongs on MainActor |
+| Script / executable | Yes | Scripts are sequential; MainActor default is natural |
+| Library / framework | No | Libraries must not impose actor isolation on consumers |
+| Package plugin | No | Same reasoning as libraries |
+
+### Opting Out with nonisolated
+
+When a type or function genuinely needs to run off the main actor, mark it `nonisolated`:
+
+```swift
+// With "infer main actor" enabled, use nonisolated to opt out:
+nonisolated struct ImageProcessor {
+    func processImage(_ data: Data) -> UIImage {
+        // Runs on any thread, not MainActor
+        ...
+    }
+}
+
+nonisolated func heavyComputation() -> Result {
+    // Runs on any thread
+    ...
+}
+```
+
+### Global and Static State Protection
+
+With default MainActor inference enabled, global and static mutable state is automatically protected:
+
+```swift
+// ❌ Before -- required explicit annotation or Sendable conformance
+@MainActor static let shared: StickerLibrary = .init()
+
+// ✅ After -- default MainActor inference handles it
+static let shared: StickerLibrary = .init()  // Implicitly @MainActor
+```
+
+Without default MainActor inference, you can still protect individual declarations:
+
+```swift
+@MainActor static let shared: StickerLibrary = .init()
+```
+
+---
+
+## 3. Isolated Conformances
+
+Allows `@MainActor` types to conform to protocols that do not require actor isolation. Before Swift 6.2, this was a common source of frustrating compiler errors.
+
+### The Problem (Swift 6.0/6.1)
+
+```swift
+protocol Exportable {
+    func export()
+}
+
+@MainActor
+final class StickerModel {
+    let processor: PhotoProcessor
+
+    func doExport() {
+        processor.exportAsPNG()
+    }
+}
+
+// ❌ Swift 6.0/6.1 -- ERROR: Main actor-isolated conformance crosses isolation boundary
+extension StickerModel: Exportable {
+    func export() {
+        processor.exportAsPNG()  // Needs MainActor, but protocol is non-isolated
+    }
+}
+```
+
+### The Solution (Swift 6.2)
+
+```swift
+// ✅ Swift 6.2 -- Isolated conformance
+extension StickerModel: @MainActor Exportable {
+    func export() {
+        processor.exportAsPNG()  // Works: conformance is MainActor-isolated
+    }
+}
+```
+
+### Usage Rules for Isolated Conformances
+
+The compiler enforces that isolated conformances are only used in matching isolation contexts:
+
+```swift
+// ✅ Used within @MainActor context -- OK
+@MainActor
+struct ImageExporter {
+    var items: [any Exportable]
+
+    mutating func add(_ item: StickerModel) {
+        items.append(item)  // OK: both are @MainActor
+    }
+}
+
+// ❌ Used outside @MainActor -- compile error
+nonisolated struct ImageExporter {
+    var items: [any Exportable]
+
+    mutating func add(_ item: StickerModel) {
+        items.append(item)  // Error: Main actor-isolated conformance
+                            // cannot be used in nonisolated context
+    }
+}
+```
+
+The conformance is not universally available. It only works when the caller shares the same isolation domain.
+
+---
+
+## 4. @concurrent -- Explicit Background Execution
+
+When you need true parallelism for CPU-heavy work, use `@concurrent` to explicitly offload to the background thread pool. This replaces the pattern of using `Task.detached` for compute-intensive operations.
+
+### Basic Usage
+
+```swift
+class PhotoProcessor {
+    var cachedStickers: [String: Sticker]
+
+    func extractSticker(data: Data, with id: String) async -> Sticker {
+        if let sticker = cachedStickers[id] { return sticker }
+        let sticker = await Self.extractSubject(from: data)  // Background execution
+        cachedStickers[id] = sticker
+        return sticker
+    }
+
+    @concurrent
+    static func extractSubject(from data: Data) async -> Sticker {
+        // Heavy image processing -- runs on concurrent thread pool
+        ...
+    }
+}
+```
+
+### Steps to Offload Work
+
+1. Make the type `nonisolated` (for structs/classes; actors are already isolated)
+2. Add `@concurrent` to the function
+3. Make the function `async`
+4. Callers use `await`
+
+```swift
+nonisolated struct ImageProcessor {
+    @concurrent
+    func resize(image: Data, to size: CGSize) async -> Data {
+        // Runs on background thread pool
+        ...
+    }
+}
+
+// Caller (on MainActor):
+let resized = await ImageProcessor().resize(image: data, to: targetSize)
+```
+
+### @concurrent vs Task.detached vs actor
+
+| Mechanism | Use Case | Structured? |
+|-----------|----------|-------------|
+| `@concurrent` | Single function that must run on background thread | Yes (inherits task context) |
+| `Task.detached` | Fire-and-forget background work, no structured parent | No |
+| `actor` | Shared mutable state needing serialized access | N/A (isolation, not scheduling) |
+| `Task {}` | Unstructured task inheriting current actor | No |
+
+Prefer `@concurrent` for compute-heavy functions. Prefer actors for shared state. Avoid `Task.detached` when `@concurrent` or structured concurrency works.
+
+### When NOT to Use @concurrent
+
+Do not mark every async function as `@concurrent`. Most app code should stay on the calling actor. Only use `@concurrent` when:
+
+- The function performs CPU-intensive work (image processing, parsing, compression)
+- The function performs blocking I/O that would freeze the UI
+- You have measured that the work takes enough time to justify the thread hop
+
+```swift
+// ❌ Wrong -- trivial work does not need @concurrent
+nonisolated struct UserFormatter {
+    @concurrent
+    func formatName(_ user: User) async -> String {  // Unnecessary thread hop
+        return "\(user.firstName) \(user.lastName)"
+    }
+}
+
+// ✅ Right -- leave it on the calling actor
+struct UserFormatter {
+    func formatName(_ user: User) -> String {
+        return "\(user.firstName) \(user.lastName)"
+    }
+}
+```
+
+---
+
+## 5. Migration Guide
+
+### From Swift 6.0/6.1 to Swift 6.2
+
+**Step 1: Update to Swift 6.2 toolchain**
+
+Ensure your Xcode version supports Swift 6.2 and your project's Swift language version is set to 6.2.
+
+**Step 2: Enable default MainActor inference (for app targets)**
+
+Xcode: Build Settings > Swift Compiler - Concurrency > Default Actor Isolation > MainActor
+
+Swift Package Manager:
+
+```swift
+.executableTarget(
+    name: "MyApp",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self)
+    ]
+)
+```
+
+**Step 3: Remove redundant `@MainActor` annotations**
+
+With default MainActor inference enabled, explicit `@MainActor` annotations on app-level types are redundant. Remove them to reduce noise:
+
+```swift
+// Before
+@MainActor class ViewModel { ... }
+@MainActor struct ContentView: View { ... }
+
+// After (with default MainActor inference)
+class ViewModel { ... }
+struct ContentView: View { ... }
+```
+
+**Step 4: Replace `Task.detached` with `@concurrent` where appropriate**
+
+```swift
+// Before
+func processImages(_ data: [Data]) async -> [UIImage] {
+    await withTaskGroup(of: UIImage.self) { group in
+        for item in data {
+            group.addTask { // Task.detached implied hop
+                await self.decode(item)
+            }
+        }
+        return await group.reduce(into: []) { $0.append($1) }
+    }
+}
+
+// After
+@concurrent
+func decode(_ data: Data) async -> UIImage {
+    // Explicitly runs on background
+    ...
+}
+```
+
+**Step 5: Fix remaining conformance errors with isolated conformances**
+
+```swift
+// Before -- workaround with @unchecked Sendable or nonisolated
+extension MyModel: @unchecked Sendable {}  // Unsafe workaround
+
+// After -- isolated conformance
+extension MyModel: @MainActor Exportable {
+    func export() { ... }
+}
+```
+
+**Step 6: Add `nonisolated` to types/functions that must not be on MainActor**
+
+With default MainActor inference, anything not explicitly marked `nonisolated` runs on MainActor. Audit your code for:
+
+- Background data processing types
+- Network parsers
+- File I/O utilities
+- Computation-heavy algorithms
+
+```swift
+nonisolated struct JSONParser {
+    @concurrent
+    func parse(_ data: Data) async throws -> [Model] { ... }
+}
+```
+
+### Migration Resources
+
+- Xcode build settings: Swift Compiler > Concurrency
+- SwiftSettings API for Swift packages
+- Official migration tooling: [swift.org/migration](https://www.swift.org/migration)
+- Apple doc reference: `/Users/ravishankar/Downloads/docs/Swift-Concurrency-Updates.md`
+
+---
+
+## Mental Model
+
+```
+Swift 6.2 Concurrency Defaults
++--------------------------------------------+
+| Everything is @MainActor by default        |
+| (with "infer main actor" build setting)    |
+|                                            |
+| Async functions stay on the calling actor  |
+| (no implicit hop to background)            |
+|                                            |
+| Use @concurrent to explicitly go background|
+| Use nonisolated to opt out of MainActor    |
++--------------------------------------------+
+
+Progression:
+1. Write code          -> runs on MainActor        -> no data races
+2. Use async/await     -> stays on calling actor   -> still no races
+3. Need parallelism    -> @concurrent              -> explicit, auditable
+4. Need shared state   -> actor                    -> serialized access
+```
+
+---
+
+## Top Mistakes
+
+### Mistake 1: Enabling default MainActor inference for a library
+
+```swift
+// ❌ Wrong -- library imposes MainActor on all consumers
+// Package.swift
+.target(
+    name: "MyNetworkingLib",
+    swiftSettings: [
+        .defaultIsolation(MainActor.self)  // Do NOT do this for libraries
+    ]
+)
+```
+
+Libraries should let consumers choose their own isolation strategy. Only app targets and executables should use default MainActor inference.
+
+### Mistake 2: Marking trivial functions @concurrent
+
+```swift
+// ❌ Wrong -- unnecessary thread hop for trivial work
+@concurrent
+func greet(_ name: String) async -> String {
+    "Hello, \(name)"
+}
+
+// ✅ Right -- no @concurrent needed
+func greet(_ name: String) -> String {
+    "Hello, \(name)"
+}
+```
+
+Every `@concurrent` call involves a thread hop. Only use it for genuinely expensive work.
+
+### Mistake 3: Forgetting nonisolated when default MainActor is enabled
+
+```swift
+// With default MainActor inference enabled:
+
+// ❌ Wrong -- this CPU-intensive parser now runs on MainActor, blocking UI
+struct LargeFileParser {
+    func parse(_ data: Data) -> [Record] {
+        // Heavy parsing blocks the main thread
+        ...
+    }
+}
+
+// ✅ Right -- opt out of MainActor for background-suitable types
+nonisolated struct LargeFileParser {
+    @concurrent
+    func parse(_ data: Data) async -> [Record] {
+        // Runs on background thread pool
+        ...
+    }
+}
+```
+
+### Mistake 4: Using isolated conformances in nonisolated contexts
+
+```swift
+extension MyModel: @MainActor Exportable {
+    func export() { ... }
+}
+
+// ❌ Wrong -- trying to use the conformance from a nonisolated context
+nonisolated func exportAll(_ items: [any Exportable]) {
+    for item in items {
+        item.export()  // Compiler error: isolated conformance not available here
+    }
+}
+
+// ✅ Right -- use the conformance from a matching isolation context
+@MainActor
+func exportAll(_ items: [any Exportable]) {
+    for item in items {
+        item.export()  // OK: both are @MainActor
+    }
+}
+```
+
+### Mistake 5: Removing @MainActor annotations without enabling the build setting
+
+```swift
+// ❌ Wrong -- removed annotations but did NOT enable default MainActor inference
+class ViewModel {  // No longer @MainActor -- state is unprotected
+    var items: [Item] = []
+    func load() async { ... }
+}
+
+// ✅ Right -- either keep annotations OR enable the build setting
+// Option A: Keep the annotation
+@MainActor
+class ViewModel {
+    var items: [Item] = []
+    func load() async { ... }
+}
+
+// Option B: Enable "Default Actor Isolation: MainActor" in build settings
+// Then annotations are unnecessary
+class ViewModel {
+    var items: [Item] = []
+    func load() async { ... }
+}
+```
+
+---
+
+## Review Checklist
+
+When reviewing code that uses or should use Swift 6.2 concurrency features:
+
+### Build Configuration
+- [ ] Swift language version is set to 6.2
+- [ ] Default MainActor inference is enabled for app/executable targets only (not libraries)
+- [ ] Libraries and frameworks do NOT use `.defaultIsolation(MainActor.self)`
+
+### Actor Isolation
+- [ ] Redundant `@MainActor` annotations removed (if default MainActor inference is enabled)
+- [ ] `nonisolated` applied to types/functions that must run off the main actor
+- [ ] CPU-intensive work marked `nonisolated` and uses `@concurrent`
+- [ ] No heavy computation running implicitly on MainActor
+
+### @concurrent Usage
+- [ ] `@concurrent` only used for genuinely expensive operations
+- [ ] `@concurrent` functions are `async`
+- [ ] Containing type is `nonisolated` (for structs/classes)
+- [ ] `Task.detached` replaced with `@concurrent` where structured concurrency is preferable
+
+### Isolated Conformances
+- [ ] `@MainActor Protocol` syntax used for MainActor types conforming to non-isolated protocols
+- [ ] Isolated conformances only consumed from matching isolation contexts
+- [ ] No `@unchecked Sendable` workarounds that isolated conformances can replace
+
+### Migration Hygiene
+- [ ] No leftover `@unchecked Sendable` conformances from pre-6.2 workarounds
+- [ ] No unnecessary `Task.detached` calls (prefer `@concurrent` or structured concurrency)
+- [ ] Async functions that previously caused data-race errors re-tested without workarounds
+- [ ] Global and static mutable state properly protected (via default MainActor or explicit annotation)
+
+---
+
+## Cross-References
+
+- **General concurrency patterns** (actors, TaskGroup, AsyncSequence, Sendable, cancellation): `swift/concurrency-patterns`
+- **Actors and isolation deep dive**: `swift/concurrency-patterns/actors-and-isolation.md`
+- **Structured concurrency patterns**: `swift/concurrency-patterns/structured-concurrency.md`
+- **Swift 6 migration guide**: `swift/concurrency-patterns/migration-guide.md`
+- **Apple documentation**: `/Users/ravishankar/Downloads/docs/Swift-Concurrency-Updates.md`
+
+## References
+
+- [Swift Evolution: Approachable Concurrency](https://www.swift.org/blog/approachable-concurrency/)
+- [Migrating to Swift 6](https://www.swift.org/migration/documentation/migrationguide/)
+- [Swift Concurrency Documentation](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/)

--- a/.claude/skills/swift-development/memory/SKILL.md
+++ b/.claude/skills/swift-development/memory/SKILL.md
@@ -1,0 +1,357 @@
+---
+name: memory
+description: Swift 6.2 InlineArray and Span types for zero-overhead memory access, fixed-size collections, and safe pointer alternatives. Use when optimizing performance-critical code paths.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# InlineArray and Span
+
+Guidance for Swift 6.2's low-level memory types: `InlineArray` for fixed-size inline storage without heap allocation, and `Span` for safe, zero-cost access to contiguous memory. These replace common uses of `UnsafeBufferPointer` and hand-tuned tuple storage with compiler-checked alternatives.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Asks about **InlineArray**, **fixed-size arrays**, or **stack-allocated collections**
+- Mentions **Span**, **MutableSpan**, **RawSpan**, or **UTF8Span**
+- Wants to **eliminate heap allocations** in hot paths
+- Is replacing **UnsafeBufferPointer** or **UnsafePointer** with safe alternatives
+- Asks about **value generics** or `let count: Int` generic parameters
+- Needs **zero-copy** access to collection storage
+- Mentions **inline storage**, **contiguous memory**, or **memory layout**
+- Is doing **binary parsing**, **signal processing**, or **embedded Swift** work
+- Wants to avoid **copy-on-write overhead** for small fixed collections
+- Asks about **non-escapable types** or **lifetime dependencies** in Swift
+
+## Decision Tree
+
+```
+What memory optimization do you need?
+│
+├─ A fixed-size collection that never grows/shrinks
+│  │
+│  ├─ Size known at compile time, stored on stack
+│  │  └─ InlineArray<N, Element>
+│  │     ├─ No heap allocation
+│  │     ├─ No reference counting
+│  │     └─ No copy-on-write (eager copies)
+│  │
+│  └─ Size may vary at runtime
+│     └─ Array<Element> (standard library)
+│
+├─ Safe read access to contiguous memory
+│  │
+│  ├─ Read-only access to typed elements
+│  │  └─ Span<Element>
+│  │
+│  ├─ Mutable access to typed elements
+│  │  └─ MutableSpan<Element>
+│  │
+│  ├─ Read-only access to raw bytes
+│  │  └─ RawSpan
+│  │
+│  ├─ Mutable access to raw bytes
+│  │  └─ MutableRawSpan
+│  │
+│  ├─ Unicode text processing
+│  │  └─ UTF8Span
+│  │
+│  └─ Initializing a new collection's storage
+│     └─ OutputSpan
+│
+├─ Unsafe pointer access (legacy or interop)
+│  └─ UnsafeBufferPointer / UnsafeMutableBufferPointer
+│     └─ Prefer Span instead for new code
+│
+└─ Standard dynamic collection
+   └─ Array<Element>
+      ├─ Heap-allocated, copy-on-write
+      └─ Grows/shrinks dynamically
+```
+
+## API Availability
+
+| API | Minimum Version | Notes |
+|-----|----------------|-------|
+| `InlineArray<let count: Int, Element>` | Swift 6.2 | Uses value generics; `@frozen` struct |
+| `Span<Element>` | Swift 6.2 | Non-escapable, lifetime-dependent |
+| `MutableSpan<Element>` | Swift 6.2 | Mutable variant of Span |
+| `RawSpan` | Swift 6.2 | Untyped byte-level access |
+| `MutableRawSpan` | Swift 6.2 | Mutable untyped byte access |
+| `UTF8Span` | Swift 6.2 | Unicode-aware text processing |
+| `OutputSpan` | Swift 6.2 | For initializing collection storage |
+| `.span` property on `Array` | Swift 6.2 | Returns `Span<Element>` |
+| `.span` property on `Data` | Swift 6.2 | Returns `Span<UInt8>` |
+
+## Top 5 Mistakes
+
+| # | Mistake | Fix |
+|---|---------|-----|
+| 1 | Trying to append/remove elements on `InlineArray` | `InlineArray` is fixed-size; use `Array` if you need dynamic sizing |
+| 2 | Returning a `Span` from a function | `Span` is non-escapable and cannot outlive its source; restructure to process data within the same scope |
+| 3 | Capturing a `Span` in a closure | `Span` cannot be captured; pass the span as a parameter or use `Array` for escaped contexts |
+| 4 | Using `InlineArray` for large or frequently copied collections | `InlineArray` copies eagerly (no COW); use `Array` for large data that is shared or copied often |
+| 5 | Accessing a `Span` after mutating the source container | Mutation invalidates the span; re-acquire the span after any modification |
+
+## InlineArray
+
+### Declaration
+
+`InlineArray` uses Swift's value generics to encode the count in the type:
+
+```swift
+@frozen struct InlineArray<let count: Int, Element> where Element: ~Copyable
+```
+
+### Initialization
+
+```swift
+// Explicit count
+let a: InlineArray<4, Int> = [1, 2, 4, 8]
+
+// Count inferred from literal
+let b: InlineArray<_, Int> = [1, 2, 4, 8]  // count = 4
+
+// Element type inferred from literal
+let c: InlineArray<4, _> = [1, 2, 4, 8]    // Element = Int
+
+// Both inferred
+let d: InlineArray = [1, 2, 4, 8]           // InlineArray<4, Int>
+```
+
+### Memory Layout
+
+Elements are stored contiguously with no overhead. Size equals `count * MemoryLayout<Element>.stride`:
+
+```swift
+MemoryLayout<InlineArray<0, UInt16>>.size       // 0
+MemoryLayout<InlineArray<0, UInt16>>.stride      // 1
+MemoryLayout<InlineArray<3, UInt16>>.size        // 6  (2 bytes x 3)
+MemoryLayout<InlineArray<3, UInt16>>.stride       // 6
+MemoryLayout<InlineArray<3, UInt16>>.alignment   // 2  (same as UInt16)
+```
+
+### Basic Usage
+
+```swift
+var array: InlineArray<3, Int> = [1, 2, 3]
+
+// Subscript access
+array[0] = 4
+
+// Iterate via indices
+for i in array.indices {
+    print(array[i])
+}
+
+// Copies are eager (no copy-on-write)
+var copy = array
+copy[0] = 99
+// array[0] is still 4
+```
+
+### InlineArray vs Array
+
+| Characteristic | InlineArray | Array |
+|---------------|-------------|-------|
+| Storage | Inline (stack or enclosing type) | Heap-allocated buffer |
+| Size | Fixed at compile time | Dynamic |
+| Copy semantics | Eager (full copy) | Copy-on-write |
+| Reference counting | None | Yes (buffer reference) |
+| Exclusivity checks | None | Yes |
+| Append/remove | Not supported | Supported |
+
+## Span Family
+
+### Span (Read-Only)
+
+Provides safe, direct access to contiguous typed memory. Non-escapable -- cannot outlive the source.
+
+```swift
+let array = [1, 2, 3, 4]
+let span = array.span  // Span<Int>
+
+// Access elements
+let first = span[0]
+let count = span.count
+
+// Iterate
+for element in span {
+    print(element)
+}
+```
+
+### MutableSpan
+
+Mutable access to contiguous storage:
+
+```swift
+var array = [1, 2, 3, 4]
+array.withMutableSpan { span in
+    for i in span.indices {
+        span[i] *= 2
+    }
+}
+// array is now [2, 4, 6, 8]
+```
+
+### RawSpan
+
+Untyped byte-level access for binary data:
+
+```swift
+let data = Data([0xFF, 0x00, 0xAB, 0xCD])
+let rawSpan = data.span  // Span<UInt8> for byte-level access
+```
+
+### UTF8Span
+
+Specialized for safe and efficient Unicode processing of UTF-8 encoded text.
+
+## Safety Constraints
+
+### Non-Escapable: Cannot Return from Functions
+
+`Span` has a lifetime dependency on the container it was derived from. It cannot be returned:
+
+```swift
+// ❌ Wrong -- Span cannot escape the function
+func getSpan() -> Span<UInt8> {
+    let array: [UInt8] = Array(repeating: 0, count: 128)
+    return array.span  // Compiler error
+}
+
+// ✅ Right -- process within the same scope
+func processData(_ array: [UInt8]) {
+    let span = array.span
+    // Use span here
+    let sum = span.reduce(0, +)
+}
+```
+
+### Non-Escapable: Cannot Capture in Closures
+
+```swift
+// ❌ Wrong -- Span cannot be captured
+func makeClosure() -> () -> Int {
+    let array: [UInt8] = Array(repeating: 0, count: 128)
+    let span = array.span
+    return { span.count }  // Compiler error
+}
+
+// ✅ Right -- use Span within the local scope only
+func countElements(_ array: [UInt8]) -> Int {
+    let span = array.span
+    return span.count
+}
+```
+
+### Invalidation on Mutation
+
+Modifying the source container invalidates any existing span:
+
+```swift
+// ❌ Wrong -- span is invalidated after mutation
+var array = [1, 2, 3]
+let span = array.span
+array.append(4)        // Invalidates span
+// let x = span[0]     // Undefined behavior
+
+// ✅ Right -- re-acquire span after mutation
+var array = [1, 2, 3]
+array.append(4)
+let span = array.span  // Fresh span after mutation
+let x = span[0]        // Safe
+```
+
+## Performance Considerations
+
+### When InlineArray Wins
+
+- **Small, fixed-size data** (e.g., color components, matrix rows, coordinate tuples)
+- **Hot loops** where heap allocation / ARC overhead is measurable
+- **Embedded Swift** or contexts with no allocator
+- **Struct fields** that should be stored inline rather than behind a pointer
+
+### When Array Wins
+
+- Collection size is unknown or variable
+- Collection is large and frequently shared (COW avoids full copies)
+- Collection is passed across module boundaries where dynamic sizing is needed
+
+### When Span Wins Over UnsafePointer
+
+- **All new code** that needs contiguous memory access -- Span provides the same performance with compile-time safety
+- **Binary parsing** where you read structured data from a byte buffer
+- **Algorithm implementations** that operate on slices of memory
+
+### When UnsafePointer Is Still Needed
+
+- C interop requiring raw pointer parameters
+- Legacy APIs that predate Span adoption
+- Interfacing with system calls that take pointer arguments
+
+## When to Use / When NOT to Use
+
+### Use InlineArray When
+
+- You know the exact element count at compile time
+- You need zero heap allocation (stack storage)
+- The collection is small (< ~64 elements as a guideline)
+- You modify in place but rarely copy the whole collection
+- You are writing performance-critical or embedded code
+
+### Do NOT Use InlineArray When
+
+- The collection size varies at runtime
+- The collection is large and frequently copied (no COW means expensive copies)
+- You need to append, insert, or remove elements
+- You benefit from sharing storage across variables
+
+### Use Span When
+
+- You need fast, safe, read-only access to contiguous memory
+- You want to replace `UnsafeBufferPointer` with a safe alternative
+- You are processing data in place without needing to escape the reference
+- You are implementing high-performance algorithms on collection storage
+
+### Do NOT Use Span When
+
+- You need to store the reference for later use (Span is non-escapable)
+- You need to pass memory access across async boundaries
+- You need mutable access (use `MutableSpan` instead)
+- C interop requires actual `UnsafePointer` arguments
+
+## Review Checklist
+
+### InlineArray
+
+- [ ] Count is a compile-time constant (value generic), not a runtime variable
+- [ ] Collection size is genuinely fixed and will not need dynamic resizing
+- [ ] No code attempts to `append`, `insert`, or `remove` elements
+- [ ] Copies are intentional -- each assignment copies all elements eagerly
+- [ ] Large `InlineArray` values are not copied in hot loops (pass by `inout` or reference)
+- [ ] `MemoryLayout` is verified if precise byte layout matters (e.g., GPU buffers, file formats)
+
+### Span
+
+- [ ] Span is never returned from a function or stored in a property
+- [ ] Span is never captured in an escaping closure
+- [ ] Source container is not mutated while a span is in use
+- [ ] Span is re-acquired after any mutation to the source
+- [ ] Correct span variant is used: `Span` (read), `MutableSpan` (write), `RawSpan` (bytes)
+- [ ] `UnsafeBufferPointer` is only used where C interop requires it; prefer `Span` otherwise
+
+### General Performance
+
+- [ ] Profile before optimizing -- confirm heap allocation or ARC is the actual bottleneck
+- [ ] Small fixed collections use `InlineArray` instead of `Array` in measured hot paths
+- [ ] `Span` is used instead of `UnsafeBufferPointer` for safe contiguous access
+- [ ] No premature optimization -- `Array` is correct default for most code
+
+## References
+
+- [Swift Standard Library - InlineArray](https://developer.apple.com/documentation/swift/inlinearray)
+- [Swift Standard Library - Span](https://developer.apple.com/documentation/swift/span)
+- [Value Generics in Swift](https://www.swift.org/blog/value-generics/)
+- [SE-0453: Vector (InlineArray)](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0453-vector.md)
+- [SE-0447: Span](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0447-span-access-shared-contiguous-storage.md)

--- a/.claude/skills/swiftdata-inheritance/SKILL.md
+++ b/.claude/skills/swiftdata-inheritance/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: swiftdata-inheritance
+description: SwiftData class inheritance patterns for hierarchical models with type-based querying, polymorphic relationships, and when to choose inheritance vs enums. Use when designing SwiftData model hierarchies.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# SwiftData Class Inheritance
+
+Guide for implementing class inheritance in SwiftData models. Covers when to use inheritance versus enums or protocols, how to annotate subclasses, query across hierarchies, and avoid common pitfalls with schema migrations and relationship modeling.
+
+## When This Skill Activates
+
+- User is designing a SwiftData model hierarchy with shared base properties
+- User asks about `@Model` on subclasses or how inheritance works in SwiftData
+- User needs to query across a type hierarchy (all trips vs only business trips)
+- User is deciding between inheritance, enums, or protocols for model variants
+- User has issues with polymorphic relationships or type casting in SwiftData
+- User is migrating a Core Data inheritance hierarchy to SwiftData
+
+## Decision Tree
+
+```
+Do your model variants share a common identity and most properties?
+|
++-- YES: Clear IS-A relationship (BusinessTrip IS-A Trip)
+|   |
+|   +-- Subclasses add significant unique properties or behavior?
+|   |   +-- YES --> Use class inheritance (this skill)
+|   |   +-- NO, just 1-2 distinguishing fields --> Use enum property on base model
+|   |
+|   +-- Need to query "all trips" AND "only business trips"?
+|       +-- YES --> Inheritance gives you both for free
+|       +-- Only one type at a time --> Enum filter is simpler
+|
++-- NO: Models share only a few properties
+|   +-- Use protocol conformance (no SwiftData inheritance needed)
+|
++-- UNCERTAIN: Could go either way
+    +-- Prefer enum on base model (simpler schema, easier migrations)
+    +-- Promote to inheritance later if variants diverge significantly
+```
+
+### When to Use Inheritance
+
+- There is a meaningful IS-A relationship (a `BusinessTrip` fundamentally IS a `Trip`)
+- Subclasses add substantial unique stored properties
+- You need deep queries (fetch all `Trip` instances regardless of subtype) and shallow queries (fetch only `BusinessTrip`)
+- Polymorphic relationships are required (a `[Trip]` array holding mixed subtypes)
+
+### When to Avoid Inheritance
+
+- Subclasses share only a few properties -- use a protocol instead
+- A boolean flag or enum could represent the distinction without separate classes
+- You want to minimize schema migration complexity
+- The hierarchy would go deeper than two levels
+
+## API Patterns
+
+### Base Model Declaration
+
+Apply `@Model` to the base class. All persistent properties live here.
+
+```swift
+@Model
+class Trip {
+    var name: String
+    var startDate: Date
+    var endDate: Date
+
+    @Attribute(.preserveValueOnDeletion)
+    var identifier: UUID
+
+    @Relationship(deleteRule: .cascade, inverse: \Accommodation.trip)
+    var accommodations: [Accommodation] = []
+
+    init(name: String, startDate: Date, endDate: Date) {
+        self.identifier = UUID()
+        self.name = name
+        self.startDate = startDate
+        self.endDate = endDate
+    }
+}
+```
+
+### Subclass Declaration
+
+Apply `@Model` to each subclass. Call `super.init()` and add subclass-specific stored properties.
+
+```swift
+@Model
+class BusinessTrip: Trip {
+    var company: String
+    var expenseReport: String?
+    var meetingAgenda: String?
+
+    init(name: String, startDate: Date, endDate: Date, company: String) {
+        self.company = company
+        super.init(name: name, startDate: startDate, endDate: endDate)
+    }
+}
+
+@Model
+class PersonalTrip: Trip {
+    enum Reason: String, Codable {
+        case vacation
+        case family
+        case adventure
+    }
+
+    var reason: Reason
+    var companions: [String] = []
+
+    init(name: String, startDate: Date, endDate: Date, reason: Reason) {
+        self.reason = reason
+        super.init(name: name, startDate: startDate, endDate: endDate)
+    }
+}
+```
+
+### Relationships Across the Hierarchy
+
+Relationships defined on the base class apply to all subclasses. The inverse can point to a base class property and will resolve to the correct subclass at runtime.
+
+```swift
+@Model
+class Accommodation {
+    var name: String
+
+    // Points to Trip -- could be BusinessTrip or PersonalTrip at runtime
+    @Relationship(inverse: \Trip.accommodations)
+    var trip: Trip?
+
+    init(name: String) { self.name = name }
+}
+```
+
+### ModelContainer Configuration
+
+Register the base class. SwiftData discovers subclasses automatically.
+
+```swift
+// Register Trip -- BusinessTrip and PersonalTrip are included automatically
+let container = try ModelContainer(for: Trip.self, Accommodation.self, Itinerary.self)
+```
+
+## Querying Hierarchies
+
+### Deep Query (All Subclasses)
+
+Querying the base class returns instances of every subclass.
+
+```swift
+// Returns Trip, BusinessTrip, and PersonalTrip instances
+@Query(sort: \Trip.startDate)
+var allTrips: [Trip]
+```
+
+### Type Filtering with Predicate
+
+Narrow results to a specific subclass using `is` or `as?` in a `#Predicate`.
+
+```swift
+// Only BusinessTrip instances
+let businessOnly = #Predicate<Trip> { trip in
+    trip is BusinessTrip
+}
+
+@Query(filter: #Predicate<Trip> { $0 is BusinessTrip }, sort: \Trip.startDate)
+var businessTrips: [Trip]
+```
+
+### Subclass Property Filtering
+
+Access subclass-specific properties with conditional casting inside the predicate.
+
+```swift
+let vacationTrips = #Predicate<Trip> { trip in
+    if let personal = trip as? PersonalTrip {
+        personal.reason == .vacation
+    } else {
+        false
+    }
+}
+```
+
+### Enum-Based Filter Switching in UI
+
+A common pattern for filter controls that switch between all trips and a specific type.
+
+```swift
+enum TripFilter: String, CaseIterable, Identifiable {
+    case all, business, personal
+    var id: String { rawValue }
+}
+
+struct TripListView: View {
+    @State private var filter: TripFilter = .all
+    @Query(sort: \Trip.startDate) var allTrips: [Trip]
+
+    var filteredTrips: [Trip] {
+        switch filter {
+        case .all: return allTrips
+        case .business: return allTrips.filter { $0 is BusinessTrip }
+        case .personal: return allTrips.filter { $0 is PersonalTrip }
+        }
+    }
+
+    var body: some View {
+        List {
+            Picker("Filter", selection: $filter) {
+                ForEach(TripFilter.allCases) { f in
+                    Text(f.rawValue.capitalized).tag(f)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            ForEach(filteredTrips) { trip in
+                TripRowView(trip: trip)
+            }
+        }
+    }
+}
+```
+
+### Type Casting at Runtime
+
+Use standard Swift casting to access subclass-specific properties in views.
+
+```swift
+if let business = trip as? BusinessTrip {
+    LabeledContent("Company", value: business.company)
+}
+if let personal = trip as? PersonalTrip {
+    LabeledContent("Reason", value: personal.reason.rawValue)
+}
+```
+
+## Top Mistakes
+
+### 1. Missing @Model on Subclass
+
+The `@Model` macro must appear on both the base class and every subclass. Omitting it on a subclass causes its unique properties to be silently ignored.
+
+```swift
+// WRONG -- subclass properties not persisted
+class BusinessTrip: Trip {
+    var company: String  // not saved
+    ...
+}
+
+// RIGHT
+@Model
+class BusinessTrip: Trip {
+    var company: String  // persisted correctly
+    ...
+}
+```
+
+### 2. Deep Hierarchies
+
+Keep to one level of subclassing. Going beyond two levels (base + one tier) increases schema complexity and migration risk.
+
+```swift
+// WRONG -- three levels deep
+@Model class InternationalBusinessTrip: BusinessTrip { ... }  // avoid
+
+// RIGHT -- flat: base + one level
+@Model class Trip { ... }
+@Model class BusinessTrip: Trip { ... }
+@Model class PersonalTrip: Trip { ... }
+```
+
+### 3. Using Inheritance When an Enum Would Suffice
+
+If the only difference is a type tag and one or two optional fields, an enum on the base model is simpler.
+
+```swift
+// WRONG -- inheritance just for a category label
+@Model class DomesticTrip: Trip { }
+@Model class InternationalTrip: Trip { var passportRequired: Bool = true }
+
+// RIGHT -- enum property on the base model
+@Model class Trip {
+    enum Category: String, Codable { case domestic, international }
+    var name: String
+    var category: Category
+    var passportRequired: Bool?
+}
+```
+
+### 4. Forgetting super.init()
+
+Subclass initializers must call `super.init()` with all required base properties. Missing this causes incomplete or corrupt records.
+
+```swift
+// WRONG -- base properties uninitialized
+init(company: String) {
+    self.company = company
+    // Missing super.init(name:startDate:endDate:)
+}
+
+// RIGHT -- always call super.init()
+init(name: String, startDate: Date, endDate: Date, company: String) {
+    self.company = company
+    super.init(name: name, startDate: startDate, endDate: endDate)
+}
+```
+
+### 5. Registering Subclasses Separately in ModelContainer
+
+SwiftData discovers subclasses automatically. Register only the base class.
+
+```swift
+// UNNECESSARY
+let container = try ModelContainer(for: Trip.self, BusinessTrip.self, PersonalTrip.self)
+
+// RIGHT
+let container = try ModelContainer(for: Trip.self)
+```
+
+## Review Checklist
+
+When reviewing code that uses SwiftData class inheritance, verify each item:
+
+- [ ] `@Model` is applied to the base class AND every subclass
+- [ ] Each subclass calls `super.init()` with all required base properties
+- [ ] Hierarchy is shallow (base + one level of subclasses, no deeper)
+- [ ] The IS-A relationship is meaningful -- not just a type tag that could be an enum
+- [ ] `@Attribute(.preserveValueOnDeletion)` is used on fields needed after deletion (sync IDs, audit trails)
+- [ ] Relationships use `inverse:` parameters correctly, pointing to the base class property
+- [ ] `@Relationship(deleteRule:)` is specified on owning side (`.cascade`, `.nullify`, or `.deny`)
+- [ ] Deep queries (base class fetch) and shallow queries (type-filtered) both work as expected
+- [ ] Type casting (`as? Subclass`) is used safely with `if let` in views and logic
+- [ ] ModelContainer registers the base class (subclasses are auto-discovered)
+- [ ] Schema migration plan exists if the hierarchy will evolve (adding/removing subclasses)
+- [ ] Enum-based filter pattern is used for UI that switches between type views
+
+## Cross-Reference
+
+- For **SwiftData repository and architecture patterns**, see `macos/swiftdata-architecture/`
+- For **SwiftData concurrency with @ModelActor**, see `swift/concurrency-patterns/`
+- For **persistence setup generator**, see `generators/persistence-setup/`
+
+## References
+
+- [Preserving your app's model data across launches](https://developer.apple.com/documentation/swiftdata/preserving-your-apps-model-data-across-launches)
+- [SwiftData documentation](https://developer.apple.com/documentation/swiftdata)
+- Apple doc: `/Users/ravishankar/Downloads/docs/SwiftData-Class-Inheritance.md`

--- a/.claude/skills/swiftui-debugging/SKILL.md
+++ b/.claude/skills/swiftui-debugging/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: swiftui-debugging
+description: Diagnose SwiftUI performance issues including unnecessary re-renders, view identity problems, and slow body evaluations. Use when SwiftUI views are slow, janky, or re-rendering too often.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# SwiftUI Performance Debugging
+
+Systematic guide for diagnosing and fixing SwiftUI performance problems: unnecessary view re-evaluations, identity issues, expensive body computations, and lazy loading mistakes.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Reports slow or janky SwiftUI views
+- Sees excessive view re-renders or body re-evaluations
+- Asks about `Self._printChanges()` or view debugging
+- Has scrolling performance issues with lists or grids
+- Asks why a view keeps updating when nothing changed
+- Mentions `@Observable` or `ObservableObject` performance differences
+- Wants to understand SwiftUI view identity or diffing
+- Uses `AnyView` and asks about performance implications
+- Has a hang or stutter traced to SwiftUI rendering
+
+## Decision Tree
+
+```
+What SwiftUI performance problem are you seeing?
+|
++- Views re-render when they should not
+|  +- Read body-reevaluation.md
+|     +- Self._printChanges() to identify which property changed
+|     +- @Observable vs ObservableObject observation differences
+|     +- Splitting views to narrow observation scope
+|
++- Scrolling is slow / choppy (lists, grids)
+|  +- Read lazy-loading.md
+|     +- VStack vs LazyVStack, ForEach without lazy container
+|     +- List prefetching, grid cell reuse
+|
++- Views lose state unexpectedly / animate when they should not
+|  +- Read view-identity.md
+|     +- Structural vs explicit identity
+|     +- .id() misuse, conditional view branching
+|
++- Known pitfall (AnyView, DateFormatter in body, etc.)
+|  +- Read common-pitfalls.md
+|     +- AnyView type erasure, object creation in body
+|     +- Over-observation, expensive computations
+|
++- General "my SwiftUI app is slow" (unknown cause)
+|  +- Start with body-reevaluation.md, then common-pitfalls.md
+|  +- Use Instruments SwiftUI template (see Debugging Tools below)
+```
+
+## API Availability
+
+| API / Technique | Minimum Version | Reference |
+|----------------|-----------------|-----------|
+| `Self._printChanges()` | iOS 15 | body-reevaluation.md |
+| `@Observable` | iOS 17 / macOS 14 | body-reevaluation.md |
+| `@ObservableObject` | iOS 13 | body-reevaluation.md |
+| `LazyVStack` / `LazyHStack` | iOS 14 | lazy-loading.md |
+| `LazyVGrid` / `LazyHGrid` | iOS 14 | lazy-loading.md |
+| `.id()` modifier | iOS 13 | view-identity.md |
+| Instruments SwiftUI template | Xcode 14+ | SKILL.md |
+| `os_signpost` | iOS 12 | SKILL.md |
+
+## Top 5 Mistakes -- Quick Reference
+
+| # | Mistake | Fix | Details |
+|---|---------|-----|---------|
+| 1 | Large `ForEach` inside `VStack` or `ScrollView` without lazy container | Wrap in `LazyVStack` -- eager `VStack` creates all views upfront | lazy-loading.md |
+| 2 | Using `AnyView` to erase types | Use `@ViewBuilder`, `Group`, or concrete generic types -- `AnyView` defeats diffing | common-pitfalls.md |
+| 3 | Creating objects in `body` (`DateFormatter()`, `NumberFormatter()`) | Use `static let` shared instances or `@State` for mutable objects | common-pitfalls.md |
+| 4 | Observing entire model when only one property is needed | Split into smaller `@Observable` objects or extract subviews | body-reevaluation.md |
+| 5 | Unstable `.id()` values causing full view recreation every render | Use stable identifiers (database IDs, UUIDs), never array indices or random values | view-identity.md |
+
+## Debugging Tools
+
+### Self._printChanges()
+
+Add to any view body to see what triggered re-evaluation:
+
+```swift
+var body: some View {
+    let _ = Self._printChanges()
+    // ... view content
+}
+```
+
+Output reads: `ViewName: @self, @identity, _propertyName changed.`
+See body-reevaluation.md for full interpretation guide.
+
+### Instruments SwiftUI Template
+
+1. **Xcode > Product > Profile** (Cmd+I)
+2. Choose **SwiftUI** template (includes View Body, View Properties, Core Animation Commits)
+3. Record, reproduce the slow interaction, stop
+4. **View Body** lane shows which views had their body evaluated and how often
+5. **View Properties** lane shows which properties changed
+
+### os_signpost for Custom Measurement
+
+```swift
+import os
+
+private let perfLog = OSLog(subsystem: "com.app.perf", category: "SwiftUI")
+
+var body: some View {
+    let _ = os_signpost(.event, log: perfLog, name: "MyView.body")
+    // ... view content
+}
+```
+
+View in Instruments with the **os_signpost** instrument to count body evaluations per second.
+
+## Review Checklist
+
+### View Identity
+- [ ] No unstable `.id()` values (random, Date(), array index on mutable arrays)
+- [ ] Conditional branches (`if`/`else`) do not cause unnecessary view destruction
+- [ ] `ForEach` uses stable, unique identifiers from the model
+
+### Body Re-evaluation
+- [ ] Views observe only the properties they actually use
+- [ ] `@Observable` classes preferred over `ObservableObject` (iOS 17+)
+- [ ] No unnecessary `@State` changes that trigger body re-evaluation
+- [ ] Large views split into smaller subviews to narrow observation scope
+
+### Lazy Loading
+- [ ] Large collections use `LazyVStack` / `LazyHStack`, not `VStack` / `HStack`
+- [ ] `List` or lazy stack used for 50+ items
+- [ ] No `.frame(maxHeight: .infinity)` on children inside lazy containers (defeats laziness)
+
+### Common Pitfalls
+- [ ] No `AnyView` type erasure (use `@ViewBuilder` or `Group`)
+- [ ] No object allocation in `body` (`DateFormatter`, `NSPredicate`, view models)
+- [ ] Expensive computations moved to background with `task { }` or `Task.detached`
+- [ ] Images use `AsyncImage` or `.resizable()` with proper sizing, not raw `UIImage` decoding in body
+
+## Reference Files
+
+| File | Content |
+|------|---------|
+| [view-identity.md](view-identity.md) | Structural vs explicit identity, `.id()` usage, conditional branching |
+| [body-reevaluation.md](body-reevaluation.md) | What triggers body, `_printChanges()`, `@Observable` vs `ObservableObject` |
+| [lazy-loading.md](lazy-loading.md) | Lazy vs eager containers, `List`, `ForEach`, grid performance |
+| [common-pitfalls.md](common-pitfalls.md) | `AnyView`, object creation in body, over-observation, expensive computations |
+| [../profiling/SKILL.md](../profiling/SKILL.md) | General Instruments profiling (Time Profiler, Memory, Energy) |

--- a/.claude/skills/swiftui-debugging/body-reevaluation.md
+++ b/.claude/skills/swiftui-debugging/body-reevaluation.md
@@ -1,0 +1,398 @@
+# Body Re-evaluation
+
+Understanding what triggers SwiftUI to call a view's `body` property, how to diagnose unnecessary re-evaluations, and how to minimize wasted work.
+
+## What Triggers body Re-evaluation
+
+SwiftUI calls `body` when it detects that a view's **dependencies** have changed. Dependencies include:
+
+| Dependency type | Triggers body when... |
+|----------------|----------------------|
+| `@State` | The wrapped value changes |
+| `@Binding` | The source value changes |
+| `@Environment` | The environment value changes |
+| `@Observable` object (iOS 17+) | A property **that body actually reads** changes |
+| `@ObservedObject` / `@EnvironmentObject` | The `objectWillChange` publisher fires (any property) |
+| Parent passes new value | An input property's value is different from last render |
+
+Key insight: `body` being called does **not** necessarily mean the view re-renders on screen. SwiftUI diffs the output of `body` against the previous output and only updates what changed. However, calling `body` itself has a cost -- especially for complex view hierarchies.
+
+## Self._printChanges()
+
+The most important debugging tool for re-evaluation. Add it as the first line in `body`:
+
+```swift
+struct ItemDetailView: View {
+    let item: Item
+    @State private var isEditing = false
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let _ = Self._printChanges()
+        // ... view content
+    }
+}
+```
+
+### Reading the Output
+
+Output format: `ViewName: _dependency1, _dependency2 changed.`
+
+| Output | Meaning |
+|--------|---------|
+| `ItemDetailView: _item changed.` | The `item` property received a new value from the parent |
+| `ItemDetailView: _isEditing changed.` | The `@State` property `isEditing` was modified |
+| `ItemDetailView: _colorScheme changed.` | The environment's color scheme changed |
+| `ItemDetailView: @self changed.` | The view struct itself was recreated (parent's body ran) |
+| `ItemDetailView: @identity changed.` | The view's identity changed (destroyed and recreated) |
+
+### @self changed -- What It Means
+
+`@self changed` means the parent view's `body` was called, which recreated this view's struct. Even if all property values are identical, SwiftUI may still call `body` because the struct was freshly allocated.
+
+This is the most common source of "unnecessary" re-evaluations. Fix it by ensuring the parent does not needlessly recreate child views.
+
+### Reducing @self Changes
+
+```swift
+// ❌ Parent rebuilds child every time its own body runs
+struct ParentView: View {
+    @State private var counter = 0
+
+    var body: some View {
+        VStack {
+            Text("Count: \(counter)")
+            Button("+1") { counter += 1 }
+            ExpensiveChildView()  // @self changes every time counter changes
+        }
+    }
+}
+
+// ✅ Extract child so its body only runs when its own deps change
+struct ParentView: View {
+    @State private var counter = 0
+
+    var body: some View {
+        VStack {
+            CounterSection(counter: $counter)
+            ExpensiveChildView()  // Now in its own struct, isolated from counter
+        }
+    }
+}
+
+struct CounterSection: View {
+    @Binding var counter: Int
+
+    var body: some View {
+        VStack {
+            Text("Count: \(counter)")
+            Button("+1") { counter += 1 }
+        }
+    }
+}
+```
+
+## @Observable vs ObservableObject
+
+This is the single largest performance improvement available in modern SwiftUI.
+
+### ObservableObject: Whole-Object Observation (iOS 13+)
+
+`ObservableObject` notifies **all** observing views when **any** `@Published` property changes:
+
+```swift
+// Every view observing this object re-evaluates when ANY property changes
+class UserStore: ObservableObject {
+    @Published var name = ""           // Change triggers all observers
+    @Published var email = ""          // Change triggers all observers
+    @Published var avatarURL: URL?     // Change triggers all observers
+    @Published var preferences = Preferences()  // Change triggers all observers
+}
+
+struct NameLabel: View {
+    @ObservedObject var store: UserStore
+
+    var body: some View {
+        let _ = Self._printChanges()
+        // This body runs when email, avatarURL, or preferences change too!
+        Text(store.name)
+    }
+}
+```
+
+### @Observable: Per-Property Observation (iOS 17+)
+
+`@Observable` tracks which properties each view's `body` actually **reads** and only notifies when those specific properties change:
+
+```swift
+@Observable
+class UserStore {
+    var name = ""
+    var email = ""
+    var avatarURL: URL?
+    var preferences = Preferences()
+}
+
+struct NameLabel: View {
+    var store: UserStore
+
+    var body: some View {
+        let _ = Self._printChanges()
+        // Only re-evaluates when store.name changes
+        // Changes to email, avatarURL, preferences do NOT trigger this view
+        Text(store.name)
+    }
+}
+```
+
+### Migration Benefit
+
+| Scenario | ObservableObject | @Observable |
+|----------|-----------------|-------------|
+| 10 views observe a model with 5 properties | Changing 1 property re-evaluates all 10 views | Only views reading that specific property re-evaluate |
+| List of 100 rows, each observing a shared store | All 100 rows re-evaluate on any change | Only affected rows re-evaluate |
+| Form with 20 fields bound to a model | Every keystroke re-evaluates all 20 fields | Only the active field re-evaluates |
+
+### @Observable Gotchas
+
+**Reading a property outside body does not create observation:**
+
+```swift
+@Observable class Model {
+    var value = 0
+}
+
+struct MyView: View {
+    var model: Model
+
+    // ❌ This read happens in init, not body -- no observation established
+    var label: String { "Value: \(model.value)" }
+
+    var body: some View {
+        // ✅ Must read model.value inside body (directly or via computed property called from body)
+        Text("Value: \(model.value)")
+    }
+}
+```
+
+**Computed properties that read observed properties do establish observation when called from body:**
+
+```swift
+@Observable class Model {
+    var firstName = ""
+    var lastName = ""
+
+    var fullName: String { "\(firstName) \(lastName)" }
+}
+
+struct NameView: View {
+    var model: Model
+
+    var body: some View {
+        // ✅ This observes both firstName and lastName
+        // because fullName reads them, and fullName is called from body
+        Text(model.fullName)
+    }
+}
+```
+
+## Minimizing Re-evaluations
+
+### Strategy 1: Extract Subviews
+
+The most effective technique. Each extracted subview only re-evaluates when its own dependencies change:
+
+```swift
+// ❌ Monolithic: entire view re-evaluates when any state changes
+struct ProfileView: View {
+    @State private var isEditingName = false
+    @State private var isEditingBio = false
+    var user: User
+
+    var body: some View {
+        VStack {
+            // All of this re-evaluates when isEditingBio changes
+            HStack {
+                Text(user.name)
+                Button("Edit") { isEditingName.toggle() }
+            }
+            // All of this re-evaluates when isEditingName changes
+            HStack {
+                Text(user.bio)
+                Button("Edit") { isEditingBio.toggle() }
+            }
+        }
+    }
+}
+
+// ✅ Split: each section only re-evaluates for its own state
+struct ProfileView: View {
+    var user: User
+
+    var body: some View {
+        VStack {
+            NameSection(name: user.name)
+            BioSection(bio: user.bio)
+        }
+    }
+}
+
+struct NameSection: View {
+    let name: String
+    @State private var isEditing = false
+
+    var body: some View {
+        HStack {
+            Text(name)
+            Button("Edit") { isEditing.toggle() }
+        }
+    }
+}
+
+struct BioSection: View {
+    let bio: String
+    @State private var isEditing = false
+
+    var body: some View {
+        HStack {
+            Text(bio)
+            Button("Edit") { isEditing.toggle() }
+        }
+    }
+}
+```
+
+### Strategy 2: Use EquatableView or Equatable Conformance
+
+Tell SwiftUI to skip body if properties are equal:
+
+```swift
+struct ExpensiveView: View, Equatable {
+    let data: LargeDataSet
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data.id == rhs.data.id && lhs.data.version == rhs.data.version
+    }
+
+    var body: some View {
+        // Complex rendering that should only happen when data truly changes
+        ComplexChart(data: data)
+    }
+}
+
+// Usage: .equatable() tells SwiftUI to use the Equatable conformance
+ExpensiveView(data: chartData)
+    .equatable()
+```
+
+### Strategy 3: Move State Down
+
+Keep `@State` as close to the view that uses it as possible:
+
+```swift
+// ❌ State at the top causes the entire tree to re-evaluate
+struct ContentView: View {
+    @State private var searchText = ""  // Every keystroke re-evaluates everything
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                SearchBar(text: $searchText)
+                ResultsList(query: searchText)
+                // ... many other views that don't need searchText
+                SidePanel()
+                Footer()
+            }
+        }
+    }
+}
+
+// ✅ Encapsulate search state in a dedicated view
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            VStack {
+                SearchSection()  // Owns its own @State
+                SidePanel()      // Not affected by search keystrokes
+                Footer()         // Not affected by search keystrokes
+            }
+        }
+    }
+}
+
+struct SearchSection: View {
+    @State private var searchText = ""
+
+    var body: some View {
+        VStack {
+            SearchBar(text: $searchText)
+            ResultsList(query: searchText)
+        }
+    }
+}
+```
+
+## Counting Body Evaluations
+
+### Instruments SwiftUI Template
+
+The **View Body** instrument counts how many times each view type's body is called:
+
+1. **Xcode > Product > Profile** (Cmd+I)
+2. Choose **SwiftUI** template
+3. Record while reproducing the slow interaction
+4. The **View Body** lane shows evaluation counts per view type
+5. Sort by count to find views that evaluate most frequently
+
+### Manual Counting with os_signpost
+
+```swift
+import os
+
+private let logger = Logger(subsystem: "com.app", category: "ViewBody")
+
+struct MyView: View {
+    var body: some View {
+        let _ = logger.debug("MyView.body evaluated")
+        // ... view content
+    }
+}
+```
+
+Filter Console output by your subsystem to see evaluation frequency.
+
+### What Counts Are Acceptable
+
+| Scenario | Expected body count | Concerning if |
+|----------|-------------------|---------------|
+| View appears once | 1-2 | > 5 |
+| Scroll through 100 rows | ~20-30 (visible + prefetch) | 100+ (not lazy) |
+| Typing in a text field | 1 per keystroke for the field | 50+ other views also updating |
+| Tapping a button | 1-3 for affected views | 20+ unrelated views updating |
+
+## Environment Changes
+
+Environment values like `colorScheme`, `dynamicTypeSize`, and `locale` affect **every** view in the subtree. When they change, a large portion of the view tree re-evaluates.
+
+This is normal and expected -- but avoid reading environment values in views that do not need them:
+
+```swift
+// ❌ Reads colorScheme even though it does not use it
+struct ItemRow: View {
+    @Environment(\.colorScheme) private var colorScheme
+    let item: Item
+
+    var body: some View {
+        Text(item.title)  // Does not actually use colorScheme
+    }
+}
+
+// ✅ Only read environment values you actually use in body
+struct ItemRow: View {
+    let item: Item
+
+    var body: some View {
+        Text(item.title)
+    }
+}
+```

--- a/.claude/skills/swiftui-debugging/common-pitfalls.md
+++ b/.claude/skills/swiftui-debugging/common-pitfalls.md
@@ -1,0 +1,494 @@
+# Common SwiftUI Performance Pitfalls
+
+Specific anti-patterns that cause SwiftUI performance problems, with concrete before/after fixes for each.
+
+## 1. AnyView Type Erasure
+
+### The Problem
+
+`AnyView` wraps a view in a type-erased container. SwiftUI uses **type information** for its diffing algorithm -- when types are erased, SwiftUI cannot efficiently diff and must do more work:
+
+- Cannot use structural identity (all `AnyView` instances have the same type)
+- Cannot skip diffing subtrees when the type has not changed
+- Prevents compile-time optimization of the view hierarchy
+
+### Before (Slow)
+
+```swift
+// ❌ AnyView defeats SwiftUI's diffing optimization
+func makeView(for item: Item) -> AnyView {
+    switch item.kind {
+    case .text:
+        return AnyView(TextItemView(item: item))
+    case .image:
+        return AnyView(ImageItemView(item: item))
+    case .video:
+        return AnyView(VideoItemView(item: item))
+    }
+}
+
+// Usage in ForEach compounds the problem
+ForEach(items) { item in
+    makeView(for: item)  // SwiftUI cannot diff between renders
+}
+```
+
+### After (Fast)
+
+```swift
+// ✅ @ViewBuilder preserves type information for the compiler
+@ViewBuilder
+func makeView(for item: Item) -> some View {
+    switch item.kind {
+    case .text:
+        TextItemView(item: item)
+    case .image:
+        ImageItemView(item: item)
+    case .video:
+        VideoItemView(item: item)
+    }
+}
+
+// ✅ Or better: dedicated view struct (avoids large switch in @ViewBuilder)
+struct ItemView: View {
+    let item: Item
+
+    var body: some View {
+        switch item.kind {
+        case .text:
+            TextItemView(item: item)
+        case .image:
+            ImageItemView(item: item)
+        case .video:
+            VideoItemView(item: item)
+        }
+    }
+}
+```
+
+### When AnyView Is Acceptable
+
+`AnyView` has negligible cost in these cases:
+- A single view used once (not in a list or `ForEach`)
+- Prototyping / throwaway code
+- Bridging to UIKit hosting controllers where type erasure is required
+
+## 2. Object Creation in body
+
+### The Problem
+
+`body` can be called frequently (dozens of times per second during animation). Creating objects each time wastes CPU and memory:
+
+```swift
+// ❌ Creates a new DateFormatter every time body runs
+// DateFormatter init is ~50x more expensive than a simple alloc
+var body: some View {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    Text(formatter.string(from: date))
+}
+```
+
+### Expensive Objects to Watch For
+
+| Object | Cost of creation | Alternative |
+|--------|-----------------|-------------|
+| `DateFormatter` | ~5-10 microseconds | `static let` shared instance |
+| `NumberFormatter` | ~5-10 microseconds | `static let` shared instance |
+| `JSONDecoder` / `JSONEncoder` | Moderate | `static let` shared instance |
+| `NSRegularExpression` | Moderate (compiles regex) | `static let` or Swift `Regex` literal |
+| `NSPredicate` | Moderate | `static let` or reuse via `@State` |
+| `URLSession` | Heavy | Use `URLSession.shared` or inject |
+| View models / controllers | Heavy | `@State` or `@StateObject` |
+| `AttributedString` with markdown | Moderate (parses markdown) | Cache in model or `@State` |
+
+### After (Fast)
+
+```swift
+// ✅ Static shared formatter -- created once, reused forever
+struct DateLabel: View {
+    let date: Date
+
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f
+    }()
+
+    var body: some View {
+        Text(Self.formatter.string(from: date))
+    }
+}
+
+// ✅ Or use the modern formatted() API which handles caching internally
+struct DateLabel: View {
+    let date: Date
+
+    var body: some View {
+        Text(date.formatted(.dateTime.month().day().year()))
+    }
+}
+```
+
+## 3. Over-Observation with ObservableObject
+
+### The Problem
+
+With `ObservableObject`, changing **any** `@Published` property notifies **all** observers. If a large view observes a store with many properties, it re-evaluates on every change:
+
+```swift
+// ❌ All views observing AppState re-evaluate when ANY property changes
+class AppState: ObservableObject {
+    @Published var user: User?
+    @Published var items: [Item] = []
+    @Published var searchText = ""        // Typing here re-evaluates everything
+    @Published var selectedTab = 0
+    @Published var isOnboarding = false
+    @Published var notifications: [Notification] = []
+}
+```
+
+### Fix Option A: Migrate to @Observable (iOS 17+)
+
+```swift
+// ✅ Per-property observation -- views only update when their dependencies change
+@Observable
+class AppState {
+    var user: User?
+    var items: [Item] = []
+    var searchText = ""          // Only views reading searchText re-evaluate
+    var selectedTab = 0
+    var notifications: [Notification] = []
+}
+```
+
+### Fix Option B: Split Into Focused Stores (Pre-iOS 17)
+
+```swift
+// ✅ Each store has a narrow scope
+class UserStore: ObservableObject {
+    @Published var user: User?
+}
+
+class SearchStore: ObservableObject {
+    @Published var searchText = ""
+    @Published var results: [Item] = []
+}
+
+class NavigationStore: ObservableObject {
+    @Published var selectedTab = 0
+}
+```
+
+### Fix Option C: Extract Subviews to Narrow Scope
+
+```swift
+// ❌ Entire view re-evaluates when searchText changes
+struct ContentView: View {
+    @ObservedObject var store: AppState
+
+    var body: some View {
+        VStack {
+            TextField("Search", text: $store.searchText)
+            ItemList(items: store.items)
+            UserBadge(user: store.user)
+        }
+    }
+}
+
+// ✅ Each subview only connects to what it needs
+struct ContentView: View {
+    @ObservedObject var store: AppState
+
+    var body: some View {
+        VStack {
+            SearchBar(store: store)
+            ItemList(items: store.items)
+            UserBadge(user: store.user)
+        }
+    }
+}
+
+struct SearchBar: View {
+    @ObservedObject var store: AppState  // Re-evaluates often, but it's tiny
+
+    var body: some View {
+        TextField("Search", text: $store.searchText)
+    }
+}
+```
+
+## 4. Expensive Computation in body
+
+### The Problem
+
+`body` runs on the main thread. Any expensive work directly blocks the UI:
+
+```swift
+// ❌ Filtering and sorting 10,000 items every time body runs
+var body: some View {
+    let filtered = items.filter { $0.matchesQuery(searchText) }
+    let sorted = filtered.sorted { $0.date > $1.date }
+
+    List(sorted) { item in
+        ItemRow(item: item)
+    }
+}
+```
+
+### After: Cache Computed Results
+
+```swift
+// ✅ Compute on change, not on every body call
+struct ItemListView: View {
+    let items: [Item]
+    @State private var searchText = ""
+    @State private var filteredItems: [Item] = []
+
+    var body: some View {
+        VStack {
+            TextField("Search", text: $searchText)
+            List(filteredItems) { item in
+                ItemRow(item: item)
+            }
+        }
+        .onChange(of: searchText) { _, newValue in
+            filteredItems = items.filter { $0.matchesQuery(newValue) }
+                .sorted { $0.date > $1.date }
+        }
+        .onAppear {
+            filteredItems = items.sorted { $0.date > $1.date }
+        }
+    }
+}
+```
+
+### After: Offload to Background for Large Data Sets
+
+```swift
+// ✅ Background computation for expensive operations
+struct ItemListView: View {
+    let items: [Item]
+    @State private var searchText = ""
+    @State private var filteredItems: [Item] = []
+
+    var body: some View {
+        VStack {
+            TextField("Search", text: $searchText)
+            List(filteredItems) { item in
+                ItemRow(item: item)
+            }
+        }
+        .task(id: searchText) {
+            // Runs on a background cooperative thread
+            // Automatically cancelled if searchText changes again
+            let query = searchText
+            let allItems = items
+            let results = await Task.detached {
+                allItems.filter { $0.matchesQuery(query) }
+                    .sorted { $0.date > $1.date }
+            }.value
+            filteredItems = results
+        }
+    }
+}
+```
+
+## 5. Large Images Without Proper Sizing
+
+### The Problem
+
+Loading full-resolution images in a scrolling list causes memory spikes and decode latency:
+
+```swift
+// ❌ Loads full resolution, decodes on main thread
+List(photos) { photo in
+    Image(uiImage: UIImage(contentsOfFile: photo.path)!)
+        .resizable()
+        .frame(height: 200)
+}
+```
+
+### After (Fast)
+
+```swift
+// ✅ AsyncImage handles loading and caching
+List(photos) { photo in
+    AsyncImage(url: photo.url) { image in
+        image.resizable().scaledToFill()
+    } placeholder: {
+        Color.gray.opacity(0.2)
+    }
+    .frame(height: 200)
+    .clipped()
+}
+
+// ✅ For local images: thumbnail generation off main thread
+struct ThumbnailView: View {
+    let imagePath: String
+    @State private var thumbnail: UIImage?
+
+    var body: some View {
+        Group {
+            if let thumbnail {
+                Image(uiImage: thumbnail)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Color.gray.opacity(0.2)
+            }
+        }
+        .frame(height: 200)
+        .clipped()
+        .task {
+            thumbnail = await UIImage(contentsOfFile: imagePath)?
+                .byPreparingThumbnail(ofSize: CGSize(width: 400, height: 400))
+        }
+    }
+}
+```
+
+## 6. Unnecessary @State Updates
+
+### The Problem
+
+Setting a `@State` variable to its current value still triggers a re-evaluation:
+
+```swift
+// ❌ Triggers re-evaluation even when value hasn't changed
+.onReceive(timer) { _ in
+    currentTime = Date()  // Always a new value, always triggers body
+}
+
+// ❌ Setting state in body (causes infinite loop risk)
+var body: some View {
+    let _ = { isReady = true }()  // NEVER modify state during body
+    Text("Hello")
+}
+```
+
+### After (Fast)
+
+```swift
+// ✅ Guard against redundant updates
+.onReceive(timer) { _ in
+    let newTime = Date()
+    // Only update if the displayed value actually changes
+    if Calendar.current.component(.second, from: newTime) !=
+       Calendar.current.component(.second, from: currentTime) {
+        currentTime = newTime
+    }
+}
+
+// ✅ Use TimelineView for time-based updates (iOS 15+)
+TimelineView(.periodic(from: .now, by: 1.0)) { context in
+    Text(context.date.formatted(.dateTime.hour().minute().second()))
+}
+```
+
+## 7. Deep View Hierarchies
+
+### The Problem
+
+Deeply nested view modifiers create large view trees that are expensive to diff:
+
+```swift
+// ❌ Each modifier adds a wrapper view to the tree
+Text("Hello")
+    .padding()
+    .background(Color.blue)
+    .cornerRadius(8)
+    .padding()
+    .background(Color.gray)
+    .cornerRadius(12)
+    .shadow(radius: 4)
+    .padding()
+    .background(Color.white)
+    .cornerRadius(16)
+```
+
+### After: Consolidate Modifiers
+
+```swift
+// ✅ Flatten by using composite modifiers and fewer nesting levels
+Text("Hello")
+    .padding(8)
+    .background(
+        RoundedRectangle(cornerRadius: 8)
+            .fill(Color.blue)
+    )
+    .padding(8)
+    .background(
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color.gray)
+            .shadow(radius: 4)
+    )
+    .padding(8)
+```
+
+### Custom ViewModifier for Reusable Combinations
+
+```swift
+// ✅ Encapsulate common modifier combinations
+struct CardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(uiColor: .secondarySystemBackground))
+            )
+    }
+}
+
+extension View {
+    func cardStyle() -> some View {
+        modifier(CardStyle())
+    }
+}
+
+// Usage: single modifier instead of three
+Text("Hello").cardStyle()
+```
+
+## 8. Inefficient Conditional Rendering
+
+### The Problem
+
+Using `opacity(0)` or `hidden()` to hide views still keeps them in the view tree and evaluates their body:
+
+```swift
+// ❌ View is invisible but still evaluated and in the layout
+ExpensiveView()
+    .opacity(showExpensive ? 1 : 0)
+```
+
+### After: Conditional Inclusion
+
+```swift
+// ✅ View is not created at all when hidden
+if showExpensive {
+    ExpensiveView()
+}
+
+// ✅ Or use Group with optional for cleaner syntax
+Group {
+    if showExpensive {
+        ExpensiveView()
+    }
+}
+```
+
+Note: this changes the view's structural identity (see view-identity.md). Use `opacity` when you need to preserve state; use `if` when you want to avoid the evaluation cost.
+
+## Quick Diagnosis Table
+
+| Symptom | Likely pitfall | Fix |
+|---------|---------------|-----|
+| Entire screen re-renders on any state change | Over-observation (#3) | Migrate to `@Observable` or split stores |
+| List scrolling stutters | Eager loading, images (#5) | Use `LazyVStack`, async image loading |
+| View body runs 100+ times/second | Unnecessary state updates (#6) | Guard against redundant state changes |
+| Memory climbs while scrolling | Full-resolution images (#5) | Use thumbnails, `AsyncImage` |
+| Initial load takes seconds | Eager container (#1 in lazy-loading.md) | Switch to lazy container |
+| Type checker hangs during build | Large `@ViewBuilder` switch | Extract cases into separate view structs |
+| Animation stutters | Expensive computation in body (#4) | Move to `.task {}` or `onChange` |

--- a/.claude/skills/swiftui-debugging/lazy-loading.md
+++ b/.claude/skills/swiftui-debugging/lazy-loading.md
@@ -1,0 +1,380 @@
+# Lazy vs Eager Loading
+
+How SwiftUI loads views in stacks, lists, and grids -- and the performance consequences of choosing the wrong container.
+
+## Eager vs Lazy Containers
+
+### Eager Containers
+
+`VStack`, `HStack`, and `ZStack` create **all** child views immediately, regardless of whether they are visible on screen:
+
+```swift
+// ❌ Creates ALL 10,000 rows immediately -- hangs on appear
+ScrollView {
+    VStack {
+        ForEach(items) { item in  // 10,000 items
+            ItemRow(item: item)   // All 10,000 created at once
+        }
+    }
+}
+```
+
+### Lazy Containers
+
+`LazyVStack`, `LazyHStack`, `LazyVGrid`, and `LazyHGrid` create child views **on demand** as they scroll into the visible area:
+
+```swift
+// ✅ Only creates visible rows + a small prefetch buffer
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in  // 10,000 items
+            ItemRow(item: item)   // ~20-30 created at a time
+        }
+    }
+}
+```
+
+### List
+
+`List` is **always lazy**. It manages its own scroll view and creates rows on demand:
+
+```swift
+// ✅ Always lazy -- handles large data sets efficiently
+List(items) { item in
+    ItemRow(item: item)
+}
+```
+
+## When to Use Each Container
+
+| Container | Use when | Creates views |
+|-----------|----------|---------------|
+| `VStack` / `HStack` | Few items (< 50) or all must render at once | All immediately |
+| `LazyVStack` / `LazyHStack` | Many items in a `ScrollView` | On demand |
+| `LazyVGrid` / `LazyHGrid` | Grid layout with many items | On demand |
+| `List` | Scrollable list with system styling (swipe actions, separators) | On demand |
+
+Rule of thumb: if you have a `ForEach` with more than ~50 items inside a `ScrollView`, use a lazy container.
+
+## LazyVStack vs VStack: Performance Comparison
+
+### The Cost of Eager Loading
+
+For a list of 1,000 items, each with a moderately complex row:
+
+| Metric | `VStack` | `LazyVStack` |
+|--------|----------|-------------|
+| Views created on appear | 1,000 | ~20-30 |
+| Time to first frame | Seconds (hang) | Milliseconds |
+| Memory at rest | All 1,000 rows in memory | Only visible rows |
+| Scroll start latency | None (already created) | Small (creates as you scroll) |
+
+### Practical Threshold
+
+| Item count | Recommendation |
+|-----------|---------------|
+| 1-20 | `VStack` is fine |
+| 20-50 | Either works; use `LazyVStack` if rows are complex |
+| 50+ | Always use `LazyVStack` or `List` |
+| 500+ | `List` or `LazyVStack` mandatory; consider pagination |
+
+## LazyVStack Configuration
+
+### Pinned Headers
+
+```swift
+ScrollView {
+    LazyVStack(spacing: 12, pinnedViews: [.sectionHeaders]) {
+        ForEach(sections) { section in
+            Section {
+                ForEach(section.items) { item in
+                    ItemRow(item: item)
+                }
+            } header: {
+                SectionHeader(title: section.title)
+            }
+        }
+    }
+}
+```
+
+### Alignment and Spacing
+
+```swift
+LazyVStack(alignment: .leading, spacing: 8) {
+    ForEach(items) { item in
+        ItemRow(item: item)
+    }
+}
+```
+
+## Common Pitfalls with Lazy Containers
+
+### Pitfall 1: Child Views That Defeat Laziness
+
+If a child view requests infinite height, the lazy container must measure all children to determine layout, defeating the purpose of laziness:
+
+```swift
+// ❌ .frame(maxHeight: .infinity) forces the lazy container to measure all children
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ItemRow(item: item)
+                .frame(maxHeight: .infinity)  // Defeats laziness!
+        }
+    }
+}
+
+// ✅ Use fixed or intrinsic sizing
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ItemRow(item: item)
+                .frame(height: 60)  // Fixed height, laziness preserved
+        }
+    }
+}
+```
+
+### Pitfall 2: GeometryReader Inside Lazy Containers
+
+`GeometryReader` proposes `.infinity` to its children. Inside a lazy container, this can cause layout issues:
+
+```swift
+// ❌ GeometryReader inside LazyVStack: layout problems
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            GeometryReader { proxy in
+                ItemRow(item: item, width: proxy.size.width)
+            }
+        }
+    }
+}
+
+// ✅ Use GeometryReader outside the lazy container
+ScrollView {
+    GeometryReader { proxy in
+        LazyVStack {
+            ForEach(items) { item in
+                ItemRow(item: item, width: proxy.size.width)
+            }
+        }
+    }
+}
+
+// ✅ Or use containerRelativeFrame (iOS 17+)
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ItemRow(item: item)
+                .containerRelativeFrame(.horizontal)
+        }
+    }
+}
+```
+
+### Pitfall 3: ScrollView With No Lazy Container
+
+A `ScrollView` does **not** make its content lazy. It only provides scrolling:
+
+```swift
+// ❌ ScrollView alone does NOT make content lazy
+ScrollView {
+    ForEach(items) { item in  // All created immediately!
+        ItemRow(item: item)
+    }
+}
+
+// ✅ Must wrap in LazyVStack
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+```
+
+### Pitfall 4: Nesting ScrollViews
+
+Nesting scroll views in the same direction causes undefined behavior:
+
+```swift
+// ❌ Nested vertical scroll views -- inner scroll may not work
+ScrollView {
+    LazyVStack {
+        ForEach(sections) { section in
+            ScrollView {  // Nested vertical scroll!
+                ForEach(section.items) { item in
+                    ItemRow(item: item)
+                }
+            }
+        }
+    }
+}
+
+// ✅ Use a single scroll view with sections
+ScrollView {
+    LazyVStack(pinnedViews: [.sectionHeaders]) {
+        ForEach(sections) { section in
+            Section {
+                ForEach(section.items) { item in
+                    ItemRow(item: item)
+                }
+            } header: {
+                SectionHeader(title: section.title)
+            }
+        }
+    }
+}
+```
+
+## Grid Performance
+
+### LazyVGrid
+
+```swift
+let columns = [
+    GridItem(.adaptive(minimum: 150, maximum: 200))
+]
+
+ScrollView {
+    LazyVGrid(columns: columns, spacing: 16) {
+        ForEach(items) { item in
+            ItemCell(item: item)
+        }
+    }
+    .padding()
+}
+```
+
+### Fixed vs Adaptive vs Flexible Columns
+
+| Column type | Behavior | Performance note |
+|------------|----------|-----------------|
+| `.fixed(200)` | Exact width | Fastest layout calculation |
+| `.flexible(minimum: 100, maximum: 300)` | Fills available space | Moderate layout cost |
+| `.adaptive(minimum: 150)` | As many as fit | Most layout calculation |
+
+For large grids (500+ items), prefer `.fixed()` columns to minimize layout computation.
+
+## List Performance
+
+### Built-in Optimizations
+
+`List` provides features that lazy stacks do not:
+- Cell reuse (like `UITableView`)
+- Built-in swipe actions
+- Separator management
+- Edit mode with reordering and deletion
+
+### List Optimization Tips
+
+```swift
+List(items) { item in
+    ItemRow(item: item)
+        .listRowSeparator(.hidden)  // Slightly faster if you don't need separators
+}
+.listStyle(.plain)  // .plain is faster than .insetGrouped for large lists
+```
+
+### When to Use List vs LazyVStack
+
+| Feature | `List` | `LazyVStack` in `ScrollView` |
+|---------|--------|------------------------------|
+| Cell reuse | Yes | No (but still lazy creation) |
+| Custom styling | Limited | Full control |
+| Swipe actions | Built-in | Manual implementation |
+| Section headers | Built-in | Manual with `pinnedViews` |
+| Scroll performance | Generally better for 1000+ items | Good for most cases |
+| Pull to refresh | `.refreshable()` works | `.refreshable()` works |
+
+## Scroll Position and Prefetching
+
+### ScrollViewReader for Programmatic Scrolling
+
+```swift
+ScrollViewReader { proxy in
+    ScrollView {
+        LazyVStack {
+            ForEach(items) { item in
+                ItemRow(item: item)
+                    .id(item.id)
+            }
+        }
+    }
+    .onChange(of: selectedItemID) { _, newID in
+        withAnimation {
+            proxy.scrollTo(newID, anchor: .center)
+        }
+    }
+}
+```
+
+### Data Prefetching for Pagination
+
+Lazy containers do not have built-in prefetch callbacks like `UICollectionViewDataSourcePrefetching`. Implement manually:
+
+```swift
+struct PaginatedListView: View {
+    @State private var items: [Item] = []
+    @State private var isLoadingMore = false
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(items) { item in
+                    ItemRow(item: item)
+                        .onAppear {
+                            if item == items.last {
+                                loadMoreIfNeeded()
+                            }
+                        }
+                }
+
+                if isLoadingMore {
+                    ProgressView()
+                }
+            }
+        }
+    }
+
+    private func loadMoreIfNeeded() {
+        guard !isLoadingMore else { return }
+        isLoadingMore = true
+        Task {
+            let newItems = await fetchNextPage()
+            items.append(contentsOf: newItems)
+            isLoadingMore = false
+        }
+    }
+}
+```
+
+## Debugging Lazy Loading Issues
+
+### Confirming Laziness
+
+Add a print statement to verify views are created lazily:
+
+```swift
+struct ItemRow: View {
+    let item: Item
+
+    init(item: Item) {
+        self.item = item
+        print("ItemRow created: \(item.id)")  // Should only print for visible rows
+    }
+
+    var body: some View {
+        Text(item.title)
+    }
+}
+```
+
+If you see all 1,000 items printed at once, the container is not lazy.
+
+### Measuring Scroll Frame Rate
+
+Use CADisplayLink or the Core Animation Commits instrument in Instruments to measure frame rate during scrolling. Dropped frames (below 60fps / 120fps on ProMotion) indicate scroll performance issues.

--- a/.claude/skills/swiftui-debugging/view-identity.md
+++ b/.claude/skills/swiftui-debugging/view-identity.md
@@ -1,0 +1,265 @@
+# View Identity
+
+How SwiftUI decides whether two views are the **same view** (update in place) or **different views** (destroy and recreate). Getting identity wrong causes lost state, broken animations, and unnecessary work.
+
+## Two Kinds of Identity
+
+### Structural Identity (Implicit)
+
+SwiftUI assigns identity based on a view's **position in the view hierarchy**. Two views at the same position in the same parent are considered the same view across renders.
+
+```swift
+// These two Text views have different structural identities
+// because they are at different positions in the VStack
+VStack {
+    Text("First")   // position 0
+    Text("Second")  // position 1
+}
+```
+
+### Explicit Identity
+
+You override structural identity using `.id()` or `ForEach` identifiers. This tells SwiftUI: "this specific value identifies this view."
+
+```swift
+ForEach(items, id: \.id) { item in
+    ItemRow(item: item)  // identity = item.id
+}
+
+DetailView(item: selectedItem)
+    .id(selectedItem.id)  // identity = selectedItem.id
+```
+
+## How SwiftUI Uses Identity
+
+| Identity comparison | SwiftUI behavior |
+|--------------------|-----------------|
+| Same identity, same type | **Update** existing view (preserves `@State`) |
+| Same identity, different type | **Destroy** old view, **create** new view |
+| Different identity | **Destroy** old view, **create** new view |
+| No identity change | **Diff** the view's properties and update as needed |
+
+Key consequence: when identity changes, **all `@State` is lost** and the view is recreated from scratch.
+
+## .id() Modifier
+
+### When to Use .id()
+
+Force SwiftUI to treat a view as a completely new instance:
+
+```swift
+// Force recreation when switching between items
+// Without .id(), SwiftUI would try to update the same view,
+// which can show stale state or skip the appear animation
+DetailView(item: selectedItem)
+    .id(selectedItem.id)
+```
+
+### Stable vs Unstable Identifiers
+
+```swift
+// ✅ Stable: database ID, UUID, or model-provided unique key
+ForEach(items, id: \.databaseID) { item in
+    ItemRow(item: item)
+}
+
+// ✅ Stable: using Identifiable conformance
+ForEach(items) { item in  // uses item.id automatically
+    ItemRow(item: item)
+}
+
+// ❌ Unstable: array index on a mutable array
+// When items are inserted/deleted, indices shift and
+// SwiftUI matches the wrong data to the wrong view
+ForEach(Array(items.enumerated()), id: \.offset) { index, item in
+    ItemRow(item: item)
+}
+
+// ❌ Unstable: random value or Date()
+// Generates a new identity every render, destroying all state
+DetailView(item: item)
+    .id(UUID())  // NEVER do this -- recreates view every body call
+```
+
+### Performance Impact of Unstable .id()
+
+When `.id()` changes every render:
+1. SwiftUI destroys the entire view subtree (including all child views)
+2. All `@State` and `@StateObject` are lost
+3. `onAppear` fires again
+4. Animations treat it as a new view (insertion transition, not update)
+5. Any in-flight async `task` is cancelled and restarted
+
+This is the single most expensive identity mistake. A view with `N` children all get destroyed and recreated.
+
+## Conditional View Branching
+
+### The if/else Identity Problem
+
+`if`/`else` branches create **different structural identities**:
+
+```swift
+// ❌ Problem: toggling isLoading destroys and recreates ContentView
+// because the two branches are different structural positions
+if isLoading {
+    ProgressView()
+} else {
+    ContentView()
+}
+```
+
+When `isLoading` changes from `true` to `false`:
+- `ProgressView` is destroyed (it existed at the "if-true" branch)
+- `ContentView` is created from scratch (it appears at the "if-else" branch)
+- All `@State` inside `ContentView` resets
+
+### When Destruction Is Acceptable
+
+If the two branches show completely different content (like loading vs loaded), this destruction is fine and expected. The problem arises when you use `if`/`else` to toggle **modifiers** on the same view:
+
+```swift
+// ❌ Bad: destroys and recreates the same Text view
+if isHighlighted {
+    Text(item.title)
+        .foregroundStyle(.yellow)
+        .bold()
+} else {
+    Text(item.title)
+        .foregroundStyle(.primary)
+}
+
+// ✅ Good: same structural identity, just different modifier values
+Text(item.title)
+    .foregroundStyle(isHighlighted ? .yellow : .primary)
+    .bold(isHighlighted)
+```
+
+### Ternary Expressions vs if/else in View Body
+
+```swift
+// ✅ Ternary: single structural identity, SwiftUI diffs the values
+RoundedRectangle(cornerRadius: 12)
+    .fill(isSelected ? Color.blue : Color.gray)
+    .frame(height: isExpanded ? 200 : 80)
+
+// ❌ if/else: two different structural identities
+if isSelected {
+    RoundedRectangle(cornerRadius: 12).fill(.blue)
+} else {
+    RoundedRectangle(cornerRadius: 12).fill(.gray)
+}
+```
+
+### AnyView and Identity
+
+`AnyView` erases type information, which breaks structural identity tracking:
+
+```swift
+// ❌ AnyView: SwiftUI cannot track structural identity across renders
+func makeView() -> AnyView {
+    if condition {
+        return AnyView(ViewA())
+    } else {
+        return AnyView(ViewB())
+    }
+}
+
+// ✅ @ViewBuilder: preserves structural identity
+@ViewBuilder
+func makeView() -> some View {
+    if condition {
+        ViewA()
+    } else {
+        ViewB()
+    }
+}
+```
+
+See common-pitfalls.md for more on `AnyView` performance costs.
+
+## ForEach Identity
+
+### How ForEach Uses Identifiers
+
+`ForEach` maps each data element to a view using the `id` key path. SwiftUI uses these identifiers to:
+- Match existing views to updated data (minimizing recreations)
+- Animate insertions, removals, and reorderings
+- Preserve `@State` in each row
+
+```swift
+// ✅ Identifiable conformance (cleanest)
+struct Item: Identifiable {
+    let id: UUID
+    var title: String
+}
+ForEach(items) { item in
+    ItemRow(item: item)
+}
+
+// ✅ Explicit id key path
+ForEach(items, id: \.uniqueKey) { item in
+    ItemRow(item: item)
+}
+```
+
+### Duplicate Identifiers
+
+If two items share the same `id`, SwiftUI behavior is **undefined** -- it may show duplicates, skip items, or crash:
+
+```swift
+// ❌ Dangerous: if two items have the same title, behavior is undefined
+ForEach(items, id: \.title) { item in
+    ItemRow(item: item)
+}
+
+// ✅ Always use a truly unique identifier
+ForEach(items, id: \.id) { item in
+    ItemRow(item: item)
+}
+```
+
+## Debugging Identity Issues
+
+### Symptoms of Identity Problems
+
+| Symptom | Likely cause |
+|---------|-------------|
+| View `@State` resets unexpectedly | Identity changed, causing view recreation |
+| `onAppear` fires repeatedly on the same view | Identity keeps changing (unstable `.id()`) |
+| Animations show insertion/removal instead of smooth update | View destroyed and recreated instead of updated |
+| Scroll position resets in a list | `ForEach` identifiers changed for existing items |
+| Text fields lose focus and typed content | The `TextField` view got a new identity |
+
+### Using _printChanges to Detect Recreation
+
+```swift
+var body: some View {
+    let _ = Self._printChanges()
+    // If you see "@identity changed" in the output,
+    // SwiftUI considers this a brand-new view instance
+    Text("Content")
+}
+```
+
+Output `@identity changed` means the view was **destroyed and recreated**, not updated in place. This usually means an unstable `.id()` or a structural identity change from `if`/`else` branching.
+
+### Verifying with onAppear / onDisappear
+
+```swift
+DetailView(item: item)
+    .id(item.id)
+    .onAppear { print("DetailView appeared: \(item.id)") }
+    .onDisappear { print("DetailView disappeared") }
+```
+
+If you see rapid appear/disappear cycles for the same content, the identity is unstable.
+
+## Fix Patterns Summary
+
+| Problem | Fix |
+|---------|-----|
+| `.id(UUID())` or `.id(Date())` | Use a stable model identifier |
+| `if`/`else` toggling modifiers on same view | Use ternary expressions for modifier values |
+| `ForEach` with array index as id | Use `Identifiable` conformance or stable key path |
+| State lost on navigation | Add `.id(item.id)` to force correct recreation timing |
+| Duplicate `ForEach` identifiers | Ensure model has truly unique `id` property |

--- a/.claude/skills/text-editing/SKILL.md
+++ b/.claude/skills/text-editing/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: text-editing
+description: Styled text display and rich text editing in SwiftUI using Text, AttributedString, and TextEditor with formatting controls. Use when implementing rich text editing or styled text display.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# Styled Text Editing
+
+Patterns for displaying styled text and building rich text editors in SwiftUI. Covers Text styling, AttributedString, TextEditor with selection-based formatting, and custom formatting definitions.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Wants to display styled or formatted text
+- Needs rich text editing with bold/italic/underline controls
+- Asks about AttributedString or TextEditor
+- Wants text formatting toolbars
+- Asks about Markdown rendering in Text views
+- Needs custom text attributes or formatting constraints
+- Wants selection-based text formatting
+
+## Decision Tree
+
+```
+What text feature do you need?
+|
++- Display styled read-only text
+|  +- Simple styling (one style) -> Text Styling section below
+|  +- Mixed styles in one string -> AttributedString section below
+|  +- Markdown content -> Markdown section below
+|
++- Edit plain text
+|  +- TextEditor(text: $stringBinding)
+|
++- Edit rich/styled text
+|  +- Basic rich editor -> Rich Text Editing section below
+|  +- With formatting toolbar -> Formatting Controls section below
+|  +- With custom constraints -> Custom Formatting section below
+```
+
+## API Availability
+
+| API | Minimum Version | Notes |
+|-----|----------------|-------|
+| `Text` with modifiers | iOS 13 | .font(), .bold(), .italic() |
+| `TextEditor(text:)` | iOS 14 | Plain string binding |
+| `.foregroundStyle()` | iOS 15 | Preferred over .foregroundColor() |
+| `AttributedString` | iOS 15 | Rich text model |
+| `.bold(condition)` | iOS 16 | Conditional bold/italic |
+| `.underline(pattern:)` | iOS 16 | Dash, dot patterns |
+| `TextEditor(text:selection:)` | iOS 18 | AttributedString + selection |
+| `AttributedTextSelection` | iOS 18 | Selection-based formatting |
+| `text.transformAttributes(in:)` | iOS 18 | Modify attributes in selection |
+| `AttributedTextFormattingDefinition` | iOS 18 | Custom formatting constraints |
+| `@Environment(\.fontResolutionContext)` | iOS 18 | Resolve font properties |
+
+## Top 5 Mistakes
+
+| # | Mistake | Fix |
+|---|---------|-----|
+| 1 | Using `.foregroundColor()` on new projects | Use `.foregroundStyle()` — supports gradients and ShapeStyle |
+| 2 | `.animation(.spring())` without `value:` on text | Deprecated in iOS 15 — always pass `value:` parameter |
+| 3 | Expecting full Markdown in `Text` | Text only supports inline Markdown: **bold**, *italic*, [links]. No lists, tables, code blocks, images |
+| 4 | Creating new AttributedString instances on every body evaluation | Cache complex AttributedString objects in @State or computed properties outside body |
+| 5 | Using `TextEditor(text: $string)` for rich text | Use `TextEditor(text: $attributedString, selection: $selection)` with AttributedString binding (iOS 18+) |
+
+## Text Styling Quick Reference
+
+```swift
+// Font
+Text("Hello").font(.headline)
+Text("Custom").font(.system(size: 24, design: .rounded))
+
+// Weight
+Text("Bold").fontWeight(.bold)
+
+// Color — prefer foregroundStyle over foregroundColor
+Text("Styled").foregroundStyle(.red)
+Text("Gradient").foregroundStyle(
+    .linearGradient(colors: [.yellow, .blue], startPoint: .top, endPoint: .bottom)
+)
+
+// Decorations
+Text("Bold").bold()
+Text("Conditional").bold(someCondition)
+Text("Underline").underline(true, pattern: .dash, color: .blue)
+Text("Strike").strikethrough(true, pattern: .dot, color: .red)
+
+// Layout
+Text("Centered").multilineTextAlignment(.center)
+Text("Spaced").lineSpacing(10)
+Text("Truncated").lineLimit(2).truncationMode(.tail)
+```
+
+## AttributedString
+
+```swift
+// Create and style ranges
+var text = AttributedString("Red and Blue")
+if let redRange = text.range(of: "Red") {
+    text[redRange].foregroundColor = .red
+    text[redRange].font = .headline
+}
+if let blueRange = text.range(of: "Blue") {
+    text[blueRange].foregroundColor = .blue
+    text[blueRange].underlineStyle = .single
+}
+
+// Display
+Text(text)
+```
+
+### Available Attributes
+
+| Attribute | Type | Example |
+|-----------|------|---------|
+| `.font` | Font | `.headline` |
+| `.foregroundColor` | Color | `.red` |
+| `.backgroundColor` | Color | `.yellow` |
+| `.underlineStyle` | UnderlineStyle | `.single` |
+| `.underlineColor` | Color | `.blue` |
+| `.strikethroughStyle` | UnderlineStyle | `.single` |
+| `.strikethroughColor` | Color | `.red` |
+| `.inlinePresentationIntent` | InlinePresentationIntent | `.stronglyEmphasized` (bold), `.emphasized` (italic) |
+
+## Rich Text Editing (iOS 18+)
+
+```swift
+struct RichTextEditorView: View {
+    @State private var text = AttributedString("Select text to format")
+    @State private var selection = AttributedTextSelection()
+
+    @Environment(\.fontResolutionContext) private var fontResolutionContext
+
+    var body: some View {
+        VStack {
+            TextEditor(text: $text, selection: $selection)
+                .frame(height: 200)
+
+            HStack {
+                Button(action: toggleBold) {
+                    Image(systemName: "bold")
+                }
+                Button(action: toggleItalic) {
+                    Image(systemName: "italic")
+                }
+                Button(action: toggleUnderline) {
+                    Image(systemName: "underline")
+                }
+            }
+        }
+    }
+
+    private func toggleBold() {
+        text.transformAttributes(in: &selection) {
+            let font = $0.font ?? .default
+            let resolved = font.resolve(in: fontResolutionContext)
+            $0.font = font.bold(!resolved.isBold)
+        }
+    }
+
+    private func toggleItalic() {
+        text.transformAttributes(in: &selection) {
+            let font = $0.font ?? .default
+            let resolved = font.resolve(in: fontResolutionContext)
+            $0.font = font.italic(!resolved.isItalic)
+        }
+    }
+
+    private func toggleUnderline() {
+        text.transformAttributes(in: &selection) {
+            if $0.underlineStyle != nil {
+                $0.underlineStyle = nil
+            } else {
+                $0.underlineStyle = .single
+            }
+        }
+    }
+}
+```
+
+### Reading Selection Attributes
+
+```swift
+// Get current attributes at the selection/cursor
+let attributes = selection.typingAttributes(in: text)
+let currentColor = attributes.foregroundColor ?? .primary
+
+// Set color on selection
+text.transformAttributes(in: &selection) {
+    $0.foregroundColor = .blue
+}
+```
+
+## Custom Formatting Definition (iOS 18+)
+
+Constrain which formatting options are available in the editor:
+
+```swift
+struct MyTextFormatting: AttributedTextFormattingDefinition {
+    typealias Scope = AttributeScopes.SwiftUIAttributes
+
+    static let fontWeight = ValueConstraint(
+        \.font,
+        constraint: { font in
+            guard let font = font else { return nil }
+            let weight = font.resolve().weight
+            return font.weight(weight == .bold ? .regular : .bold)
+        }
+    )
+}
+
+// Apply to TextEditor
+TextEditor(text: $text, selection: $selection)
+    .textFormattingDefinition(MyTextFormatting.self)
+```
+
+## Markdown in Text
+
+```swift
+// Inline markdown support
+Text("This is **bold** and *italic* text")
+Text("Visit [Apple](https://www.apple.com)")
+Text("Code: `inline code`")
+```
+
+### Markdown Limitations
+
+Text supports only **inline** Markdown:
+- ✅ Bold (`**text**`), italic (`*text*`), links, inline code
+- ❌ Line breaks, block formatting, lists, tables, code blocks, images, block quotes
+
+## Review Checklist
+
+### Text Display
+- [ ] Using `.foregroundStyle()` instead of deprecated `.foregroundColor()`
+- [ ] `.lineLimit()` paired with `.help()` tooltip or `.textSelection(.enabled)` for truncated text
+- [ ] Dynamic Type supported — using system font styles, not hardcoded sizes
+- [ ] Colors adapt to dark mode — using system colors or semantic styles
+
+### AttributedString
+- [ ] Complex AttributedString cached in @State, not recreated in body
+- [ ] Range lookups use safe `if let range = text.range(of:)` pattern
+- [ ] Appropriate attributes used (`.inlinePresentationIntent` for semantic bold/italic)
+
+### TextEditor
+- [ ] Rich text uses `TextEditor(text: $attributedString, selection: $selection)` (iOS 18+)
+- [ ] Formatting toolbar uses `text.transformAttributes(in: &selection)` pattern
+- [ ] Font resolution uses `@Environment(\.fontResolutionContext)` for toggle logic
+- [ ] Accessibility labels provided for formatting buttons
+
+### Localization
+- [ ] User-facing strings use `LocalizedStringKey`
+- [ ] Markdown in localized strings uses `Text(LocalizedStringKey("**Bold** text"))`
+
+## References
+
+- [SwiftUI Text and Symbol Modifiers](https://developer.apple.com/documentation/SwiftUI/View-Text-and-Symbols)
+- [Building Rich SwiftUI Text Experiences](https://developer.apple.com/documentation/SwiftUI/building-rich-swiftui-text-experiences)
+- [AttributedString Documentation](https://developer.apple.com/documentation/Foundation/AttributedString)
+- [TextEditor Documentation](https://developer.apple.com/documentation/SwiftUI/TextEditor)

--- a/.claude/skills/toolbars/SKILL.md
+++ b/.claude/skills/toolbars/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: toolbars
+description: Modern SwiftUI toolbar patterns including customizable toolbars, search integration, transition effects, and platform-specific behavior. Use when implementing or customizing toolbars in SwiftUI.
+allowed-tools: [Read, Glob, Grep]
+---
+
+# SwiftUI Toolbars
+
+Modern toolbar patterns for SwiftUI apps. Covers customizable toolbars, enhanced search integration, new placements, transition effects, and platform-specific considerations.
+
+## When This Skill Activates
+
+Use this skill when the user:
+- Wants to add or customize toolbars
+- Asks about customizable/user-configurable toolbars
+- Needs search field in toolbar with specific placement
+- Wants toolbar item transitions or animations
+- Asks about toolbar placements (bottomBar, largeSubtitle, etc.)
+- Needs platform-specific toolbar behavior (iOS vs macOS)
+- Wants to reposition system toolbar items (search, sidebar)
+
+## Decision Tree
+
+```
+What toolbar feature do you need?
+|
++- User-customizable toolbar (add/remove/reorder items)
+|  +- Use .toolbar(id:) with ToolbarItem(id:)
+|
++- Search field in toolbar
+|  +- Minimize to button -> .searchToolbarBehavior(.minimize)
+|  +- Reposition search -> DefaultToolbarItem(kind: .search, placement:)
+|
++- Toolbar transition/animation
+|  +- Zoom transition from toolbar item -> .matchedTransitionSource(id:in:)
+|  +- Hide glass background -> .sharedBackgroundVisibility(.hidden)
+|
++- Custom subtitle area content
+|  +- Use ToolbarItem(placement: .largeSubtitle)
+|
++- System toolbar items with custom placement
+|  +- DefaultToolbarItem(kind: .search/.sidebar, placement:)
+```
+
+## API Availability
+
+| API | Minimum Version | Notes |
+|-----|----------------|-------|
+| `.toolbar { }` | iOS 14 | Basic toolbar |
+| `ToolbarItem(placement:)` | iOS 14 | Standard placements |
+| `.toolbar(id:)` | iOS 16 | Customizable toolbars |
+| `ToolbarItem(id:)` | iOS 16 | Items in customizable toolbars |
+| `ToolbarSpacer` | iOS 16 | Fixed and flexible spacers |
+| `.searchable()` | iOS 15 | Search integration |
+| `.searchToolbarBehavior(.minimize)` | iOS 17 | Minimized search button |
+| `DefaultToolbarItem(kind:placement:)` | iOS 18 | Reposition system items |
+| `ToolbarItem(placement: .largeSubtitle)` | iOS 18 | Subtitle area content |
+| `.matchedTransitionSource(id:in:)` | iOS 18 | Toolbar transition source |
+| `.sharedBackgroundVisibility()` | iOS 18 | Glass background control |
+
+## Customizable Toolbars
+
+Allow users to personalize toolbar items by adding, removing, and rearranging:
+
+```swift
+ContentView()
+    .toolbar(id: "main-toolbar") {
+        ToolbarItem(id: "tag") {
+            TagButton()
+        }
+        ToolbarItem(id: "share") {
+            ShareButton()
+        }
+        ToolbarSpacer(.fixed)
+        ToolbarItem(id: "more") {
+            MoreButton()
+        }
+    }
+```
+
+### Toolbar Spacers
+
+```swift
+ToolbarSpacer(.fixed)      // Fixed-width space
+ToolbarSpacer(.flexible)   // Flexible space — pushes items apart
+```
+
+### Anti-Patterns
+
+```swift
+// ❌ Missing IDs in customizable toolbar — items can't be customized
+.toolbar(id: "main") {
+    ToolbarItem {           // No id parameter
+        ShareButton()
+    }
+}
+
+// ✅ Every item needs its own ID
+.toolbar(id: "main") {
+    ToolbarItem(id: "share") {
+        ShareButton()
+    }
+}
+```
+
+## Enhanced Search Integration
+
+### Minimized Search
+
+Renders search field as a compact button that expands on tap:
+
+```swift
+@State private var searchText = ""
+
+NavigationStack {
+    RecipeList()
+        .searchable(text: $searchText)
+        .searchToolbarBehavior(.minimize)
+}
+```
+
+### Repositioning Search
+
+Move the default search field to a different toolbar position:
+
+```swift
+NavigationSplitView {
+    AllCalendarsView()
+} detail: {
+    SelectedCalendarView()
+        .searchable(text: $query)
+        .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                CalendarPicker()
+            }
+            ToolbarItem(placement: .bottomBar) {
+                Invites()
+            }
+            DefaultToolbarItem(kind: .search, placement: .bottomBar)
+            ToolbarSpacer(placement: .bottomBar)
+            ToolbarItem(placement: .bottomBar) {
+                NewEventButton()
+            }
+        }
+}
+```
+
+## System-Defined Toolbar Items
+
+Reposition system items with custom placements:
+
+```swift
+.toolbar {
+    DefaultToolbarItem(kind: .search, placement: .bottomBar)
+    DefaultToolbarItem(kind: .sidebar, placement: .navigationBarLeading)
+}
+```
+
+## Large Subtitle Placement
+
+Place custom content in the navigation bar subtitle area:
+
+```swift
+NavigationStack {
+    DetailView()
+        .navigationTitle("Title")
+        .navigationSubtitle("Subtitle")
+        .toolbar {
+            ToolbarItem(placement: .largeSubtitle) {
+                CustomLargeNavigationSubtitle()
+            }
+        }
+}
+```
+
+The `.largeSubtitle` placement takes precedence over the value provided to `navigationSubtitle(_:)`.
+
+## Transition Effects
+
+### Matched Transition from Toolbar
+
+Create zoom transitions originating from a toolbar button:
+
+```swift
+struct ContentView: View {
+    @State private var isPresented = false
+    @Namespace private var namespace
+
+    var body: some View {
+        NavigationStack {
+            DetailView()
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Show Sheet", systemImage: "globe") {
+                            isPresented = true
+                        }
+                    }
+                    .matchedTransitionSource(id: "world", in: namespace)
+                }
+                .sheet(isPresented: $isPresented) {
+                    SheetView()
+                        .navigationTransition(
+                            .zoom(sourceID: "world", in: namespace))
+                }
+        }
+    }
+}
+```
+
+### Glass Background Control
+
+Control the shared glass background on toolbar items:
+
+```swift
+ContentView()
+    .toolbar(id: "main") {
+        ToolbarItem(id: "build-status", placement: .principal) {
+            BuildStatus()
+        }
+        .sharedBackgroundVisibility(.hidden)
+    }
+```
+
+## Top 5 Mistakes
+
+| # | Mistake | Fix |
+|---|---------|-----|
+| 1 | Missing `id` on ToolbarItem in customizable toolbar | Every item in `.toolbar(id:)` must have its own `id` parameter |
+| 2 | Using `.searchToolbarBehavior(.minimize)` without `.searchable()` | Must pair with `.searchable()` modifier — `.minimize` only affects rendering |
+| 3 | Putting `.matchedTransitionSource` on the Button instead of ToolbarItem | Apply `.matchedTransitionSource(id:in:)` on the `ToolbarItem`, not its content |
+| 4 | Using `.largeSubtitle` alongside `.navigationSubtitle()` expecting both to show | `.largeSubtitle` takes precedence — the subtitle modifier value is hidden |
+| 5 | Forgetting `placement:` on DefaultToolbarItem | Without explicit placement, system items use their default position |
+
+## Platform Considerations
+
+| Platform | Recommendations |
+|----------|----------------|
+| **iOS** | Bottom bar useful on iPhones. Use `.searchToolbarBehavior(.minimize)` for space efficiency. |
+| **iPadOS** | Customizable toolbars valuable in productivity apps. Consider keyboard shortcuts. |
+| **macOS** | Users expect toolbar customization. Use spacers for logical groupings. |
+
+## Review Checklist
+
+### Customizable Toolbars
+- [ ] `.toolbar(id:)` has a unique, stable string identifier
+- [ ] Every `ToolbarItem` within has its own unique `id`
+- [ ] Spacers used to create logical groups of related items
+- [ ] Toolbar tested with customization panel (long-press on iPadOS, right-click on macOS)
+
+### Search Integration
+- [ ] `.searchable()` paired with appropriate `.searchToolbarBehavior()`
+- [ ] Search placement makes sense for the platform (bottom bar on iOS, toolbar on macOS)
+- [ ] `DefaultToolbarItem(kind: .search)` used when repositioning is needed
+
+### Transitions
+- [ ] `.matchedTransitionSource` applied to `ToolbarItem`, not its content view
+- [ ] Namespace declared with `@Namespace` at the view level
+- [ ] Source ID matches between `.matchedTransitionSource` and `.navigationTransition(.zoom)`
+
+### Platform
+- [ ] Toolbar layouts tested on both iOS and macOS (if multiplatform)
+- [ ] Bottom bar items appropriate for small screens
+- [ ] Customizable toolbars provided for complex macOS apps
+
+## References
+
+- [SwiftUI ToolbarItemPlacement](https://developer.apple.com/documentation/SwiftUI/ToolbarItemPlacement)
+- [SwiftUI CustomizableToolbarContent](https://developer.apple.com/documentation/SwiftUI/CustomizableToolbarContent)
+- [SwiftUI SearchToolbarBehavior](https://developer.apple.com/documentation/SwiftUI/SearchToolbarBehavior)
+- [SwiftUI DefaultToolbarItem](https://developer.apple.com/documentation/SwiftUI/DefaultToolbarItem)
+- [SwiftUI ToolbarSpacer](https://developer.apple.com/documentation/SwiftUI/ToolbarSpacer)


### PR DESCRIPTION
## Summary

Relocates eight Claude Code skills that only apply to Taskmato from the global `~/.claude/skills/` directory into the repo-tracked `.claude/skills/` directory.

## Linked issue

None — housekeeping change with no tracking issue.

## Motivation

These skills (macOS development, Swift, SwiftUI, App Store, monetization) were installed globally but are only relevant to this project. Globally they cluttered every other project's skill list; tracked in the repo they load automatically in every worktree and for any agent working on Taskmato.

## Changes

Adds 77 files under `.claude/skills/` (moved verbatim from `~/.claude/skills/`, no content edits):

- `macos-development` — Swift 6+, SwiftUI, AppKit bridging, macOS Tahoe APIs, UI review
- `swift-development` — concurrency patterns, memory, modern idioms
- `swiftdata-inheritance` — SwiftData model hierarchy patterns
- `swiftui-debugging` — re-render, view identity, and body-evaluation diagnosis
- `text-editing` — SwiftUI rich text / `AttributedString` patterns
- `toolbars` — SwiftUI toolbar patterns
- `app-store` — ASO, descriptions, screenshots, review responses
- `monetization` — pricing and tier strategy for Apple apps

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

No Swift sources changed, so `make lint` / tests were not run. Manually verified the skills load from `.claude/skills/` and no longer exist in the global directory.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [x] Safe to label `no-deploy`
- [ ] Preview deploy is useful for reviewing this change
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Skill content is third-party/imported markdown — review the file list and locations rather than the prose. Repo markdown is not linted in CI, so the ~70 new `.md` files won't affect checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)