### PR TITLE
feat(reminders): add list scoping via glob patterns

### DIFF
--- a/app/Taskmato/Settings/RemindersSetupSheet.swift
+++ b/app/Taskmato/Settings/RemindersSetupSheet.swift
@@ -14,7 +14,20 @@ struct RemindersSetupSheet: View {
   @Environment(\.dismiss) private var dismiss
 
   @State private var error: RemindersProviderError?
-  @State private var listCount: Int?
+  @State private var allCalendarTitles: [String] = []
+  @State private var patternText: String = ""
+  @FocusState private var isPatternFocused: Bool
+
+  private var listSummaryText: String {
+    let total = allCalendarTitles.count
+    if provider.listPatterns.isEmpty {
+      return "\(total) reminder list\(total == 1 ? "" : "s") available"
+    }
+    let matched = allCalendarTitles.filter {
+      provider.matchesAnyPattern(title: $0, patterns: provider.listPatterns)
+    }.count
+    return "\(matched) of \(total) lists match"
+  }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 16) {
@@ -26,8 +39,11 @@ struct RemindersSetupSheet: View {
 
       HStack {
         Spacer()
-        Button("Done") { dismiss() }
-          .keyboardShortcut(.defaultAction)
+        Button("Done") {
+          commitPatterns()
+          dismiss()
+        }
+        .keyboardShortcut(.defaultAction)
       }
     }
     .padding(24)
@@ -46,6 +62,8 @@ struct RemindersSetupSheet: View {
   private var content: some View {
     if provider.isAuthorized {
       authorizedView
+        .task { await loadAllCalendarTitles() }
+        .onAppear { patternText = provider.listPatterns.joined(separator: ", ") }
     } else if error == .accessRestricted {
       restrictedView
     } else {
@@ -59,13 +77,18 @@ struct RemindersSetupSheet: View {
       Image(systemName: "checkmark.circle.fill")
         .foregroundStyle(.green)
         .imageScale(.large)
-      if let count = listCount {
-        Text("\(count) reminder list\(count == 1 ? "" : "s") available")
-      } else {
-        Text("Reminders access granted")
-      }
+      Text(listSummaryText)
     }
-    .task { await loadListCount() }
+
+    LabeledContent("List patterns") {
+      TextField("e.g. Work*, *Personal*", text: $patternText)
+        .autocorrectionDisabled()
+        .focused($isPatternFocused)
+        .onSubmit { commitPatterns() }
+        .onChange(of: isPatternFocused) { _, focused in
+          if !focused { commitPatterns() }
+        }
+    }
   }
 
   private var grantAccessView: some View {
@@ -130,13 +153,23 @@ struct RemindersSetupSheet: View {
   private func requestAccess() async {
     do {
       try await provider.authorize()
-      await loadListCount()
+      await loadAllCalendarTitles()
     } catch let err as RemindersProviderError {
       error = err
     } catch {}
   }
 
-  private func loadListCount() async {
-    listCount = (try? await provider.lists())?.count
+  private func loadAllCalendarTitles() async {
+    allCalendarTitles = provider.allCalendarTitles()
+  }
+
+  private func commitPatterns() {
+    let patterns =
+      patternText
+      .components(separatedBy: ",")
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+    provider.setListPatterns(patterns)
+    patternText = provider.listPatterns.joined(separator: ", ")
   }
 }

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -26,19 +26,27 @@ final class RemindersProvider: ClosableTaskProvider {
   /// Whether the user has granted full Reminders access.
   private(set) var isAuthorized = false
 
+  /// Glob patterns used to restrict which calendars ``lists()`` returns.
+  /// Empty array means no filtering — all calendars are returned.
+  private(set) var listPatterns: [String]
+
   private let store: any RemindersEventStore
+  private let defaults: UserDefaults
+  private static let patternsKey = "reminders.listPatterns"
   private var streamContinuation: AsyncStream<[TaskItem]>.Continuation?
   private var observer: NSObjectProtocol?
   private let debouncer = Debouncer()
 
   /// Production initializer using live EventKit.
   convenience init() {
-    self.init(store: LiveRemindersEventStore())
+    self.init(store: LiveRemindersEventStore(), defaults: .standard)
   }
 
   /// Test-friendly initializer accepting any ``RemindersEventStore`` conformer.
-  init(store: any RemindersEventStore) {
+  init(store: any RemindersEventStore, defaults: UserDefaults = .standard) {
     self.store = store
+    self.defaults = defaults
+    self.listPatterns = defaults.array(forKey: Self.patternsKey) as? [String] ?? []
     isAuthorized = store.authorizationStatus() == .fullAccess
   }
 
@@ -68,17 +76,40 @@ final class RemindersProvider: ClosableTaskProvider {
     }
   }
 
+  // MARK: - List pattern filtering
+
+  /// Replaces the stored list-pattern array and persists it to UserDefaults.
+  func setListPatterns(_ patterns: [String]) {
+    listPatterns = patterns
+    defaults.set(listPatterns, forKey: Self.patternsKey)
+  }
+
+  /// Returns titles of all Reminders calendars without applying ``listPatterns``.
+  /// Used by the settings UI to compute the N-of-M match preview.
+  func allCalendarTitles() -> [String] {
+    guard isAuthorized else { return [] }
+    return store.calendars(for: .reminder).map(\.title)
+  }
+
+  /// Returns `true` if `title` matches any element of `patterns` using `fnmatch`
+  /// with `FNM_CASEFOLD`. Internal so the settings view can reuse it for live preview.
+  func matchesAnyPattern(title: String, patterns: [String]) -> Bool {
+    patterns.contains { fnmatch($0, title, FNM_CASEFOLD) == 0 }
+  }
+
   // MARK: - TaskProvider
 
   func lists() async throws -> [TaskList] {
     guard isAuthorized else { return [] }
-    return store.calendars(for: .reminder).map { calendar in
+    let all = store.calendars(for: .reminder).map { calendar in
       TaskList(
         id: calendar.calendarIdentifier,
         providerID: Self.providerID,
         name: calendar.title
       )
     }
+    guard !listPatterns.isEmpty else { return all }
+    return all.filter { matchesAnyPattern(title: $0.name, patterns: listPatterns) }
   }
 
   func tasks(in list: TaskList?) async throws -> [TaskItem] {

--- a/app/TaskmatoTests/RemindersProviderTests.swift
+++ b/app/TaskmatoTests/RemindersProviderTests.swift
@@ -193,6 +193,56 @@ struct RemindersProviderListTests {
     #expect(lists.map(\.name) == ["Work", "Personal"])
   }
 }
+// MARK: - List pattern tests
+@Suite("RemindersProvider — list patterns")
+@MainActor
+struct RemindersProviderListPatternTests {
+  private func authorizedProvider(
+    patterns: [String] = [],
+    calendarTitles: [String] = []
+  ) async throws -> RemindersProvider {
+    let store = FakeRemindersEventStore()
+    store.status = .fullAccess
+    store.stubbedCalendars = calendarTitles.map { store.makeCalendar(title: $0) }
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
+    try await provider.authorize()
+    if !patterns.isEmpty { provider.setListPatterns(patterns) }
+    return provider
+  }
+
+  @Test func emptyPatternsReturnsAllLists() async throws {
+    let provider = try await authorizedProvider(
+      patterns: [], calendarTitles: ["Work", "Personal", "Shopping"])
+    #expect(try await provider.lists().count == 3)
+  }
+
+  @Test func singlePatternFiltersToMatchingLists() async throws {
+    let provider = try await authorizedProvider(
+      patterns: ["Work"], calendarTitles: ["Work", "Personal"])
+    let lists = try await provider.lists()
+    #expect(lists.count == 1)
+    #expect(lists.first?.name == "Work")
+  }
+
+  @Test func wildcardGlobMatchesMultipleLists() async throws {
+    let provider = try await authorizedProvider(
+      patterns: ["Work*"], calendarTitles: ["Work", "Work Projects", "Personal"])
+    #expect(try await provider.lists().map(\.name).sorted() == ["Work", "Work Projects"])
+  }
+
+  @Test func matchingIsCaseInsensitive() async throws {
+    let provider = try await authorizedProvider(
+      patterns: ["work"], calendarTitles: ["Work", "Personal"])
+    #expect(try await provider.lists().count == 1)
+  }
+
+  @Test func nonMatchingPatternReturnsEmptyArray() async throws {
+    let provider = try await authorizedProvider(
+      patterns: ["Nonexistent*"], calendarTitles: ["Work", "Personal"])
+    #expect(try await provider.lists().isEmpty)
+  }
+}
 
 // MARK: - Tasks tests
 @Suite("RemindersProvider — tasks")


### PR DESCRIPTION
## Summary

Closes #370.

- Adds `listPatterns: [String]` to `RemindersProvider`; `lists()` filters calendars by title using glob patterns when patterns are non-empty
- Empty patterns preserve existing behaviour — all lists are returned
- Pattern matching uses `fnmatch` with `FNM_CASEFOLD` (case-insensitive, no path-segment semantics)
- Patterns persist across relaunch via `UserDefaults["reminders.listPatterns"]`
- Adds a pattern editor to `RemindersSetupSheet` with live "N of M lists match" preview
- Done button commits the text field before dismissing (prevents patterns from being silently dropped when the field never lost focus)

## Test plan

- [ ] `Cmd+U` — all tests pass, including 5 new pattern tests (`RemindersProviderListPatternTests`)
  - empty patterns → all lists returned
  - single pattern → exact match only
  - glob wildcard (`Work*`) → matches prefix
  - case-insensitive match (`work` matches `Work`)
  - no-match pattern → empty result
- [ ] Launch app → Settings → enable Reminders → open "Configure Apple Reminders…"
  - Pattern field appears below the checkmark when authorized
  - "N reminder lists available" shown when pattern field is empty
  - Type `Work*`, press Return → summary updates to "N of M lists match"; sidebar collapses to matching lists
  - Click Done without pressing Return → pattern still saves (Done button fix)
  - Clear field, press Return → all lists restored
  - Quit and relaunch → pattern persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)