### PR TITLE
chore(audit): sync workflows and configs with repo-template-base

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     labels:
       - 'dependencies'
     groups:
-      github-actions:
+      first-party-actions:
         patterns:
-          - '*'
+          - 'actions/*'
+      third-party-actions:
+        exclude-patterns:
+          - 'actions/*'

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,9 @@
+[
+  { "name": "idea",            "color": "c5def5", "description": "Rough idea or note captured for later." },
+  { "name": "bug",             "color": "d73a4a", "description": "Something isn't working." },
+  { "name": "enhancement",     "color": "a2eeef", "description": "New capability or meaningful improvement." },
+  { "name": "task",            "color": "e4e669", "description": "Upkeep, refactoring, cleanup, docs, or process work." },
+  { "name": "documentation",   "color": "0075ca", "description": "Improvements or additions to documentation." },
+  { "name": "dependencies",    "color": "0366d6", "description": "Dependency version updates." },
+  { "name": "breaking-change", "color": "b60205", "description": "Introduces a backwards-incompatible change." }
+]

--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -13,30 +13,29 @@ permissions:
   pull-requests: read
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    outputs:
-      relevant: ${{ steps.detect.outputs.relevant }}
-    steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: ./.github/actions/detect-relevant-changes
-        id: detect
-
   build:
-    needs: check
-    if: needs.check.outputs.relevant == 'true'
     runs-on: macos-15
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # required status check is always registered. A job-level skip
+      # leaves that check unreported, which blocks PRs that require it.
       - name: Checkout source code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: Select Xcode
+        if: steps.changes.outputs.relevant == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Sync version
+        if: steps.changes.outputs.relevant == 'true'
         run: bash scripts/sync-version.sh
 
       - name: Build
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           xcodebuild build \
             -project app/Taskmato.xcodeproj \

--- a/.github/workflows/code-codeql.yaml
+++ b/.github/workflows/code-codeql.yaml
@@ -15,18 +15,7 @@ permissions:
   security-events: write
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    outputs:
-      relevant: ${{ steps.detect.outputs.relevant }}
-    steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: ./.github/actions/detect-relevant-changes
-        id: detect
-
   analyze:
-    needs: check
-    if: needs.check.outputs.relevant == 'true'
     name: analyze
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -71,24 +60,38 @@ jobs:
           - language: swift
             runner: macos-15
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # matrix-expanded status check (e.g. "analyze (actions, ubuntu-latest)")
+      # is always registered. A job-level skip leaves that check unreported,
+      # which blocks PRs that require it.
       - name: Checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
+        with:
+          # 'actions' language only cares about workflow/action edits;
+          # 'swift' falls back to the action's default source pattern set
+          # (app/, scripts/, Makefile, workflows) by passing an empty value.
+          patterns: ${{ matrix.language == 'actions' && '^\.github/(workflows|actions)/' || '' }}
 
       - name: Select Xcode
-        if: matrix.language == 'swift'
+        if: matrix.language == 'swift' && steps.changes.outputs.relevant == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Initialize CodeQL
+        if: steps.changes.outputs.relevant == 'true'
         uses: github/codeql-action/init@v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Sync version
-        if: matrix.language == 'swift'
+        if: matrix.language == 'swift' && steps.changes.outputs.relevant == 'true'
         run: bash scripts/sync-version.sh
 
       - name: Build Swift project (for CodeQL extraction)
-        if: matrix.language == 'swift'
+        if: matrix.language == 'swift' && steps.changes.outputs.relevant == 'true'
         run: |
           xcodebuild build \
             -project app/Taskmato.xcodeproj \
@@ -100,6 +103,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO
 
       - name: Perform CodeQL analysis
+        if: steps.changes.outputs.relevant == 'true'
         uses: github/codeql-action/analyze@v4.36.3
         with:
-          category: '/language:${{ matrix.language }}'
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/code-lint.yaml
+++ b/.github/workflows/code-lint.yaml
@@ -13,32 +13,29 @@ permissions:
   pull-requests: read
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    outputs:
-      relevant: ${{ steps.detect.outputs.relevant }}
-    steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: ./.github/actions/detect-relevant-changes
-        id: detect
-
   lint:
-    needs: check
-    if: needs.check.outputs.relevant == 'true'
     runs-on: macos-15
-
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # required status check is always registered. A job-level skip
+      # leaves that check unreported, which blocks PRs that require it.
       - name: Checkout source code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: Select Xcode
+        if: steps.changes.outputs.relevant == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Install SwiftLint
+        if: steps.changes.outputs.relevant == 'true'
         run: brew install swiftlint
 
       - name: Check formatting
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         run: |
           xcrun swift-format lint --recursive --strict \
             app/Taskmato \
@@ -46,5 +43,5 @@ jobs:
             app/TaskmatoUITests
 
       - name: Check lint
