### PR TITLE
refactor(design): establish design token vocabulary and styling reference

### DIFF
--- a/app/Taskmato/Views/App/DesignTokens/Opacity.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Opacity.swift
@@ -1,0 +1,15 @@
+//
+//  Opacity.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension Double {
+
+  /// Faint overlay used for card surfaces lifted off the background.
+  static let subtle: Double = 0.1
+
+  /// Low-emphasis overlay used for inactive track elements like the timer ring.
+  static let muted: Double = 0.2
+}

--- a/app/Taskmato/Views/App/DesignTokens/Palette.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Palette.swift
@@ -1,0 +1,32 @@
+//
+//  Palette.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension Color {
+
+  /// Due date that has reached or passed its urgency threshold.
+  static let dueUrgent: Color = .red
+
+  /// Accent tint for elevated-priority tasks (medium and above).
+  static let priorityHigh: Color = .orange
+
+  /// Default tint for tasks without elevated priority.
+  static let priorityNeutral: Color = .primary
+
+  /// Unfilled portion of the circular timer ring.
+  static let timerRingTrack: Color = .secondary.opacity(.muted)
+
+  /// Fill behind a card surface to lift it off the background.
+  static let cardSurface: Color = .secondary.opacity(.subtle)
+
+  /// Marker on the provider's default (favorite) list.
+  static let favoriteStar: Color = .yellow
+
+  /// Ordered colors assigned to slices/series in stats charts.
+  static let chartPalette: [Color] = [
+    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,
+  ]
+}

--- a/app/Taskmato/Views/App/DesignTokens/Shape.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Shape.swift
@@ -1,0 +1,23 @@
+//
+//  Shape.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension CGFloat {
+
+  /// Corner radius for card surfaces (task cards, stat cards).
+  static let cardCornerRadius: CGFloat = 8
+
+  /// Corner radius for chart bars and legend swatches.
+  static let barCornerRadius: CGFloat = 2
+}
+
+extension RoundedRectangle {
+
+  /// Rounded rectangle used as the canonical card surface and clip shape.
+  static var card: RoundedRectangle {
+    RoundedRectangle(cornerRadius: .cardCornerRadius)
+  }
+}

--- a/app/Taskmato/Views/App/DesignTokens/Spacing.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Spacing.swift
@@ -1,0 +1,30 @@
+//
+//  Spacing.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension CGFloat {
+
+  /// Tight gap between a title and the metadata directly under it.
+  static let stackTight: CGFloat = 2
+
+  /// Vertical padding around a task row in a list.
+  static let rowVertical: CGFloat = 4
+
+  /// Gap between an icon and its adjacent label.
+  static let iconLabel: CGFloat = 6
+
+  /// Standard gap between sibling elements within a group.
+  static let contentGap: CGFloat = 8
+
+  /// Interior padding of a card.
+  static let cardPadding: CGFloat = 10
+
+  /// Gap between distinct sections of content.
+  static let sectionGap: CGFloat = 16
+
+  /// Padding between content and the edge of a screen, sheet, or popover.
+  static let screenPadding: CGFloat = 24
+}

--- a/app/Taskmato/Views/App/DesignTokens/Typography.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Typography.swift
@@ -1,0 +1,36 @@
+//
+//  Typography.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension Font {
+
+  /// Primary task title in list rows, cards, and the active-task label.
+  static let taskTitle: Font = .callout
+
+  /// Supporting metadata beneath a task title (due date, provider marks).
+  static let taskMetadata: Font = .caption2
+
+  /// Ancestor/lineage breadcrumb shown under a task; sits below metadata in emphasis.
+  static let taskLineage: Font = .caption2
+
+  /// Large monospaced countdown at the center of the timer ring.
+  static let timerCountdown: Font = .system(size: 36, weight: .light, design: .monospaced)
+
+  /// Phase label ("Focus", "Break") under the timer countdown.
+  static let timerPhaseLabel: Font = .subheadline
+
+  /// Prominent numeric value in a stat card; monospaced so digits don't jitter.
+  static let statValue: Font = .title.monospacedDigit()
+
+  /// Caption describing what a stat value represents.
+  static let statLabel: Font = .caption
+
+  /// Grouping header above a section of rows or cards.
+  static let sectionHeader: Font = .subheadline.weight(.semibold)
+
+  /// Title above a chart or stats visualization.
+  static let chartTitle: Font = .headline
+}

