### PR TITLE
fix(reminders): isolate UserDefaults in RemindersProvider tests

### DIFF
--- a/app/TaskmatoTests/RemindersProviderTests.swift
+++ b/app/TaskmatoTests/RemindersProviderTests.swift
@@ -15,7 +15,6 @@ import Testing
 
 @MainActor
 struct RemindersEventStoreTests {
-
   @Test func fakeStoreReturnsConfiguredStatus() {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
@@ -51,7 +50,6 @@ struct RemindersEventStoreTests {
 @Suite("RemindersProvider — authorization")
 @MainActor
 struct RemindersProviderAuthorizationTests {
-
   private func makeProvider(
     status: EKAuthorizationStatus = .notDetermined,
     grantAccess: Bool = true
@@ -59,7 +57,8 @@ struct RemindersProviderAuthorizationTests {
     let store = FakeRemindersEventStore()
     store.status = status
     store.grantAccess = grantAccess
-    let provider = RemindersProvider(store: store)
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
     return (provider, store)
   }
 
@@ -143,13 +142,13 @@ struct RemindersProviderAuthorizationTests {
 @Suite("RemindersProvider — lists")
 @MainActor
 struct RemindersProviderListTests {
-
   private func makeAuthorizedProvider() async throws -> (
     provider: RemindersProvider, store: FakeRemindersEventStore
   ) {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
-    let provider = RemindersProvider(store: store)
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
     try await provider.authorize()
     return (provider, store)
   }
@@ -248,13 +247,13 @@ struct RemindersProviderListPatternTests {
 @Suite("RemindersProvider — tasks")
 @MainActor
 struct RemindersProviderTaskTests {
-
   private func makeAuthorizedProvider() async throws -> (
     provider: RemindersProvider, store: FakeRemindersEventStore
   ) {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
-    let provider = RemindersProvider(store: store)
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
     try await provider.authorize()
     return (provider, store)
   }
@@ -401,13 +400,13 @@ struct RemindersProviderTaskTests {
 @Suite("RemindersProvider — mutations")
 @MainActor
 struct RemindersProviderMutationTests {
-
   private func makeAuthorizedProvider() async throws -> (
     provider: RemindersProvider, store: FakeRemindersEventStore
   ) {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
-    let provider = RemindersProvider(store: store)
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
     try await provider.authorize()
     return (provider, store)
   }
@@ -504,13 +503,13 @@ struct RemindersProviderMutationTests {
 @Suite("RemindersProvider — completedTasks")
 @MainActor
 struct RemindersProviderCompletedTasksTests {
-
   private func makeAuthorizedProvider() async throws -> (
     provider: RemindersProvider, store: FakeRemindersEventStore
   ) {
     let store = FakeRemindersEventStore()
     store.grantAccess = true
-    let provider = RemindersProvider(store: store)
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
     try await provider.authorize()
     return (provider, store)
   }
@@ -543,7 +542,8 @@ struct RemindersProviderCompletedTasksTests {
     store.stubbedReminders = [
       store.makeReminder(title: "Done", isCompleted: true)
     ]
-    let provider = RemindersProvider(store: store)
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, defaults: defaults)
     let tasks = try await provider.completedTasks()
     #expect(tasks.isEmpty)
   }


### PR DESCRIPTION
## Summary

Fixes two `RemindersProviderListTests` that failed deterministically on a clean checkout. The Reminders provider test helpers built `RemindersProvider(store:)` against the shared standard `UserDefaults`, so list-scope glob patterns persisted by the #439 scoping feature (on the developer's machine or by sibling tests) leaked in and filtered out stubbed calendars.

## Linked issue

Closes #440

## Root cause

Since #439, `RemindersProvider.lists()` reads persisted list-scope glob patterns from `UserDefaults`. The `RemindersProviderListTests` helper (and the other `RemindersProvider*Tests` helpers) constructed the provider with the standard suite instead of an isolated one — unlike `RemindersProviderListPatternTests`, which already used a UUID-named suite. Patterns left in the shared defaults filtered out calendars titled "Shopping"/"Groceries", so `listsMapsSingleCalendar()` and `listsUsesCalendarTitleAsListName()` failed.

## Fix

Give every provider-building helper its own `UserDefaults(suiteName: UUID().uuidString)` via the existing `RemindersProvider(store:defaults:)` initializer, matching `RemindersProviderListPatternTests`, so all suites are hermetic and immune to persisted patterns. Removed the redundant blank line after each struct's opening brace to keep the file within the 550-line file-length limit (net line count unchanged).

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

`make lint` (0 violations), `make format-check` (clean), and every `RemindersProvider*Tests`/`RemindersEventStoreTests` suite passes under `xcodebuild test`; the two formerly-red tests now pass.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Test-only change; no app/provider source touched. All six provider-construction sites in the file were isolated (not just the two failing tests) so the whole file is hermetic against future list-scope persistence.
