### PR TITLE
feat(stats): show streak in session stats footer

### DIFF
--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -100,7 +100,8 @@ struct MenuBarPopoverView: View {
         DispatchQueue.main.async { popover?.close() }
       } label: {
         SessionStatsView(
-          count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes)
+          count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes,
+          streak: statsViewModel.currentStreak)
       }
       .buttonStyle(.plain)
       .padding(.horizontal, 16)

--- a/app/Taskmato/Views/Timer/Components/SessionStatsView.swift
+++ b/app/Taskmato/Views/Timer/Components/SessionStatsView.swift
@@ -5,19 +5,21 @@
 
 import SwiftUI
 
-/// A compact summary row showing today's focus session count and total focused time.
+/// A compact summary row showing today's focus session count, focused time, and current streak.
 struct SessionStatsView: View {
 
   /// Number of completed focus sessions today.
   let count: Int
   /// Total minutes of completed focus time today.
   let minutes: Int
+  /// Current consecutive-day focus streak; `0` hides the streak indicator.
+  var streak: Int = 0
 
   var body: some View {
     HStack {
-      Label(sessionLabel, systemImage: "timer")
+      Text(sessionLabel)
       Spacer()
-      Label(minuteLabel, systemImage: "clock")
+      Text(minuteLabel)
     }
     .font(.caption)
     .foregroundStyle(.secondary)
@@ -28,6 +30,6 @@ struct SessionStatsView: View {
   }
 
   private var minuteLabel: String {
-    "\(minutes) min focused"
+    streak > 0 ? "\(minutes) min · 🔥\(streak)" : "\(minutes) min focused"
   }
 }

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -62,7 +62,8 @@ struct TimerTabView: View {
         .padding(.horizontal, 24)
 
       SessionStatsView(
-        count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes
+        count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes,
+        streak: statsViewModel.currentStreak
       )
       .padding(.horizontal, 24)
       .padding(.vertical, 12)


### PR DESCRIPTION
## Summary

The compact stats footer (menu-bar popover and Timer tab) now surfaces the user's current consecutive-day focus **streak** — the one motivational signal it was missing. The two `timer`/`clock` SF Symbols are removed; they were indistinguishable at caption size in secondary color and added visual noise without aiding comprehension.

## Linked issue

Closes #271

## Approach

Reuses the existing shared `SessionStatsView` and the existing `StatsViewModel.currentStreak` computation (landed with #401/#451) — no new type, no new placement, no change to the 280pt popover width.

- `SessionStatsView` — both `Label(_, systemImage:)` replaced with plain `Text`; new `streak: Int = 0` parameter. Right label reads `"X min · 🔥N"` when `streak > 0`, else `"X min focused"`.
- `TimerTabView` and `MenuBarPopoverView` — both call sites pass `streak: statsViewModel.currentStreak`. They already read count/minutes from `StatsViewModel` post-#451, so no data-source migration was needed.

## Out of scope

- Streak computation itself (lives in `StatsViewModel`, added under #401).
- Any new streak UI beyond the existing footer row.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

Manual verification: rendered `SessionStatsView` at the popover's 248pt inner width across `streak == 0`, a typical streak, and the worst case (`42 sessions today` / `999 min · 🔥365`) — no truncation in any case. No test added: the change is pure `View` string formatting in a private computed property, matching the existing untested `SessionStatsView`; the streak logic it consumes is covered by `StatsViewModel` tests.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Footer rendering at 248pt (light/dark), worst case included:

```
0 sessions today                    0 min focused
4 sessions today                    42 min · 🔥5
42 sessions today                   999 min · 🔥365
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3k2iK7PtiMq8pAyQWVfGd