--- a/docs/reference/styling.md
+++ b/docs/reference/styling.md
@@ -1,0 +1,72 @@
+# Styling Tokens
+
+Reference for Taskmato's design tokens — the named styling values that views consume
+instead of literals. Tokens are defined as type extensions under
+`app/Taskmato/Views/App/DesignTokens/` and read at the call site as `.taskTitle`,
+`.cardPadding`, `.dueUrgent`, and so on.
+
+System hierarchical styles (`.primary`, `.secondary`, `.tertiary`) are already semantic and
+are used directly — they are not re-exported as tokens.
+
+## Typography
+
+`Font` extensions in `Typography.swift`. Applied with `.font(_:)`.
+
+| Token | Value | Where it's appropriate |
+| --- | --- | --- |
+| `taskTitle` | `.callout` | Primary task title in rows, cards, and the active-task label |
+| `taskMetadata` | `.caption2` | Supporting metadata under a title (due date, priority marks) |
+| `taskLineage` | `.caption2` | Ancestor/lineage breadcrumb under a task |
+| `timerCountdown` | `.system(size: 36, weight: .light, design: .monospaced)` | Countdown at the center of the timer ring |
+| `timerPhaseLabel` | `.subheadline` | Phase label under the countdown |
+| `statValue` | `.title.monospacedDigit()` | Prominent numeric value in a stat card |
+| `statLabel` | `.caption` | Caption describing a stat value |
+| `sectionHeader` | `.subheadline.weight(.semibold)` | Header above a section of rows or cards |
+| `chartTitle` | `.headline` | Title above a chart or stats visualization |
+
+## Color
+
+`Color` extensions in `Palette.swift`. Applied with `.foregroundStyle(_:)`, `.fill(_:)`, etc.
+
+| Token | Value | Where it's appropriate |
+| --- | --- | --- |
+| `dueUrgent` | `.red` | Due date at or past its urgency threshold |
+| `priorityHigh` | `.orange` | Accent for elevated-priority tasks (medium and above) |
+| `priorityNeutral` | `.primary` | Default tint for tasks without elevated priority |
+| `timerRingTrack` | `.secondary.opacity(.muted)` | Unfilled portion of the circular timer ring |
+| `cardSurface` | `.secondary.opacity(.subtle)` | Fill behind a card to lift it off the background |
+| `favoriteStar` | `.yellow` | Marker on a provider's default (favorite) list |
+| `chartPalette` | `[.blue, .green, .orange, .purple, .red, .teal, .indigo, .pink]` | Ordered colors for chart slices/series |
+
+## Spacing
+
+`CGFloat` extensions in `Spacing.swift`. Applied with `.padding(_:)` and stack `spacing:`.
+
+| Token | Value | Where it's appropriate |
+| --- | --- | --- |
+| `stackTight` | `2` | Gap between a title and the metadata directly under it |
+| `rowVertical` | `4` | Vertical padding around a task row in a list |
+| `iconLabel` | `6` | Gap between an icon and its adjacent label |
+| `contentGap` | `8` | Standard gap between sibling elements in a group |
+| `cardPadding` | `10` | Interior padding of a card |
+| `sectionGap` | `16` | Gap between distinct sections of content |
+| `screenPadding` | `24` | Padding between content and a screen/sheet/popover edge |
+
+## Shape
+
+`CGFloat` and `RoundedRectangle` extensions in `Shape.swift`.
+
+| Token | Value | Where it's appropriate |
+| --- | --- | --- |
+| `cardCornerRadius` | `8` | Corner radius for card surfaces (task cards, stat cards) |
+| `barCornerRadius` | `2` | Corner radius for chart bars and legend swatches |
+| `RoundedRectangle.card` | `RoundedRectangle(cornerRadius: .cardCornerRadius)` | Canonical card surface and clip shape |
+
+## Opacity
+
+`Double` extensions in `Opacity.swift`. Applied with `.opacity(_:)` or nested in a color.
+
+| Token | Value | Where it's appropriate |
+| --- | --- | --- |
+| `subtle` | `0.1` | Faint overlay for card surfaces lifted off the background |
+| `muted` | `0.2` | Low-emphasis overlay for inactive tracks like the timer ring |


### PR DESCRIPTION
## Summary

Establish a design token vocabulary capturing the implicit styling rules used across the views today, and document it in a Divio reference doc. No view files change — this only defines the tokens and the reference. Application across views and resolution of the audit-surfaced inconsistencies land in the follow-up (#416).

## Linked issue

Closes #415

## Motivation

Views use ad-hoc literals whose semantic intent lives in the developer's head: `.orange` for priority, `.red` for urgent due dates, `Color.secondary.opacity(0.2)` for the timer ring, `RoundedRectangle(cornerRadius: 10)` for task cards vs `8` for stat cards, magic spacing values `2/3/4/6/8/10/12/16/20/24`, and a hardcoded `.system(size: 36, weight: .light, design: .monospaced)` timer countdown. Naming these makes the intent explicit and gives the upcoming presenters (#405, #406) and the accessibility pass (#411) a shared vocabulary to consume rather than re-inventing.

## Changes

- Add a type-extension token layer under `app/Taskmato/Views/App/DesignTokens/`, one file per concern (matches the existing `TaskPriority+Styling` / `ProviderTint+Color` precedent):
  - `Typography.swift` — `Font` (`taskTitle`, `timerCountdown`, `statValue`, `sectionHeader`, …)
  - `Palette.swift` — `Color` (`dueUrgent`, `priorityHigh/Neutral`, `timerRingTrack`, `cardSurface`, `chartPalette`, …)
  - `Spacing.swift` — `CGFloat` (`rowVertical`, `cardPadding`, `sectionGap`, …)
  - `Shape.swift` — `CGFloat` corner radii + `RoundedRectangle.card`
  - `Opacity.swift` — `Double` (`subtle`, `muted`)
- Add `docs/reference/styling.md` — flat token lookup per Divio's reference quadrant.

System hierarchical styles (`.primary`/`.secondary`/`.tertiary`) are intentionally used directly, not re-aliased. Tokens are defined but unreferenced by design; a clean build confirms they are type-correct.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

`make sync-version` → `make lint` (0 violations) → `make format-check` (exit 0) → `make build` (**BUILD SUCCEEDED**; all five token files compile, no new warnings). Unit tests were not run: this PR adds no referenced code and modifies no existing file, so the suite is unaffected. `git diff` confirms only new files — no view modified.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- **Follow-up (#416, apply pass)** will consume these tokens across views and resolve the inconsistencies the audit surfaced: card corner radius `10` vs `8` (canonicalized to `8`), card surface fill (`.secondary.opacity(0.1)` vs `.background.secondary`), section-header weight (`.semibold` vs `.medium`), inline spacing `3/6/8`, section gap `16` vs `20`, chart bar radius `2` vs `3`, `taskMetadata`/`taskLineage` currently identical, and repointing `TaskPriority.accentColor` at `priorityHigh`/`priorityNeutral`. These will be filed as the #416 checklist.
- Canonical values (e.g. card radius `8`) are the one place to push back if a different default is preferred, since #416 will apply them everywhere.