-        if: always()
+        if: always() && steps.changes.outputs.relevant == 'true'
         run: swiftlint lint --strict

--- a/.github/workflows/code-test.yaml
+++ b/.github/workflows/code-test.yaml
@@ -13,31 +13,29 @@ permissions:
   pull-requests: read
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    outputs:
-      relevant: ${{ steps.detect.outputs.relevant }}
-    steps:
-      - uses: actions/checkout@v7.0.0
-      - uses: ./.github/actions/detect-relevant-changes
-        id: detect
-
   test:
-    needs: check
-    if: needs.check.outputs.relevant == 'true'
     runs-on: macos-15
-
     steps:
+      # Steps are conditionally skipped rather than the job, so the
+      # required status check is always registered. A job-level skip
+      # leaves that check unreported, which blocks PRs that require it.
       - name: Checkout source code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7
+
+      - name: Detect relevant changes
+        id: changes
+        uses: ./.github/actions/detect-relevant-changes
 
       - name: Select Xcode
+        if: steps.changes.outputs.relevant == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
       - name: Sync version
+        if: steps.changes.outputs.relevant == 'true'
         run: bash scripts/sync-version.sh
 
       - name: Run unit tests
+        if: steps.changes.outputs.relevant == 'true'
         run: |
           xcodebuild test \
             -project app/Taskmato.xcodeproj \

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels from branch prefix
-        uses: actions/labeler@v6.2.0
+        uses: actions/labeler@v6
         with:
           configuration-path: .github/labeler.yml
           sync-labels: true

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,10 +17,10 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
 
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@v5.0.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/seed-labels.yaml
+++ b/.github/workflows/seed-labels.yaml
@@ -1,0 +1,30 @@
+name: Seed labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/labels.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  seed:
+    name: seed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Create or update labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          jq -c '.[]' .github/labels.json | while IFS= read -r label; do
+            name=$(jq -r '.name' <<< "$label")
+            color=$(jq -r '.color' <<< "$label")
+            description=$(jq -r '.description' <<< "$label")
+            gh label create "$name" --color "$color" --description "$description" --force
+          done

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,6 @@
   "[swift]": {
     "editor.defaultFormatter": "sweetpad.sweetpad"
   },
-  "cSpell.words": ["pomodoro", "swiftlint", "taskmato"],
+  "cSpell.words": ["codeql", "pomodoro", "richwklein", "swiftlint", "taskmato"],
   "sweetpad.build.xcodeWorkspacePath": "app/Taskmato.xcodeproj/project.xcworkspace"
 }


### PR DESCRIPTION
## Summary

Sync template-tracked CI files with `richwklein/repo-template-base` (via `/repo-template-audit`), most notably adopting the template's step-level change-detection gating that fixes required checks never reporting on PRs with no relevant changes.

## Linked issue

None — drift found by the template audit.

## Motivation

PR #436 was permanently blocked: its files ruled all heavy CI jobs irrelevant, and the job-level `if:` skip on the CodeQL matrix job meant the matrix never expanded, so the required `analyze (actions, ubuntu-latest)` / `analyze (swift, macos-15)` contexts were never reported. The template (and repo-template-astro / agingdeveloper) already fixed this with step-level gating; taskmato had drifted behind.

## Changes

- **code-codeql.yaml** — merged template's step-level gating (steps no-op instead of the job skipping) while keeping the Swift matrix entry, Xcode select, sync-version, and xcodebuild extraction steps; per-language `patterns` input for the detect action
- **code-build/lint/test.yaml** — same step-level conversion, dropping the separate `check` job
- **pr-labeler.yaml / release-please.yaml** — fast-forward to template: `labeler@v6`, release-please auth via `client-id` + `release-please-action@v5.0.0`
- **New:** `.github/labels.json` + `seed-labels.yaml` workflow (declarative label seeding)
- **dependabot.yml** — split github-actions into first-party / third-party groups
- Action pins normalized to policy: first-party major-only (`checkout@v7`, `labeler@v6`), third-party full patch (`release-please-action@v5.0.0`, `codeql-action@v4.36.3`)
- `.vscode/settings.json` — merged template cSpell words

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

All workflow YAML validated locally; no Swift sources touched, so app lint/tests were not run. This PR touches `.github/workflows/**`, so its own CI run exercises the reworked gating end-to-end (all required contexts should report).

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

⚠️ **Before merging:** release-please.yaml now authenticates with `client-id`; the `RELEASE_BOT_CLIENT_ID` secret must be added (the GitHub App's client ID) or the release workflow breaks on the next main push. `RELEASE_BOT_APP_ID` can be removed afterwards.

No ruleset changes needed — the step-level gating means all five required contexts always report. Once this merges, #436 unblocks on its next synchronize (pull_request runs use the merge commit's workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
