### PR TITLE
feat(stats): Day / Week / Month / All Time charts in StatsView

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -46,6 +46,9 @@ struct AppComposition {
       repository: sessionRepository,
       providerLabel: { [registry] providerID in
         registry.providers.first { $0.id == providerID }?.displayName ?? providerID
+      },
+      providerTint: { [registry] providerID in
+        registry.providers.first { $0.id == providerID }?.tint ?? .gray
       })
     Self.configureNotifications(notifications)
     Self.registerProviders(

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -24,6 +24,7 @@ final class LocalProvider: WritableTaskProvider {
   let displayName: String = "Local"
   let displayOrder: Int = 0
   let icon: String = "tray"
+  let tint: ProviderTint = .green
   let entitlement: ProviderEntitlement = .free
 
   /// Lists managed by this provider, in creation order.

--- a/app/Taskmato/Tasks/Models/ProviderTint.swift
+++ b/app/Taskmato/Tasks/Models/ProviderTint.swift
@@ -1,0 +1,29 @@
+//
+//  ProviderTint.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A provider's semantic display color, resolved to a concrete `Color` in the view layer.
+///
+/// A plain, Foundation-only token — the sibling of ``TaskProvider/icon`` — so the `Tasks`
+/// layer carries provider visual identity without importing SwiftUI. The Stats views map
+/// each case to a `Color`; focus time with no provider falls back to ``gray``.
+enum ProviderTint: Equatable, Sendable {
+
+  /// Blue accent.
+  case blue
+
+  /// Green accent.
+  case green
+
+  /// Orange accent.
+  case orange
+
+  /// Purple accent.
+  case purple
+
+  /// Neutral gray, used for untracked focus time and providers with no explicit tint.
+  case gray
+}

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -27,6 +27,7 @@ final class ObsidianProvider: ClosableTaskProvider {
   let id: String = ObsidianProvider.providerID
   let displayName: String = "Obsidian"
   let icon: String = "book.closed"
+  let tint: ProviderTint = .purple
   let entitlement: ProviderEntitlement = .free
 
   /// The user-selected vault directory, resolved from the stored security-scoped bookmark.

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -21,6 +21,7 @@ final class RemindersProvider: ClosableTaskProvider {
   let id: String = RemindersProvider.providerID
   let displayName: String = "Apple Reminders"
   let icon: String = "checklist"
+  let tint: ProviderTint = .orange
   let entitlement: ProviderEntitlement = .free
 
   /// Whether the user has granted full Reminders access.

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -26,6 +26,11 @@ protocol TaskProvider: AnyObject, Sendable {
   /// SF Symbol name used to represent this provider in the UI.
   var icon: String { get }
 
+  /// Semantic color used to represent this provider in charts and legends.
+  ///
+  /// Defaults to ``ProviderTint/gray``; providers override it to claim a distinct hue.
+  var tint: ProviderTint { get }
+
   /// Whether this provider is free or requires a StoreKit purchase.
   var entitlement: ProviderEntitlement { get }
 
@@ -57,6 +62,7 @@ protocol TaskProvider: AnyObject, Sendable {
 extension TaskProvider {
   var isAuthorized: Bool { true }
   var displayOrder: Int { Int.max }
+  var tint: ProviderTint { .gray }
 }
 
 /// A `TaskProvider` that supports toggling task completion state in the source system.

--- a/app/Taskmato/Views/Stats/Components/AllTimeTaskTable.swift
+++ b/app/Taskmato/Views/Stats/Components/AllTimeTaskTable.swift
@@ -1,0 +1,38 @@
+//
+//  AllTimeTaskTable.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A sortable table of every task's all-time focus totals.
+///
+/// Rows come from ``StatsViewModel/allTaskRows``; column sort state is owned by the view
+/// (not the view model) so sorting never triggers re-aggregation.
+struct AllTimeTaskTable: View {
+
+  /// Every task's all-time focus totals, as produced by the view model.
+  let rows: [AllTimeTaskRow]
+
+  @State private var sortOrder = [
+    KeyPathComparator(\AllTimeTaskRow.totalMinutes, order: .reverse)
+  ]
+
+  var body: some View {
+    Table(rows.sorted(using: sortOrder), sortOrder: $sortOrder) {
+      TableColumn("Task", value: \.title) { row in
+        Text(row.title).lineLimit(1)
+      }
+      TableColumn("Provider", value: \.providerLabel) { row in
+        Text(row.providerLabel).foregroundStyle(.secondary)
+      }
+      TableColumn("Total", value: \.totalMinutes) { row in
+        Text(FocusDuration.label(minutes: row.totalMinutes)).monospacedDigit()
+      }
+      TableColumn("Last Session", value: \.lastSessionDate) { row in
+        Text(row.lastSessionDate.formatted(date: .abbreviated, time: .omitted))
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}

--- a/app/Taskmato/Views/Stats/Components/DailyBarChart.swift
+++ b/app/Taskmato/Views/Stats/Components/DailyBarChart.swift
@@ -1,0 +1,47 @@
+//
+//  DailyBarChart.swift
+//  Taskmato
+//
+
+import Charts
+import SwiftUI
+
+/// A stacked bar chart of daily focus minutes, one bar per day, colored by provider.
+///
+/// Bars come from ``StatsViewModel/dailyFocusTotals`` and the color/legend domain from
+/// ``StatsViewModel/providerBreakdown``, so provider colors stay keyed by `providerID`
+/// and consistent across the chart and its legend.
+struct DailyBarChart: View {
+
+  /// Per-day, per-provider focus minutes driving each stacked segment.
+  let totals: [DayTotal]
+
+  /// Providers present in the period, supplying legend labels, colors, and stacking order.
+  let providers: [ProviderSlice]
+
+  private var labelByID: [String: String] {
+    Dictionary(uniqueKeysWithValues: providers.map { ($0.providerID, $0.label) })
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Daily Focus")
+        .font(.headline)
+
+      Chart(totals) { total in
+        BarMark(
+          x: .value("Day", total.day, unit: .day),
+          y: .value("Minutes", total.minutes)
+        )
+        .cornerRadius(2)
+        .foregroundStyle(by: .value("Provider", labelByID[total.providerID] ?? total.providerID))
+      }
+      .chartForegroundStyleScale(
+        domain: providers.map(\.label),
+        range: providers.map { Color($0.tint) }
+      )
+      .chartLegend(position: .bottom, alignment: .leading)
+      .frame(height: 200)
+    }
+  }
+}

--- a/app/Taskmato/Views/Stats/Components/FocusDuration.swift
+++ b/app/Taskmato/Views/Stats/Components/FocusDuration.swift
@@ -1,0 +1,25 @@
+//
+//  FocusDuration.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Formats focus durations as compact `"Xh Ym"` / `"Xm"` labels for the stats UI.
+enum FocusDuration {
+
+  /// Formats whole minutes as `"Xh Ym"` when ≥ 60, `"Xh"` on the hour, otherwise `"Xm"`.
+  static func label(minutes: Int) -> String {
+    if minutes >= 60 {
+      let hours = minutes / 60
+      let mins = minutes % 60
+      return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h"
+    }
+    return "\(minutes)m"
+  }
+
+  /// Formats a duration in seconds by truncating to whole minutes.
+  static func label(seconds: TimeInterval) -> String {
+    label(minutes: Int(seconds / 60))
+  }
+}

--- a/app/Taskmato/Views/Stats/Components/ProviderTint+Color.swift
+++ b/app/Taskmato/Views/Stats/Components/ProviderTint+Color.swift
@@ -1,0 +1,23 @@
+//
+//  ProviderTint+Color.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension Color {
+
+  /// Maps a provider's semantic ``ProviderTint`` to a concrete color.
+  ///
+  /// The single place `ProviderTint` becomes a SwiftUI `Color`, keeping the `Tasks`
+  /// layer free of SwiftUI.
+  init(_ tint: ProviderTint) {
+    switch tint {
+    case .blue: self = .blue
+    case .green: self = .green
+    case .orange: self = .orange
+    case .purple: self = .purple
+    case .gray: self = .gray
+    }
+  }
+}

--- a/app/Taskmato/Views/Stats/Components/RankedTaskList.swift
+++ b/app/Taskmato/Views/Stats/Components/RankedTaskList.swift
@@ -1,0 +1,35 @@
+//
+//  RankedTaskList.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A ranked list of focus time by task, shown below the daily bar chart.
+///
+/// Rows come from ``StatsViewModel/taskBreakdown`` (already ordered by duration descending).
+struct RankedTaskList: View {
+
+  /// Task focus-time slices, ordered by duration descending.
+  let slices: [SessionSummary.TaskSlice]
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("By Task")
+        .font(.headline)
+
+      VStack(spacing: 6) {
+        ForEach(slices) { slice in
+          HStack(spacing: 8) {
+            Text(slice.label)
+              .lineLimit(1)
+            Spacer()
+            Text(FocusDuration.label(seconds: slice.seconds))
+              .foregroundStyle(.secondary)
+              .monospacedDigit()
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/Taskmato/Views/Stats/Components/StatCardView.swift
+++ b/app/Taskmato/Views/Stats/Components/StatCardView.swift
@@ -1,0 +1,33 @@
+//
+//  StatCardView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A compact summary card showing a single metric with an icon, value, and label.
+struct StatCardView: View {
+
+  let icon: String
+  let value: String
+  let label: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Image(systemName: icon)
+        .font(.title2)
+        .foregroundStyle(.secondary)
+      Text(value)
+        .font(.title)
+        .fontWeight(.semibold)
+        .monospacedDigit()
+      Text(label)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(12)
+    .background(.background.secondary)
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+  }
+}

--- a/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
+++ b/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
@@ -1,0 +1,69 @@
+//
+//  TaskDonutChart.swift
+//  Taskmato
+//
+
+import Charts
+import SwiftUI
+
+/// A donut chart of focus time by task, with a color-keyed legend below.
+///
+/// Slices are colored by task (not provider); the Today scope uses this to break the
+/// day's focus time down across the tasks worked on.
+struct TaskDonutChart: View {
+
+  /// Focus-time slices, one per task, ordered by duration descending.
+  let slices: [SessionSummary.TaskSlice]
+
+  /// Total focus seconds in the period, used to compute each slice's percentage.
+  let totalSeconds: TimeInterval
+
+  /// Ordered palette assigned to slices by index.
+  private static let palette: [Color] = [
+    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,
+  ]
+
+  private func color(_ index: Int) -> Color {
+    Self.palette[index % Self.palette.count]
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Task Breakdown")
+        .font(.headline)
+
+      Chart(slices) { slice in
+        SectorMark(
+          angle: .value("Time", slice.seconds),
+          innerRadius: .ratio(0.5),
+          angularInset: 1.5
+        )
+        .cornerRadius(3)
+        .foregroundStyle(by: .value("Task", slice.label))
+      }
+      .chartForegroundStyleScale(
+        domain: slices.map(\.label),
+        range: (0..<slices.count).map(color)
+      )
+      .chartLegend(.hidden)
+      .frame(height: 160)
+
+      VStack(spacing: 6) {
+        ForEach(Array(slices.enumerated()), id: \.element.id) { index, slice in
+          HStack(spacing: 8) {
+            Circle()
+              .fill(color(index))
+              .frame(width: 10, height: 10)
+            Text(slice.label)
+              .lineLimit(1)
+            Spacer()
+            let pct = totalSeconds > 0 ? Int(slice.seconds / totalSeconds * 100) : 0
+            Text("\(slice.minutes) min · \(pct)%")
+              .foregroundStyle(.secondary)
+              .font(.caption)
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/Taskmato/Views/Stats/StatTypes.swift
+++ b/app/Taskmato/Views/Stats/StatTypes.swift
@@ -21,11 +21,14 @@ enum StatScope: CaseIterable {
   case allTime
 
   /// Human-readable title shown in the scope picker.
+  ///
+  /// Generalized to the period *kind* (Day, Week, Month) so it reads correctly alongside the
+  /// navigation label, which names the specific period being viewed.
   var label: String {
     switch self {
-    case .today: return "Today"
-    case .thisWeek: return "7 Days"
-    case .thisMonth: return "This Month"
+    case .today: return "Day"
+    case .thisWeek: return "Week"
+    case .thisMonth: return "Month"
     case .allTime: return "All Time"
     }
   }
@@ -39,6 +42,9 @@ struct DayTotal: Identifiable {
 
   /// Provider that owns the focus time, or `"__untracked__"` when no task was selected.
   let providerID: String
+
+  /// Semantic color of the owning provider, used for the stacked bar segment.
+  let tint: ProviderTint
 
   /// Focus minutes attributed to this provider on this day.
   let minutes: Int
@@ -55,6 +61,9 @@ struct ProviderSlice: Identifiable {
 
   /// Human-readable provider name shown in the legend.
   let label: String
+
+  /// Semantic color of the provider, used for the legend swatch and bar segments.
+  let tint: ProviderTint
 
   /// Focus minutes attributed to this provider.
   let minutes: Int

--- a/app/Taskmato/Views/Stats/StatsTabView.swift
+++ b/app/Taskmato/Views/Stats/StatsTabView.swift
@@ -3,13 +3,14 @@
 //  Taskmato
 //
 
-import Charts
 import SwiftUI
 
 /// The statistics tab shown in the main application window.
 ///
-/// Displays a scope picker, four summary stat cards, and a donut chart of focus time broken
-/// down by task. All data is derived from ``StatsViewModel``.
+/// Shows a scope picker and, for every scope except All Time, period back/forward navigation.
+/// Each scope renders its own visualisation — a task donut (Today), a stacked daily bar chart
+/// with a ranked task list (7 Days / This Month), or a sortable all-time task table. All data
+/// is derived from ``StatsViewModel``.
 struct StatsTabView: View {
 
   @Bindable var statsViewModel: StatsViewModel
@@ -17,25 +18,66 @@ struct StatsTabView: View {
   var body: some View {
     VStack(spacing: 0) {
       scopePicker
+      navigationRow
+      content
+    }
+  }
 
-      if statsViewModel.isEmpty {
-        ContentUnavailableView(
-          "No Sessions Yet",
-          systemImage: "chart.bar",
-          description: Text("Complete a focus session to see your statistics here.")
-        )
+  // MARK: - Content
+
+  @ViewBuilder
+  private var content: some View {
+    if statsViewModel.isEmpty {
+      emptyState(
+        "No Sessions Yet",
+        description: "Complete a focus session to see your statistics here.")
+    } else {
+      let summary = statsViewModel.statCards
+      if summary.focusCount == 0 && summary.breakCount == 0 {
+        emptyState(
+          "No Sessions",
+          description: "No focus sessions in this period.")
       } else {
-        let summary = statsViewModel.statCards
-        ScrollView {
-          VStack(alignment: .leading, spacing: 20) {
-            statGrid(summary)
-            if !summary.taskBreakdown.isEmpty {
-              taskBreakdownSection(summary)
-            }
-          }
-          .padding()
-        }
+        scopeContent(summary)
       }
+    }
+  }
+
+  @ViewBuilder
+  private func scopeContent(_ summary: SessionSummary) -> some View {
+    switch statsViewModel.scope {
+    case .allTime:
+      VStack(alignment: .leading, spacing: 20) {
+        statGrid(summary).padding([.horizontal, .top])
+        AllTimeTaskTable(rows: statsViewModel.allTaskRows)
+      }
+    default:
+      ScrollView {
+        VStack(alignment: .leading, spacing: 20) {
+          statGrid(summary)
+          scopeCharts(summary)
+        }
+        .padding()
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func scopeCharts(_ summary: SessionSummary) -> some View {
+    switch statsViewModel.scope {
+    case .today:
+      if !summary.taskBreakdown.isEmpty {
+        TaskDonutChart(slices: summary.taskBreakdown, totalSeconds: summary.focusSeconds)
+      }
+    case .thisWeek, .thisMonth:
+      DailyBarChart(
+        totals: statsViewModel.dailyFocusTotals,
+        providers: statsViewModel.providerBreakdown)
+      if !summary.taskBreakdown.isEmpty {
+        RankedTaskList(slices: summary.taskBreakdown)
+      }
+    case .allTime:
+      EmptyView()
     }
   }
 
@@ -48,8 +90,67 @@ struct StatsTabView: View {
       }
     }
     .pickerStyle(.segmented)
+    .labelsHidden()
     .padding([.horizontal, .top])
+    .padding(.bottom, 16)
+  }
+
+  // MARK: - Period navigation
+
+  /// Always rendered so its height is constant across scopes; the arrows are hidden for All
+  /// Time (which has no period navigation) to keep the layout from jumping.
+  private var navigationRow: some View {
+    let showsArrows = statsViewModel.canNavigateBack
+    return HStack(spacing: 8) {
+      Button {
+        statsViewModel.navigateBack()
+      } label: {
+        Image(systemName: "chevron.left")
+      }
+      .disabled(!showsArrows)
+      .opacity(showsArrows ? 1 : 0)
+      .accessibilityLabel("Previous period")
+
+      Text(periodLabel)
+        .font(.subheadline.weight(.medium))
+        .monospacedDigit()
+        .frame(width: 160)
+
+      Button {
+        statsViewModel.navigateForward()
+      } label: {
+        Image(systemName: "chevron.right")
+      }
+      .disabled(!statsViewModel.canNavigateForward)
+      .opacity(showsArrows ? 1 : 0)
+      .accessibilityLabel("Next period")
+    }
+    .buttonStyle(.borderless)
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal)
     .padding(.bottom, 8)
+  }
+
+  /// The navigated period rendered for the current scope and offset.
+  private var periodLabel: String {
+    let interval = statsViewModel.currentInterval
+    switch statsViewModel.scope {
+    case .today:
+      switch statsViewModel.offset {
+      case 0: return "Today"
+      case -1: return "Yesterday"
+      default: return interval.start.formatted(.dateTime.month(.abbreviated).day())
+      }
+    case .thisWeek:
+      let lastDay = interval.end.addingTimeInterval(-1)
+      let start = interval.start.formatted(.dateTime.month(.abbreviated).day())
+      let end = lastDay.formatted(.dateTime.month(.abbreviated).day())
+      return "\(start) – \(end)"
+    case .thisMonth:
+      return interval.start.formatted(.dateTime.month(.wide).year())
+    case .allTime:
+      return "All Time"
+    }
   }
 
   // MARK: - Stat grid
@@ -59,7 +160,7 @@ struct StatsTabView: View {
       StatCardView(icon: "target", value: "\(summary.focusCount)", label: "Sessions")
       StatCardView(
         icon: "timer",
-        value: formatDuration(summary.focusSeconds),
+        value: FocusDuration.label(seconds: summary.focusSeconds),
         label: "Focus Time"
       )
       StatCardView(icon: "cup.and.saucer", value: "\(summary.breakCount)", label: "Breaks")
@@ -67,105 +168,38 @@ struct StatsTabView: View {
     }
   }
 
-  // MARK: - Task breakdown
+  // MARK: - Empty state
 
-  private func taskBreakdownSection(_ summary: SessionSummary) -> some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Task Breakdown")
-        .font(.headline)
-
-      Chart(summary.taskBreakdown) { slice in
-        SectorMark(
-          angle: .value("Time", slice.seconds),
-          innerRadius: .ratio(0.5),
-          angularInset: 1.5
-        )
-        .cornerRadius(3)
-        .foregroundStyle(by: .value("Task", slice.label))
-      }
-      .chartForegroundStyleScale(
-        domain: summary.taskBreakdown.map(\.label),
-        range: chartColors(count: summary.taskBreakdown.count)
-      )
-      .chartLegend(.hidden)
-      .frame(height: 160)
-
-      VStack(spacing: 6) {
-        ForEach(Array(summary.taskBreakdown.enumerated()), id: \.element.id) { idx, slice in
-          HStack(spacing: 8) {
-            Circle()
-              .fill(sliceColor(idx))
-              .frame(width: 10, height: 10)
-            Text(slice.label)
-              .lineLimit(1)
-            Spacer()
-            let pct =
-              summary.focusSeconds > 0
-              ? Int(slice.seconds / summary.focusSeconds * 100) : 0
-            Text("\(slice.minutes) min · \(pct)%")
-              .foregroundStyle(.secondary)
-              .font(.caption)
-          }
-        }
-      }
-    }
-  }
-
-  // MARK: - Helpers
-
-  private static let palette: [Color] = [
-    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,
-  ]
-
-  private func sliceColor(_ index: Int) -> Color {
-    Self.palette[index % Self.palette.count]
-  }
-
-  private func chartColors(count: Int) -> [Color] {
-    (0..<count).map { sliceColor($0) }
-  }
-
-  /// Formats a duration in seconds as `"Xh Ym"` when ≥ 60 min, otherwise `"Xm"`.
-  private func formatDuration(_ seconds: TimeInterval) -> String {
-    let minutes = Int(seconds / 60)
-    if minutes >= 60 {
-      let hours = minutes / 60
-      let mins = minutes % 60
-      return mins > 0 ? "\(hours)h \(mins)m" : "\(hours)h"
-    }
-    return "\(minutes)m"
+  private func emptyState(_ title: String, description: String) -> some View {
+    ContentUnavailableView(
+      title,
+      systemImage: "chart.bar",
+      description: Text(description)
+    )
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 
-// MARK: - StatCardView
-
-/// A compact summary card showing a single metric with an icon, value, and label.
-private struct StatCardView: View {
-
-  let icon: String
-  let value: String
-  let label: String
-
-  var body: some View {
-    VStack(alignment: .leading, spacing: 4) {
-      Image(systemName: icon)
-        .font(.title2)
-        .foregroundStyle(.secondary)
-      Text(value)
-        .font(.title)
-        .fontWeight(.semibold)
-        .monospacedDigit()
-      Text(label)
-        .font(.caption)
-        .foregroundStyle(.secondary)
-    }
-    .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(12)
-    .background(.background.secondary)
-    .clipShape(RoundedRectangle(cornerRadius: 8))
-  }
+#Preview("Today") {
+  StatsTabView(statsViewModel: .previewSeeded)
+    .frame(width: 420, height: 560)
 }
 
-#Preview {
+#Preview("7 Days") {
+  let viewModel = StatsViewModel.previewSeeded
+  viewModel.scope = .thisWeek
+  return StatsTabView(statsViewModel: viewModel)
+    .frame(width: 420, height: 560)
+}
+
+#Preview("All Time") {
+  let viewModel = StatsViewModel.previewSeeded
+  viewModel.scope = .allTime
+  return StatsTabView(statsViewModel: viewModel)
+    .frame(width: 420, height: 560)
+}
+
+#Preview("Empty") {
   StatsTabView(statsViewModel: .preview)
+    .frame(width: 420, height: 560)
 }

--- a/app/Taskmato/Views/Stats/StatsViewModel.swift
+++ b/app/Taskmato/Views/Stats/StatsViewModel.swift
@@ -20,6 +20,7 @@ final class StatsViewModel {
 
   private let repository: SessionRepository
   private let providerLabel: (String) -> String
+  private let providerTint: (String) -> ProviderTint
 
   /// The full session log, oldest-first; the source for every derived value.
   private var sessions: [Session] = []
@@ -36,9 +37,15 @@ final class StatsViewModel {
   /// - Parameters:
   ///   - repository: The session log to aggregate.
   ///   - providerLabel: Resolves a `providerID` to a display name; defaults to the raw ID.
-  init(repository: SessionRepository, providerLabel: @escaping (String) -> String = { $0 }) {
+  ///   - providerTint: Resolves a `providerID` to a display color; defaults to ``ProviderTint/gray``.
+  init(
+    repository: SessionRepository,
+    providerLabel: @escaping (String) -> String = { $0 },
+    providerTint: @escaping (String) -> ProviderTint = { _ in .gray }
+  ) {
     self.repository = repository
     self.providerLabel = providerLabel
+    self.providerTint = providerTint
     Task { await refresh() }
   }
 
@@ -74,6 +81,9 @@ final class StatsViewModel {
   /// Whether period navigation applies; always hidden for all-time.
   var canNavigateBack: Bool { scope != .allTime }
 
+  /// The date range the current scope and offset resolve to, for the navigation label.
+  var currentInterval: DateInterval { scopedInterval }
+
   // MARK: - Aggregated outputs
 
   /// Whether any sessions have been recorded at all.
@@ -107,7 +117,8 @@ final class StatsViewModel {
       .compactMap { key -> DayTotal? in
         guard let entry = accumulated[key] else { return nil }
         return DayTotal(
-          day: entry.day, providerID: entry.providerID, minutes: Int(entry.seconds / 60))
+          day: entry.day, providerID: entry.providerID,
+          tint: displayTint(for: entry.providerID), minutes: Int(entry.seconds / 60))
       }
       .sorted { ($0.day, $0.providerID) < ($1.day, $1.providerID) }
   }
@@ -129,6 +140,7 @@ final class StatsViewModel {
         ProviderSlice(
           providerID: providerID,
           label: displayLabel(for: providerID),
+          tint: displayTint(for: providerID),
           minutes: Int((accumulated[providerID] ?? 0) / 60))
       }
       .sorted { $0.minutes > $1.minutes }
@@ -243,6 +255,11 @@ final class StatsViewModel {
     providerID == Self.untrackedKey ? "Untracked" : providerLabel(providerID)
   }
 
+  /// Display color for a provider grouping key, gray for the untracked sentinel.
+  private func displayTint(for providerID: String) -> ProviderTint {
+    providerID == Self.untrackedKey ? .gray : providerTint(providerID)
+  }
+
   /// The date range the scope-dependent outputs are computed over, honoring `offset`.
   private var scopedInterval: DateInterval {
     let calendar = Calendar.current
@@ -276,12 +293,56 @@ final class StatsViewModel {
 #if DEBUG
   extension StatsViewModel {
 
-    /// A view model backed by a throwaway temp-file repository, for SwiftUI previews.
+    /// Sample provider display names and tints used by the seeded preview.
+    private static let previewProviders: [String: (label: String, tint: ProviderTint)] = [
+      "local": ("Local", .green),
+      "reminders": ("Reminders", .orange),
+      "obsidian": ("Obsidian", .purple),
+    ]
+
+    /// A view model backed by an empty throwaway temp-file repository, for SwiftUI previews.
     static var preview: StatsViewModel {
-      StatsViewModel(
-        repository: JSONSessionRepository(
-          fileURL: FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString + ".json")))
+      seeded([])
+    }
+
+    /// A view model seeded with two weeks of sample sessions across providers.
+    static var previewSeeded: StatsViewModel {
+      let calendar = Calendar.current
+      let today = calendar.startOfDay(for: Date())
+      let providers = ["local", "reminders", "obsidian", nil]
+      var sessions: [Session] = []
+      for dayOffset in 0..<14 {
+        guard let day = calendar.date(byAdding: .day, value: -dayOffset, to: today) else {
+          continue
+        }
+        for slot in 0...(dayOffset % 3) {
+          let provider = providers[(dayOffset + slot) % providers.count]
+          let start = day.addingTimeInterval(TimeInterval((9 + slot) * 3_600))
+          let ref = provider.map { TaskRef(providerID: $0, nativeID: "task-\(slot)") }
+          sessions.append(
+            Session(
+              id: UUID(), phase: .focus, startedAt: start,
+              endedAt: start.addingTimeInterval(25 * 60), wasCompleted: true,
+              taskRef: ref, taskTitle: provider.map { "\($0.capitalized) task \(slot)" }))
+        }
+      }
+      return seeded(sessions)
+    }
+
+    /// Builds a preview view model backed by a temp file seeded with `sessions`.
+    private static func seeded(_ sessions: [Session]) -> StatsViewModel {
+      let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString + ".json")
+      let encoder = JSONEncoder()
+      encoder.dateEncodingStrategy = .iso8601
+      if let data = try? encoder.encode(sessions) { try? data.write(to: url) }
+      let viewModel = StatsViewModel(
+        repository: JSONSessionRepository(fileURL: url),
+        providerLabel: { previewProviders[$0]?.label ?? $0 },
+        providerTint: { previewProviders[$0]?.tint ?? .gray })
+      // Seed the cache synchronously so previews render without waiting on the async refresh.
+      viewModel.sessions = sessions
+      return viewModel
     }
   }
 #endif

--- a/app/TaskmatoTests/StatsViewModelTests.swift
+++ b/app/TaskmatoTests/StatsViewModelTests.swift
@@ -54,10 +54,12 @@ struct StatsViewModelTests {
   }
 
   private func makeViewModel(
-    _ sessions: [Session], providerLabel: @escaping (String) -> String = { $0 }
+    _ sessions: [Session], providerLabel: @escaping (String) -> String = { $0 },
+    providerTint: @escaping (String) -> ProviderTint = { _ in .gray }
   ) async -> StatsViewModel {
     let viewModel = StatsViewModel(
-      repository: FakeSessionRepository(sessions: sessions), providerLabel: providerLabel)
+      repository: FakeSessionRepository(sessions: sessions), providerLabel: providerLabel,
+      providerTint: providerTint)
     await viewModel.refresh()
     return viewModel
   }
@@ -272,6 +274,48 @@ struct StatsViewModelTests {
       $0.providerID == "__untracked__" && Self.calendar.isDate($0.day, inSameDayAs: dayTwo)
     }
     #expect(untrackedDayTwo?.minutes == 10)
+  }
+
+  // MARK: - Current interval (navigation label)
+
+  @Test func currentIntervalTracksScopeAndOffset() async {
+    let viewModel = await makeViewModel([])
+    let cal = Self.calendar
+    let today = cal.startOfDay(for: Date())
+
+    viewModel.scope = .today
+    #expect(viewModel.currentInterval.start == today)
+    #expect(viewModel.currentInterval.end == cal.date(byAdding: .day, value: 1, to: today))
+
+    viewModel.navigateBack()
+    let yesterday = cal.date(byAdding: .day, value: -1, to: today)!
+    #expect(viewModel.currentInterval.start == yesterday)
+    #expect(viewModel.currentInterval.end == today)
+
+    viewModel.scope = .allTime
+    #expect(viewModel.currentInterval.start == .distantPast)
+    #expect(viewModel.currentInterval.end == .distantFuture)
+  }
+
+  // MARK: - Provider tint resolution
+
+  @Test func outputsCarryProviderTint() async {
+    let day = Self.fixedNoon(day: 300)
+    let viewModel = await makeViewModel(
+      [
+        focus(start: day, minutes: 25, provider: "local"),
+        focus(start: day, minutes: 10, provider: nil),
+      ],
+      providerTint: { ["local": ProviderTint.green][$0] ?? .gray })
+    viewModel.scope = .allTime
+
+    let providers = viewModel.providerBreakdown
+    #expect(providers.first { $0.providerID == "local" }?.tint == .green)
+    #expect(providers.first { $0.providerID == "__untracked__" }?.tint == .gray)
+
+    let totals = viewModel.dailyFocusTotals
+    #expect(totals.first { $0.providerID == "local" }?.tint == .green)
+    #expect(totals.first { $0.providerID == "__untracked__" }?.tint == .gray)
   }
 
   // MARK: - Optimistic append

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -267,6 +267,16 @@ struct TaskProviderTests {
     #expect(provider.isAuthorized)
   }
 
+  @Test func tintDefaultsToGray() {
+    #expect(FakeReadOnlyProvider().tint == .gray)
+  }
+
+  @Test @MainActor func localProviderDeclaresGreenTint() {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    #expect(LocalProvider(fileURL: url).tint == .green)
+  }
+
   @Test func isAuthorizedCanBeOverridden() {
     let provider = FakeUnauthorizedProvider()
     #expect(!provider.isAuthorized)


### PR DESCRIPTION
## Summary

Turns the Stats tab from bare totals into real visualisations. Each scope now renders a purpose-built chart or list, and every scope except All Time gets period back/forward navigation. The `StatsViewModel` aggregation layer from #401 already exposed everything needed — this is the view work that consumes it.

## Linked issue

Closes #270

## Approach

Purely the view layer; no aggregation logic was added to `StatsViewModel`.

- **Per-scope layout** in `StatsTabView` via a `switch scope`:
  - **Day** → task donut (extracted to `TaskDonutChart`)
  - **Week / Month** → provider-colored stacked `BarMark` chart (`DailyBarChart`) over `dailyFocusTotals`, with a ranked task list (`RankedTaskList`) below
  - **All Time** → native macOS `Table` (`AllTimeTaskTable`) over `allTaskRows`, with **view-owned** column sort state so sorting never re-runs aggregation
- **Period navigation** — a `‹ label ›` row bound to `navigateBack/Forward`, disabled/hidden via `canNavigate*`. The center label is period-aware (`Today` / `Yesterday` / `Jul 15 – Jul 21` / `July 2026`), formatted in the view from a new additive `StatsViewModel.currentInterval`. The row is always rendered (arrows hidden for All Time) so the layout doesn't jump between scopes.
- **Provider color** — added a `ProviderTint` token to `TaskProvider`, a Foundation-only sibling of `icon` with a `.gray` default so no conformer is forced (Local `.green`, Reminders `.orange`, Obsidian `.purple`). It's resolved to `Color` only in the Stats views (via a single `Color(_:)` mapping), keeping SwiftUI out of the `Tasks` layer, and is carried on `DayTotal` / `ProviderSlice` so chart and legend colors stay keyed by `providerID`.
- Scope picker labels generalize to **Day / Week / Month / All Time** (the specific period is named by the nav label), and the redundant "Scope" title is hidden.

Design context: [`docs/architecture/design/0006-stats-view-model.md`](docs/architecture/design/0006-stats-view-model.md).

## Out of scope

- SwiftData migration (#402) and the popover streak/icon changes (#271)
- Stats sidebar (deferred to 1.1 per design doc 0006 / ADR-0003)
- Marking design doc 0006 "Accepted" — the shipped `StatsViewModel` refined its "Proposed" sketch (computed-on-read outputs, plus `refresh`/`recordAppended`/`isEmpty`); a follow-up `docs:` PR will reconcile the doc to the code.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

`make lint` (0 violations), `make format-check` (clean), full `TaskmatoTests` target green. New tests: `currentIntervalTracksScopeAndOffset`, `outputsCarryProviderTint`, and `ProviderTint` default/override guards. Each scope verified visually via seeded SwiftUI previews.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- Two decisions worth a look: **(1)** provider colors are resolved in the `AppComposition` closure (mirroring `providerLabel`) rather than plumbing `TaskRegistry` into the view; **(2)** the donut stays **task-keyed** (per the design mockup) while provider-keyed coloring applies to the bar chart and its legend — my reading of the "consistent palette, keyed by providerID" acceptance criterion.
- Delivered as three logical commits (tint + navigation + Today · bar/list · all-time table).
- 1,000-session performance smoke check from the acceptance criteria not yet run — outputs are all computed-on-read; worth a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
