### PR TITLE
refactor(stats): introduce StatsViewModel and remove SessionStore scope methods

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -20,6 +20,7 @@ struct AppComposition {
   let engine: SessionEngine
   let settings: AppSettings
   let store: SessionStore
+  let statsViewModel: StatsViewModel
   let selectionStore: TaskSelectionStore
   let registry: TaskRegistry
   let notifications: NotificationService
@@ -41,51 +42,25 @@ struct AppComposition {
     let obsidianProvider = ObsidianProvider()
     let localProvider = LocalProvider()
     let remindersProvider = RemindersProvider()
-    // Request notification auth once at launch; refresh on every app activation.
-    Task { await notifications.requestAuthorizationIfNeeded() }
-    NotificationCenter.default.addObserver(
-      forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
-    ) { _ in Task { await notifications.refreshAuthStatus() } }
-
-    registry.register(obsidianProvider)
-    registry.register(localProvider)
-    registry.register(remindersProvider)
-    // Auto-enable on first launch before any provider state is persisted.
-    if registry.enabledIDs.isEmpty { registry.enable(localProvider) }
+    let statsViewModel = StatsViewModel(
+      repository: sessionRepository,
+      providerLabel: { [registry] providerID in
+        registry.providers.first { $0.id == providerID }?.displayName ?? providerID
+      })
+    Self.configureNotifications(notifications)
+    Self.registerProviders(
+      [obsidianProvider, localProvider, remindersProvider], into: registry,
+      fallback: localProvider)
     let nav = MainNavigation(settings: settings)
     let urlHandler = URLSchemeHandler(
       registry: registry, selectionStore: selectionStore,
       engine: engine, settings: settings,
       nav: nav
     )
-    engine.onPhaseEnded = { phase, startedAt, endedAt, wasCompleted in
-      store.append(
-        Session(
-          id: UUID(), phase: phase, startedAt: startedAt,
-          endedAt: endedAt, wasCompleted: wasCompleted,
-          taskRef: selectionStore.activeTask?.id,
-          taskTitle: selectionStore.activeTask?.title
-        ))
-      guard wasCompleted else { return }
-      notifications.send(phase: phase)
-      engine.focusDuration = settings.focusDuration
-      engine.shortBreakDuration = settings.shortBreakDuration
-      engine.longBreakDuration = settings.longBreakDuration
-      let next: SessionPhase
-      switch phase {
-      case .focus:
-        next = engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
-      case .shortBreak, .longBreak: next = .focus
-      }
-      if settings.autoStartNextPhase {
-        engine.start(phase: next)
-      } else {
-        engine.enqueuePhase(next)
-      }
-    }
     self.engine = engine
     self.settings = settings
     self.store = store
+    self.statsViewModel = statsViewModel
     self.selectionStore = selectionStore
     self.registry = registry
     self.notifications = notifications
@@ -94,5 +69,54 @@ struct AppComposition {
     self.remindersProvider = remindersProvider
     self.urlHandler = urlHandler
     self.nav = nav
+    engine.onPhaseEnded = makePhaseEndedHandler()
+  }
+
+  /// Requests notification authorization at launch and refreshes it on each app activation.
+  private static func configureNotifications(_ notifications: NotificationService) {
+    Task { await notifications.requestAuthorizationIfNeeded() }
+    NotificationCenter.default.addObserver(
+      forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+    ) { _ in Task { await notifications.refreshAuthStatus() } }
+  }
+
+  /// Registers each provider, enabling `fallback` on first launch when nothing is persisted.
+  private static func registerProviders(
+    _ providers: [any TaskProvider], into registry: TaskRegistry, fallback: any TaskProvider
+  ) {
+    for provider in providers { registry.register(provider) }
+    if registry.enabledIDs.isEmpty { registry.enable(fallback) }
+  }
+
+  /// Records the completed session, fires the phase notification, and advances the timer.
+  ///
+  /// The engine holds this callback; it moves to `PhaseOrchestrator` at 0.9.0.
+  private func makePhaseEndedHandler() -> (SessionPhase, Date, Date, Bool) -> Void {
+    { phase, startedAt, endedAt, wasCompleted in
+      let session = Session(
+        id: UUID(), phase: phase, startedAt: startedAt,
+        endedAt: endedAt, wasCompleted: wasCompleted,
+        taskRef: self.selectionStore.activeTask?.id,
+        taskTitle: self.selectionStore.activeTask?.title
+      )
+      self.store.append(session)
+      self.statsViewModel.recordAppended(session)
+      guard wasCompleted else { return }
+      self.notifications.send(phase: phase)
+      self.engine.focusDuration = self.settings.focusDuration
+      self.engine.shortBreakDuration = self.settings.shortBreakDuration
+      self.engine.longBreakDuration = self.settings.longBreakDuration
+      let next: SessionPhase
+      switch phase {
+      case .focus:
+        next = self.engine.nextBreakPhase(longBreakAfter: self.settings.longBreakAfterSessions)
+      case .shortBreak, .longBreak: next = .focus
+      }
+      if self.settings.autoStartNextPhase {
+        self.engine.start(phase: next)
+      } else {
+        self.engine.enqueuePhase(next)
+      }
+    }
   }
 }

--- a/app/Taskmato/Session/SessionStore.swift
+++ b/app/Taskmato/Session/SessionStore.swift
@@ -10,8 +10,7 @@ import Observation
 ///
 /// Holds a published mirror of the recorded sessions for synchronous SwiftUI access and
 /// delegates all persistence to an injected ``SessionRepository``. The authoritative cache
-/// lives in the repository; this facade's aggregation helpers move to the stats view model
-/// as the storage layer evolves.
+/// lives in the repository; all scope-shaping and aggregation now lives in ``StatsViewModel``.
 @Observable
 @MainActor
 final class SessionStore {
@@ -43,41 +42,6 @@ final class SessionStore {
   /// - Parameter interval: The date range to scope results to.
   func summary(for interval: DateInterval) -> SessionSummary {
     SessionSummary(sessions: sessions, over: interval)
-  }
-
-  /// Returns a summary scoped to the current calendar day (local time zone).
-  func todaySummary() -> SessionSummary {
-    let calendar = Calendar.current
-    let start = calendar.startOfDay(for: Date())
-    let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
-    return summary(for: DateInterval(start: start, end: end))
-  }
-
-  /// Returns a summary scoped to a rolling seven-day window ending now.
-  func thisWeekSummary() -> SessionSummary {
-    let calendar = Calendar.current
-    let todayStart = calendar.startOfDay(for: Date())
-    let start = calendar.date(byAdding: .day, value: -6, to: todayStart) ?? todayStart
-    return summary(for: DateInterval(start: start, end: Date()))
-  }
-
-  /// Number of completed focus sessions that started today (calendar day, local time zone).
-  func todayFocusCount() -> Int {
-    let calendar = Calendar.current
-    let today = calendar.startOfDay(for: Date())
-    return sessions.filter {
-      $0.phase == .focus && $0.wasCompleted && calendar.startOfDay(for: $0.startedAt) == today
-    }.count
-  }
-
-  /// Total elapsed minutes across all completed focus sessions that started today.
-  func todayFocusMinutes() -> Int {
-    let calendar = Calendar.current
-    let today = calendar.startOfDay(for: Date())
-    let total = sessions.filter {
-      $0.phase == .focus && $0.wasCompleted && calendar.startOfDay(for: $0.startedAt) == today
-    }.reduce(0) { $0 + $1.duration }
-    return Int(total / 60)
   }
 
   // MARK: - Private

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -26,7 +26,7 @@ struct TaskmatoApp: App {
       MenuBarPopoverView(
         engine: composition.engine,
         settings: composition.settings,
-        store: composition.store,
+        statsViewModel: composition.statsViewModel,
         selectionStore: composition.selectionStore,
         registry: composition.registry,
         nav: composition.nav,
@@ -77,7 +77,7 @@ struct TaskmatoApp: App {
       MainWindowView(
         engine: composition.engine,
         settings: composition.settings,
-        store: composition.store,
+        statsViewModel: composition.statsViewModel,
         selectionStore: composition.selectionStore,
         registry: composition.registry,
         nav: composition.nav

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -24,7 +24,7 @@ struct MainWindowView: View {
 
   var engine: SessionEngine
   var settings: AppSettings
-  var store: SessionStore
+  var statsViewModel: StatsViewModel
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   @Bindable var nav: MainNavigation
@@ -50,7 +50,7 @@ struct MainWindowView: View {
         TimerTabView(
           engine: engine,
           settings: settings,
-          store: store,
+          statsViewModel: statsViewModel,
           selectionStore: selectionStore,
           registry: registry,
           nav: nav,
@@ -63,7 +63,7 @@ struct MainWindowView: View {
         AppLabels.Tab.stats.title, systemImage: AppLabels.Tab.stats.systemImage,
         value: MainTab.stats
       ) {
-        StatsTabView(store: store)
+        StatsTabView(statsViewModel: statsViewModel)
       }
     }
     .frame(minWidth: 640, minHeight: 400)
@@ -108,7 +108,7 @@ struct MainWindowView: View {
   MainWindowView(
     engine: SessionEngine(),
     settings: AppSettings(),
-    store: SessionStore(),
+    statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
     nav: MainNavigation(settings: AppSettings())

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -16,7 +16,7 @@ struct MenuBarPopoverView: View {
 
   var engine: SessionEngine
   var settings: AppSettings
-  var store: SessionStore
+  var statsViewModel: StatsViewModel
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   var nav: MainNavigation
@@ -99,7 +99,8 @@ struct MenuBarPopoverView: View {
         nav.showStatsInMainWindow()
         DispatchQueue.main.async { popover?.close() }
       } label: {
-        SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
+        SessionStatsView(
+          count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes)
       }
       .buttonStyle(.plain)
       .padding(.horizontal, 16)
@@ -221,7 +222,7 @@ struct MenuBarPopoverView: View {
   MenuBarPopoverView(
     engine: SessionEngine(),
     settings: AppSettings(),
-    store: SessionStore(),
+    statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
     nav: MainNavigation(settings: AppSettings()),

--- a/app/Taskmato/Views/Stats/StatTypes.swift
+++ b/app/Taskmato/Views/Stats/StatTypes.swift
@@ -1,0 +1,89 @@
+//
+//  StatTypes.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// The time window a stats view is scoped to.
+enum StatScope: CaseIterable {
+
+  /// The current calendar day.
+  case today
+
+  /// A rolling seven-day window.
+  case thisWeek
+
+  /// The current calendar month.
+  case thisMonth
+
+  /// Every recorded session, ignoring period navigation.
+  case allTime
+
+  /// Human-readable title shown in the scope picker.
+  var label: String {
+    switch self {
+    case .today: return "Today"
+    case .thisWeek: return "7 Days"
+    case .thisMonth: return "This Month"
+    case .allTime: return "All Time"
+    }
+  }
+}
+
+/// One day's focus contribution from a single provider, used in the stacked bar chart.
+struct DayTotal: Identifiable {
+
+  /// Start of day in the local time zone; the bar's x-axis position.
+  let day: Date
+
+  /// Provider that owns the focus time, or `"__untracked__"` when no task was selected.
+  let providerID: String
+
+  /// Focus minutes attributed to this provider on this day.
+  let minutes: Int
+
+  /// Stable identity combining the day and provider.
+  var id: String { "\(day.timeIntervalSinceReferenceDate):\(providerID)" }
+}
+
+/// A provider's aggregate share of focus time within the current scope/period.
+struct ProviderSlice: Identifiable {
+
+  /// Provider that owns the focus time, or `"__untracked__"` when no task was selected.
+  let providerID: String
+
+  /// Human-readable provider name shown in the legend.
+  let label: String
+
+  /// Focus minutes attributed to this provider.
+  let minutes: Int
+
+  /// Stable identity derived from the provider.
+  var id: String { providerID }
+}
+
+/// A row in the All Time sortable task table.
+struct AllTimeTaskRow: Identifiable {
+
+  /// The task this row aggregates, or `nil` for untracked focus time.
+  let taskRef: TaskRef?
+
+  /// `Session.taskTitle` snapshot; `"Untracked"` when no task was selected.
+  let title: String
+
+  /// Human-readable provider name, or `"—"` for untracked focus time.
+  let providerLabel: String
+
+  /// Total focus minutes across every session attributed to this task.
+  let totalMinutes: Int
+
+  /// When the most recent session for this task ended.
+  let lastSessionDate: Date
+
+  /// Stable identity derived from the task reference, falling back to the title.
+  var id: String {
+    if let taskRef { return "\(taskRef.providerID):\(taskRef.nativeID)" }
+    return "__untracked__"
+  }
+}

--- a/app/Taskmato/Views/Stats/StatsTabView.swift
+++ b/app/Taskmato/Views/Stats/StatsTabView.swift
@@ -8,26 +8,24 @@ import SwiftUI
 
 /// The statistics tab shown in the main application window.
 ///
-/// Displays a scope picker (Today / 7 Days), four summary stat cards, and a donut
-/// chart of focus time broken down by task. Data is derived from ``SessionStore``.
+/// Displays a scope picker, four summary stat cards, and a donut chart of focus time broken
+/// down by task. All data is derived from ``StatsViewModel``.
 struct StatsTabView: View {
 
-  var store: SessionStore
-
-  @State private var scope: StatScope = .today
+  @Bindable var statsViewModel: StatsViewModel
 
   var body: some View {
     VStack(spacing: 0) {
       scopePicker
 
-      if store.sessions.isEmpty {
+      if statsViewModel.isEmpty {
         ContentUnavailableView(
           "No Sessions Yet",
           systemImage: "chart.bar",
           description: Text("Complete a focus session to see your statistics here.")
         )
       } else {
-        let summary = currentSummary
+        let summary = statsViewModel.statCards
         ScrollView {
           VStack(alignment: .leading, spacing: 20) {
             statGrid(summary)
@@ -44,7 +42,7 @@ struct StatsTabView: View {
   // MARK: - Scope picker
 
   private var scopePicker: some View {
-    Picker("Scope", selection: $scope) {
+    Picker("Scope", selection: $statsViewModel.scope) {
       ForEach(StatScope.allCases, id: \.self) { statScope in
         Text(statScope.label).tag(statScope)
       }
@@ -115,10 +113,6 @@ struct StatsTabView: View {
 
   // MARK: - Helpers
 
-  private var currentSummary: SessionSummary {
-    scope == .today ? store.todaySummary() : store.thisWeekSummary()
-  }
-
   private static let palette: [Color] = [
     .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,
   ]
@@ -140,20 +134,6 @@ struct StatsTabView: View {
       return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h"
     }
     return "\(minutes)m"
-  }
-}
-
-// MARK: - Scope
-
-private enum StatScope: CaseIterable {
-  case today
-  case thisWeek
-
-  var label: String {
-    switch self {
-    case .today: return "Today"
-    case .thisWeek: return "7 Days"
-    }
   }
 }
 
@@ -187,5 +167,5 @@ private struct StatCardView: View {
 }
 
 #Preview {
-  StatsTabView(store: SessionStore())
+  StatsTabView(statsViewModel: .preview)
 }

--- a/app/Taskmato/Views/Stats/StatsViewModel.swift
+++ b/app/Taskmato/Views/Stats/StatsViewModel.swift
@@ -1,0 +1,287 @@
+//
+//  StatsViewModel.swift
+//  Taskmato
+//
+
+import Foundation
+import Observation
+
+/// The single owner of stats scope state, period navigation, and all session aggregation.
+///
+/// Loads the full session log from an injected ``SessionRepository`` into an in-memory cache
+/// and derives every value the stats UI and popover footer consume. All grouping, counting,
+/// and streak logic lives here — never in the repository (design doc 0006, decisions D1/D2).
+@Observable
+@MainActor
+final class StatsViewModel {
+
+  /// Grouping key used for focus time recorded without a selected task.
+  private static let untrackedKey = "__untracked__"
+
+  private let repository: SessionRepository
+  private let providerLabel: (String) -> String
+
+  /// The full session log, oldest-first; the source for every derived value.
+  private var sessions: [Session] = []
+
+  /// The time window the scope-dependent outputs are computed over.
+  var scope: StatScope = .today {
+    didSet { offset = 0 }
+  }
+
+  /// Period offset: `0` is the current period, `-1` the previous, and so on.
+  private(set) var offset = 0
+
+  /// Creates a view model backed by a repository.
+  /// - Parameters:
+  ///   - repository: The session log to aggregate.
+  ///   - providerLabel: Resolves a `providerID` to a display name; defaults to the raw ID.
+  init(repository: SessionRepository, providerLabel: @escaping (String) -> String = { $0 }) {
+    self.repository = repository
+    self.providerLabel = providerLabel
+    Task { await refresh() }
+  }
+
+  // MARK: - Data lifecycle
+
+  /// Reloads the full session log from the repository.
+  func refresh() async {
+    let all = try? await repository.sessions(
+      over: DateInterval(start: .distantPast, end: .distantFuture))
+    sessions = all ?? []
+  }
+
+  /// Optimistically adds a just-recorded session to the cache for immediate UI updates.
+  ///
+  /// Persistence remains the repository's responsibility (via `SessionStore`); this only
+  /// keeps the in-memory cache current between reloads.
+  /// - Parameter session: The session that was appended.
+  func recordAppended(_ session: Session) {
+    sessions.append(session)
+  }
+
+  // MARK: - Navigation
+
+  /// Moves one period into the past.
+  func navigateBack() { offset -= 1 }
+
+  /// Moves one period toward the present, never past the current period.
+  func navigateForward() { if offset < 0 { offset += 1 } }
+
+  /// Whether a later period exists to navigate to.
+  var canNavigateForward: Bool { offset < 0 }
+
+  /// Whether period navigation applies; always hidden for all-time.
+  var canNavigateBack: Bool { scope != .allTime }
+
+  // MARK: - Aggregated outputs
+
+  /// Whether any sessions have been recorded at all.
+  var isEmpty: Bool { sessions.isEmpty }
+
+  /// Summary stat cards for the current scope and period.
+  var statCards: SessionSummary { SessionSummary(sessions: sessions, over: scopedInterval) }
+
+  /// Focus time by task within the current scope, sorted by duration descending.
+  var taskBreakdown: [SessionSummary.TaskSlice] { statCards.taskBreakdown }
+
+  /// Focus minutes per day, split by provider, within the current scope.
+  var dailyFocusTotals: [DayTotal] {
+    let calendar = Calendar.current
+    var order: [String] = []
+    var accumulated: [String: DayBucket] = [:]
+
+    for session in completedFocus(in: scopedInterval) {
+      let day = calendar.startOfDay(for: session.startedAt)
+      let providerID = session.taskRef?.providerID ?? Self.untrackedKey
+      let key = "\(day.timeIntervalSinceReferenceDate):\(providerID)"
+      if accumulated[key] == nil {
+        order.append(key)
+        accumulated[key] = DayBucket(day: day, providerID: providerID, seconds: 0)
+      }
+      accumulated[key]!.seconds += session.duration
+    }
+
+    return
+      order
+      .compactMap { key -> DayTotal? in
+        guard let entry = accumulated[key] else { return nil }
+        return DayTotal(
+          day: entry.day, providerID: entry.providerID, minutes: Int(entry.seconds / 60))
+      }
+      .sorted { ($0.day, $0.providerID) < ($1.day, $1.providerID) }
+  }
+
+  /// Focus time by provider within the current scope, sorted by duration descending.
+  var providerBreakdown: [ProviderSlice] {
+    var order: [String] = []
+    var accumulated: [String: TimeInterval] = [:]
+
+    for session in completedFocus(in: scopedInterval) {
+      let providerID = session.taskRef?.providerID ?? Self.untrackedKey
+      if accumulated[providerID] == nil { order.append(providerID) }
+      accumulated[providerID, default: 0] += session.duration
+    }
+
+    return
+      order
+      .map { providerID in
+        ProviderSlice(
+          providerID: providerID,
+          label: displayLabel(for: providerID),
+          minutes: Int((accumulated[providerID] ?? 0) / 60))
+      }
+      .sorted { $0.minutes > $1.minutes }
+  }
+
+  /// Every task's all-time focus totals, ranked by total minutes descending.
+  var allTaskRows: [AllTimeTaskRow] {
+    var order: [String] = []
+    var accumulated: [String: TaskBucket] = [:]
+
+    for session in sessions where session.phase == .focus && session.wasCompleted {
+      let key: String
+      if let ref = session.taskRef {
+        key = "\(ref.providerID):\(ref.nativeID)"
+      } else {
+        key = Self.untrackedKey
+      }
+      if accumulated[key] == nil {
+        order.append(key)
+        accumulated[key] = TaskBucket(
+          taskRef: session.taskRef, title: session.taskTitle ?? "Untracked", seconds: 0,
+          last: session.endedAt)
+      }
+      accumulated[key]!.seconds += session.duration
+      if session.endedAt > accumulated[key]!.last { accumulated[key]!.last = session.endedAt }
+    }
+
+    return
+      order
+      .compactMap { key -> AllTimeTaskRow? in
+        guard let entry = accumulated[key] else { return nil }
+        let resolvedLabel = entry.taskRef.map { providerLabel($0.providerID) } ?? "—"
+        return AllTimeTaskRow(
+          taskRef: entry.taskRef, title: entry.title, providerLabel: resolvedLabel,
+          totalMinutes: Int(entry.seconds / 60), lastSessionDate: entry.last)
+      }
+      .sorted { $0.totalMinutes > $1.totalMinutes }
+  }
+
+  /// Consecutive calendar days ending today (or yesterday, as a grace) with ≥1 focus session.
+  var currentStreak: Int {
+    let calendar = Calendar.current
+    let activeDays = Set(
+      sessions
+        .filter { $0.phase == .focus && $0.wasCompleted }
+        .map { calendar.startOfDay(for: $0.startedAt) })
+    guard !activeDays.isEmpty else { return 0 }
+
+    let today = calendar.startOfDay(for: Date())
+    var cursor = today
+    if !activeDays.contains(cursor) {
+      guard let yesterday = calendar.date(byAdding: .day, value: -1, to: today),
+        activeDays.contains(yesterday)
+      else { return 0 }
+      cursor = yesterday
+    }
+
+    var streak = 0
+    while activeDays.contains(cursor) {
+      streak += 1
+      guard let previous = calendar.date(byAdding: .day, value: -1, to: cursor) else { break }
+      cursor = previous
+    }
+    return streak
+  }
+
+  /// Number of completed focus sessions that started today.
+  var todayFocusCount: Int { todaysFocus.count }
+
+  /// Total whole minutes across completed focus sessions that started today.
+  var todayFocusMinutes: Int {
+    Int(todaysFocus.reduce(0) { $0 + $1.duration } / 60)
+  }
+
+  // MARK: - Private
+
+  /// Mutable accumulator for one `(day, provider)` bucket while building `dailyFocusTotals`.
+  private struct DayBucket {
+    let day: Date
+    let providerID: String
+    var seconds: TimeInterval
+  }
+
+  /// Mutable accumulator for one task while building `allTaskRows`.
+  private struct TaskBucket {
+    let taskRef: TaskRef?
+    let title: String
+    var seconds: TimeInterval
+    var last: Date
+  }
+
+  /// Completed focus sessions that started today (calendar day, local time zone).
+  private var todaysFocus: [Session] {
+    let calendar = Calendar.current
+    let today = calendar.startOfDay(for: Date())
+    return sessions.filter {
+      $0.phase == .focus && $0.wasCompleted
+        && calendar.startOfDay(for: $0.startedAt) == today
+    }
+  }
+
+  /// Completed focus sessions whose start falls within `interval` (half-open).
+  private func completedFocus(in interval: DateInterval) -> [Session] {
+    sessions.filter {
+      $0.phase == .focus && $0.wasCompleted
+        && $0.startedAt >= interval.start && $0.startedAt < interval.end
+    }
+  }
+
+  /// Display label for a provider grouping key, handling the untracked sentinel.
+  private func displayLabel(for providerID: String) -> String {
+    providerID == Self.untrackedKey ? "Untracked" : providerLabel(providerID)
+  }
+
+  /// The date range the scope-dependent outputs are computed over, honoring `offset`.
+  private var scopedInterval: DateInterval {
+    let calendar = Calendar.current
+    let now = Date()
+    switch scope {
+    case .today:
+      let base = calendar.startOfDay(for: now)
+      let start = calendar.date(byAdding: .day, value: offset, to: base) ?? base
+      let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
+      return DateInterval(start: start, end: end)
+    case .thisWeek:
+      let todayEnd =
+        calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
+        ?? now
+      let end = calendar.date(byAdding: .day, value: 7 * offset, to: todayEnd) ?? todayEnd
+      let start = calendar.date(byAdding: .day, value: -7, to: end) ?? end
+      return DateInterval(start: start, end: end)
+    case .thisMonth:
+      let monthStart =
+        calendar.date(from: calendar.dateComponents([.year, .month], from: now))
+        ?? calendar.startOfDay(for: now)
+      let start = calendar.date(byAdding: .month, value: offset, to: monthStart) ?? monthStart
+      let end = calendar.date(byAdding: .month, value: 1, to: start) ?? start
+      return DateInterval(start: start, end: end)
+    case .allTime:
+      return DateInterval(start: .distantPast, end: .distantFuture)
+    }
+  }
+}
+
+#if DEBUG
+  extension StatsViewModel {
+
+    /// A view model backed by a throwaway temp-file repository, for SwiftUI previews.
+    static var preview: StatsViewModel {
+      StatsViewModel(
+        repository: JSONSessionRepository(
+          fileURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".json")))
+    }
+  }
+#endif

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -10,7 +10,7 @@ struct TimerTabView: View {
 
   var engine: SessionEngine
   var settings: AppSettings
-  var store: SessionStore
+  var statsViewModel: StatsViewModel
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   var nav: MainNavigation
@@ -61,9 +61,11 @@ struct TimerTabView: View {
       Divider()
         .padding(.horizontal, 24)
 
-      SessionStatsView(count: store.todayFocusCount(), minutes: store.todayFocusMinutes())
-        .padding(.horizontal, 24)
-        .padding(.vertical, 12)
+      SessionStatsView(
+        count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes
+      )
+      .padding(.horizontal, 24)
+      .padding(.vertical, 12)
     }
   }
 
@@ -173,7 +175,7 @@ struct TimerTabView: View {
   TimerTabView(
     engine: SessionEngine(),
     settings: AppSettings(),
-    store: SessionStore(),
+    statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
     nav: MainNavigation(settings: AppSettings()),

--- a/app/TaskmatoTests/StatsViewModelTests.swift
+++ b/app/TaskmatoTests/StatsViewModelTests.swift
@@ -1,0 +1,290 @@
+//
+//  StatsViewModelTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+/// In-memory repository seeded with fixed sessions; stands in for the SwiftData fixture
+/// that #402 will make extractable.
+@MainActor
+private final class FakeSessionRepository: SessionRepository {
+
+  private var stored: [Session]
+
+  init(sessions: [Session]) { self.stored = sessions }
+
+  func sessions(over interval: DateInterval) async throws -> [Session] {
+    stored.filter { interval.contains($0.startedAt) }
+  }
+
+  func append(_ session: Session) async throws { stored.append(session) }
+}
+
+@MainActor
+struct StatsViewModelTests {
+
+  // MARK: - Fixtures
+
+  private static let calendar = Calendar.current
+
+  /// Midnight (local) `days` before today.
+  private static func dayStart(daysAgo days: Int) -> Date {
+    let today = calendar.startOfDay(for: Date())
+    return calendar.date(byAdding: .day, value: -days, to: today) ?? today
+  }
+
+  /// A fixed absolute noon `days` after the reference date, for scope-independent grouping.
+  private static func fixedNoon(day: Int) -> Date {
+    Date(timeIntervalSinceReferenceDate: TimeInterval(day * 86_400 + 12 * 3_600))
+  }
+
+  private func focus(
+    start: Date, minutes: Int = 25, completed: Bool = true,
+    provider: String? = nil, nativeID: String = "t1", title: String? = nil
+  ) -> Session {
+    let ref = provider.map { TaskRef(providerID: $0, nativeID: nativeID) }
+    return Session(
+      id: UUID(), phase: .focus, startedAt: start,
+      endedAt: start.addingTimeInterval(TimeInterval(minutes * 60)),
+      wasCompleted: completed, taskRef: ref, taskTitle: title)
+  }
+
+  private func makeViewModel(
+    _ sessions: [Session], providerLabel: @escaping (String) -> String = { $0 }
+  ) async -> StatsViewModel {
+    let viewModel = StatsViewModel(
+      repository: FakeSessionRepository(sessions: sessions), providerLabel: providerLabel)
+    await viewModel.refresh()
+    return viewModel
+  }
+
+  // MARK: - Empty store
+
+  @Test func emptyStore() async {
+    let viewModel = await makeViewModel([])
+    #expect(viewModel.isEmpty)
+    #expect(viewModel.todayFocusCount == 0)
+    #expect(viewModel.todayFocusMinutes == 0)
+    #expect(viewModel.currentStreak == 0)
+    #expect(viewModel.statCards.focusCount == 0)
+    #expect(viewModel.taskBreakdown.isEmpty)
+    #expect(viewModel.dailyFocusTotals.isEmpty)
+    #expect(viewModel.providerBreakdown.isEmpty)
+    #expect(viewModel.allTaskRows.isEmpty)
+  }
+
+  // MARK: - Single session
+
+  @Test func singleSessionToday() async {
+    let start = Self.dayStart(daysAgo: 0).addingTimeInterval(9 * 3_600)
+    let viewModel = await makeViewModel([focus(start: start, minutes: 25, provider: "local")])
+
+    #expect(!viewModel.isEmpty)
+    #expect(viewModel.todayFocusCount == 1)
+    #expect(viewModel.todayFocusMinutes == 25)
+    #expect(viewModel.currentStreak == 1)
+    #expect(viewModel.statCards.focusCount == 1)
+    #expect(viewModel.taskBreakdown.count == 1)
+    #expect(viewModel.allTaskRows.count == 1)
+  }
+
+  @Test func incompleteAndBreakSessionsIgnoredForFocus() async {
+    let start = Self.dayStart(daysAgo: 0).addingTimeInterval(9 * 3_600)
+    let viewModel = await makeViewModel([
+      focus(start: start, completed: false),
+      Session(
+        id: UUID(), phase: .shortBreak, startedAt: start, endedAt: start.addingTimeInterval(300),
+        wasCompleted: true, taskRef: nil, taskTitle: nil),
+    ])
+    #expect(viewModel.todayFocusCount == 0)
+    #expect(viewModel.currentStreak == 0)
+    #expect(viewModel.statCards.focusCount == 0)
+  }
+
+  // MARK: - Multi-day window scoping
+
+  @Test func todayScopeExcludesYesterday() async {
+    let today = Self.dayStart(daysAgo: 0).addingTimeInterval(9 * 3_600)
+    let yesterday = Self.dayStart(daysAgo: 1).addingTimeInterval(9 * 3_600)
+    let viewModel = await makeViewModel([
+      focus(start: today, provider: "local"),
+      focus(start: yesterday, provider: "local"),
+    ])
+
+    viewModel.scope = .today
+    #expect(viewModel.statCards.focusCount == 1)
+
+    viewModel.scope = .thisWeek
+    #expect(viewModel.statCards.focusCount == 2)
+  }
+
+  @Test func offsetShiftsTodayWindowToYesterday() async {
+    let yesterday = Self.dayStart(daysAgo: 1).addingTimeInterval(9 * 3_600)
+    let viewModel = await makeViewModel([focus(start: yesterday, provider: "local")])
+
+    viewModel.scope = .today
+    #expect(viewModel.statCards.focusCount == 0)
+
+    viewModel.navigateBack()
+    #expect(viewModel.statCards.focusCount == 1)
+  }
+
+  // MARK: - Time-zone / day boundary
+
+  @Test func midnightSessionCountsTowardToday() async {
+    let midnight = Self.dayStart(daysAgo: 0)
+    let viewModel = await makeViewModel([focus(start: midnight, provider: "local")])
+
+    #expect(viewModel.todayFocusCount == 1)
+    viewModel.scope = .today
+    #expect(viewModel.statCards.focusCount == 1)
+  }
+
+  // MARK: - Streak
+
+  @Test func streakStopsAtGap() async {
+    let viewModel = await makeViewModel([
+      focus(start: Self.dayStart(daysAgo: 0).addingTimeInterval(3_600)),
+      focus(start: Self.dayStart(daysAgo: 1).addingTimeInterval(3_600)),
+      // gap on day 2
+      focus(start: Self.dayStart(daysAgo: 3).addingTimeInterval(3_600)),
+    ])
+    #expect(viewModel.currentStreak == 2)
+  }
+
+  @Test func streakGraceWhenTodayEmpty() async {
+    let viewModel = await makeViewModel([
+      focus(start: Self.dayStart(daysAgo: 1).addingTimeInterval(3_600)),
+      focus(start: Self.dayStart(daysAgo: 2).addingTimeInterval(3_600)),
+    ])
+    #expect(viewModel.currentStreak == 2)
+  }
+
+  @Test func streakZeroWhenLatestIsTwoDaysAgo() async {
+    let viewModel = await makeViewModel([
+      focus(start: Self.dayStart(daysAgo: 2).addingTimeInterval(3_600))
+    ])
+    #expect(viewModel.currentStreak == 0)
+  }
+
+  // MARK: - Offset navigation per scope
+
+  @Test func navigationBoundsPerScope() async {
+    let viewModel = await makeViewModel([])
+
+    for scope in [StatScope.today, .thisWeek, .thisMonth] {
+      viewModel.scope = scope
+      #expect(viewModel.offset == 0)
+      #expect(viewModel.canNavigateBack)
+      #expect(!viewModel.canNavigateForward)
+
+      viewModel.navigateBack()
+      #expect(viewModel.offset == -1)
+      #expect(viewModel.canNavigateForward)
+
+      viewModel.navigateForward()
+      #expect(viewModel.offset == 0)
+      viewModel.navigateForward()  // never past current period
+      #expect(viewModel.offset == 0)
+    }
+
+    viewModel.scope = .allTime
+    #expect(!viewModel.canNavigateBack)
+  }
+
+  @Test func changingScopeResetsOffset() async {
+    let viewModel = await makeViewModel([])
+    viewModel.scope = .thisWeek
+    viewModel.navigateBack()
+    viewModel.navigateBack()
+    #expect(viewModel.offset == -2)
+
+    viewModel.scope = .thisMonth
+    #expect(viewModel.offset == 0)
+  }
+
+  // MARK: - Aggregation grouping and labels (all-time scope)
+
+  @Test func providerBreakdownRanksAndLabels() async {
+    let day = Self.fixedNoon(day: 100)
+    let viewModel = await makeViewModel(
+      [
+        focus(start: day, minutes: 50, provider: "reminders", nativeID: "a", title: "A"),
+        focus(start: day, minutes: 25, provider: "obsidian", nativeID: "b", title: "B"),
+        focus(start: day, minutes: 10, provider: nil, title: nil),
+      ],
+      providerLabel: { ["reminders": "Reminders", "obsidian": "Obsidian"][$0] ?? $0 })
+
+    viewModel.scope = .allTime
+    let breakdown = viewModel.providerBreakdown
+    #expect(breakdown.map(\.minutes) == [50, 25, 10])
+    #expect(breakdown.map(\.label) == ["Reminders", "Obsidian", "Untracked"])
+  }
+
+  @Test func allTaskRowsRankAndResolveProviderLabel() async {
+    let earlier = Self.fixedNoon(day: 100)
+    let later = Self.fixedNoon(day: 105)
+    let viewModel = await makeViewModel(
+      [
+        focus(start: earlier, minutes: 30, provider: "reminders", nativeID: "a", title: "Task A"),
+        focus(start: later, minutes: 20, provider: "reminders", nativeID: "a", title: "Task A"),
+        focus(start: earlier, minutes: 15, provider: nil, title: nil),
+      ],
+      providerLabel: { ["reminders": "Reminders"][$0] ?? $0 })
+
+    viewModel.scope = .allTime
+    let rows = viewModel.allTaskRows
+    #expect(rows.count == 2)
+
+    let taskA = rows[0]
+    #expect(taskA.title == "Task A")
+    #expect(taskA.providerLabel == "Reminders")
+    #expect(taskA.totalMinutes == 50)
+    #expect(taskA.lastSessionDate == later.addingTimeInterval(20 * 60))
+
+    let untracked = rows[1]
+    #expect(untracked.title == "Untracked")
+    #expect(untracked.providerLabel == "—")
+    #expect(untracked.taskRef == nil)
+  }
+
+  @Test func dailyFocusTotalsGroupByDayAndProvider() async {
+    let dayOne = Self.fixedNoon(day: 200)
+    let dayTwo = Self.fixedNoon(day: 201)
+    let viewModel = await makeViewModel([
+      focus(start: dayOne, minutes: 25, provider: "local"),
+      focus(start: dayOne, minutes: 25, provider: "local"),
+      focus(start: dayTwo, minutes: 25, provider: "local"),
+      focus(start: dayTwo, minutes: 10, provider: nil),
+    ])
+
+    viewModel.scope = .allTime
+    let totals = viewModel.dailyFocusTotals
+    // day one: one local bucket (50); day two: local (25) + untracked (10)
+    #expect(totals.count == 3)
+    let localDayOne = totals.first { Self.calendar.isDate($0.day, inSameDayAs: dayOne) }
+    #expect(localDayOne?.minutes == 50)
+    let untrackedDayTwo = totals.first {
+      $0.providerID == "__untracked__" && Self.calendar.isDate($0.day, inSameDayAs: dayTwo)
+    }
+    #expect(untrackedDayTwo?.minutes == 10)
+  }
+
+  // MARK: - Optimistic append
+
+  @Test func recordAppendedUpdatesTodayCounts() async {
+    let viewModel = await makeViewModel([])
+    #expect(viewModel.todayFocusCount == 0)
+
+    let start = Self.dayStart(daysAgo: 0).addingTimeInterval(9 * 3_600)
+    viewModel.recordAppended(focus(start: start, minutes: 25, provider: "local"))
+
+    #expect(viewModel.todayFocusCount == 1)
+    #expect(viewModel.todayFocusMinutes == 25)
+    #expect(viewModel.currentStreak == 1)
+  }
+}


### PR DESCRIPTION
## Summary

Introduce `StatsViewModel` as the single owner of stats scope state, period navigation, and all session aggregation, and remove the four UI-shaped scope methods from `SessionStore`. This is PR 18 of design doc [`0006-stats-view-model.md`](https://github.com/richwklein/taskmato/blob/main/docs/architecture/design/0006-stats-view-model.md).

## Linked issue

Closes #401

## Motivation

`SessionStore` exposed UI-shaped scope helpers (`todaySummary`, `thisWeekSummary`, `todayFocusCount`, `todayFocusMinutes`) — design doc 0005, Finding P. All grouping, counting, and streak logic belongs in a view model over raw `[Session]`, not in the storage layer. Consolidating it here keeps `SessionRepository` a minimal conduit and lets the SwiftData swap (#402) be a composition-root flip.

Reviewing #402 drove the key design choice: `StatsViewModel` is **repository-injected with a full-log cache**, not `SessionStore`-backed. That keeps it decoupled from the storage technology, avoids perpetuating the "load everything into the mirror" pattern #402 retires, and makes it testable against #402's in-memory `ModelContainer` fixture.

## Changes

- **New** `Views/Stats/StatTypes.swift` — `StatScope` (Today / 7 Days / This Month / All Time), `DayTotal`, `ProviderSlice`, `AllTimeTaskRow`.
- **New** `Views/Stats/StatsViewModel.swift` — `@Observable @MainActor`; owns `scope`, `offset`, navigation (`navigateBack/Forward`, `canNavigate*`), and every derived output: `statCards`, `taskBreakdown`, `dailyFocusTotals`, `providerBreakdown`, `allTaskRows`, `currentStreak`, `todayFocusCount/Minutes`. `refresh()` loads from the repository; `recordAppended(_:)` keeps the popover footer live.
- **`SessionStore`** — removed the four scope methods; remains the append conduit.
- **Rewired** `StatsTabView`, `TimerTabView`, `MenuBarPopoverView`, `MainWindowView`, `TaskmatoApp` to read from `StatsViewModel` (no visible layout change; picker now shows all four scopes).
- **`AppComposition`** — constructs the model with a `TaskRegistry`-backed provider-label resolver, records appends into it, and extracts notification/provider/phase-ended wiring into helpers.
- **New** `StatsViewModelTests` — 15 tests: empty/single/multi-day windows, timezone boundary, streak with gaps + grace, offset navigation per scope, aggregation grouping, and provider-label resolution.

Charts (#270) and popover streak/icons (#271) are intentionally out of scope; the model already exposes everything they consume.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

`make build` succeeds; `make test` passes; `make lint` reports 0 violations; `make format-check` is clean.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- Aggregation outputs are computed properties over the cache + `scope`/`offset`, so they recompute reactively via Observation — a refinement over the design doc's stored-property sketch, same intent.
- `StatsViewModel` becomes the sole stats reader, so `SessionStore`'s in-memory mirror loses its last view readers; removing it is a follow-up cleanup, kept out of this PR's scope.
- `.thisMonth`/`.allTime` render the existing stat-cards + donut in the interim; per-scope chart layouts land in #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)