### PR TITLE
refactor(design): adopt design tokens across existing views

### DIFF
--- a/app/Taskmato/Views/App/DesignTokens/Palette.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Palette.swift
@@ -25,6 +25,12 @@ extension Color {
   /// Marker on the provider's default (favorite) list.
   static let favoriteStar: Color = .yellow
 
+  /// Error or warning indicator (permission failure, validation).
+  static let statusError: Color = .red
+
+  /// Success or authorized-state indicator.
+  static let statusSuccess: Color = .green
+
   /// Ordered colors assigned to slices/series in stats charts.
   static let chartPalette: [Color] = [
     .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,

--- a/app/Taskmato/Views/App/DesignTokens/Spacing.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Spacing.swift
@@ -22,6 +22,9 @@ extension CGFloat {
   /// Interior padding of a card.
   static let cardPadding: CGFloat = 10
 
+  /// Gap between grouped items or grid cells; one step looser than `contentGap`.
+  static let groupGap: CGFloat = 12
+
   /// Gap between distinct sections of content.
   static let sectionGap: CGFloat = 16
 

--- a/app/Taskmato/Views/App/DesignTokens/Typography.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Typography.swift
@@ -33,4 +33,7 @@ extension Font {
 
   /// Title above a chart or stats visualization.
   static let chartTitle: Font = .headline
+
+  /// Title at the top of a modal sheet.
+  static let sheetTitle: Font = .title2.weight(.semibold)
 }

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -55,9 +55,9 @@ struct MenuBarPopoverView: View {
         .buttonStyle(.plain)
         .help("Open \(Bundle.main.appName)")
       }
-      .padding(.horizontal, 16)
-      .padding(.top, 12)
-      .padding(.bottom, 8)
+      .padding(.horizontal, .sectionGap)
+      .padding(.top, .groupGap)
+      .padding(.bottom, .contentGap)
 
       CircularTimerView(
         progress: progress,
@@ -67,11 +67,11 @@ struct MenuBarPopoverView: View {
 
       controls
         .frame(height: 44)
-        .padding(.top, 16)
-        .padding(.bottom, 12)
+        .padding(.top, .sectionGap)
+        .padding(.bottom, .groupGap)
 
       Divider()
-        .padding(.horizontal, 16)
+        .padding(.horizontal, .sectionGap)
 
       if selectionStore.activeTask != nil {
         ActiveTaskView(engine: engine, selectionStore: selectionStore, registry: registry, nav: nav)
@@ -87,12 +87,12 @@ struct MenuBarPopoverView: View {
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 6)
+        .padding(.horizontal, .sectionGap)
+        .padding(.vertical, .iconLabel)
       }
 
       Divider()
-        .padding(.horizontal, 16)
+        .padding(.horizontal, .sectionGap)
 
       Button {
         let popover = NSApp.keyWindow
@@ -104,8 +104,8 @@ struct MenuBarPopoverView: View {
           streak: statsViewModel.currentStreak)
       }
       .buttonStyle(.plain)
-      .padding(.horizontal, 16)
-      .padding(.vertical, 10)
+      .padding(.horizontal, .sectionGap)
+      .padding(.vertical, .cardPadding)
     }
     .frame(width: 280)
     .onAppear {
@@ -120,7 +120,7 @@ struct MenuBarPopoverView: View {
   // MARK: - Controls
 
   private var controls: some View {
-    HStack(spacing: 12) {
+    HStack(spacing: .groupGap) {
       if engine.isRunning {
         ControlButton(
           label: AppLabels.Timer.pause.title,

--- a/app/Taskmato/Views/Settings/Obsidian/ObsidianSettingsView.swift
+++ b/app/Taskmato/Views/Settings/Obsidian/ObsidianSettingsView.swift
@@ -25,7 +25,7 @@ struct ObsidianSettingsView: View {
         LabeledContent("Vault", value: provider.vaultName)
 
         LabeledContent("File patterns") {
-          VStack(alignment: .leading, spacing: 4) {
+          VStack(alignment: .leading, spacing: .rowVertical) {
             TextField("e.g. **/*.md", text: $patternText)
               .autocorrectionDisabled()
               .focused($isPatternFocused)

--- a/app/Taskmato/Views/Settings/Obsidian/ObsidianSetupSheet.swift
+++ b/app/Taskmato/Views/Settings/Obsidian/ObsidianSetupSheet.swift
@@ -12,10 +12,9 @@ struct ObsidianSetupSheet: View {
   @Environment(\.dismiss) private var dismiss
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 16) {
+    VStack(alignment: .leading, spacing: .sectionGap) {
       Text("Configure \(provider.displayName)")
-        .font(.title2)
-        .fontWeight(.semibold)
+        .font(.sheetTitle)
 
       ObsidianSettingsView(provider: provider)
 
@@ -25,7 +24,7 @@ struct ObsidianSetupSheet: View {
           .keyboardShortcut(.defaultAction)
       }
     }
-    .padding(24)
+    .padding(.screenPadding)
     .frame(minWidth: 360)
   }
 }

--- a/app/Taskmato/Views/Settings/Reminders/RemindersSetupSheet.swift
+++ b/app/Taskmato/Views/Settings/Reminders/RemindersSetupSheet.swift
@@ -30,10 +30,9 @@ struct RemindersSetupSheet: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 16) {
+    VStack(alignment: .leading, spacing: .sectionGap) {
       Text("Apple Reminders")
-        .font(.title2)
-        .fontWeight(.semibold)
+        .font(.sheetTitle)
 
       content
 
@@ -46,7 +45,7 @@ struct RemindersSetupSheet: View {
         .keyboardShortcut(.defaultAction)
       }
     }
-    .padding(24)
+    .padding(.screenPadding)
     .frame(minWidth: 360)
     .alert(
       "Reminders Access Denied",
@@ -73,9 +72,9 @@ struct RemindersSetupSheet: View {
 
   @ViewBuilder
   private var authorizedView: some View {
-    HStack(spacing: 8) {
+    HStack(spacing: .contentGap) {
       Image(systemName: "checkmark.circle.fill")
-        .foregroundStyle(.green)
+        .foregroundStyle(Color.statusSuccess)
         .imageScale(.large)
       Text(listSummaryText)
     }
@@ -92,7 +91,7 @@ struct RemindersSetupSheet: View {
   }
 
   private var grantAccessView: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: .groupGap) {
       Text(
         "Taskmato needs access to your reminders so you can "
           + "select one as your focus task."

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -34,12 +34,12 @@ struct SettingsView: View {
 
         if settings.notificationsEnabled {
           if notifications.authStatus == .denied {
-            HStack(spacing: 8) {
+            HStack(spacing: .contentGap) {
               Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
-              VStack(alignment: .leading, spacing: 2) {
+                .foregroundStyle(Color.statusError)
+              VStack(alignment: .leading, spacing: .stackTight) {
                 Text("Notifications are disabled in System Settings")
-                  .foregroundStyle(.red)
+                  .foregroundStyle(Color.statusError)
                 Button("Open Notification Settings…") {
                   openNotificationSettings()
                 }
@@ -62,7 +62,7 @@ struct SettingsView: View {
           }
 
           DisclosureGroup {
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: .iconLabel) {
               Text(
                 "Taskmato's settings control which cues fire. "
                   + "System Settings → Notifications → Taskmato controls how they appear:"
@@ -176,7 +176,7 @@ private struct BulletText: View {
   }
 
   var body: some View {
-    HStack(alignment: .top, spacing: 4) {
+    HStack(alignment: .top, spacing: .rowVertical) {
       Text("•").foregroundStyle(.secondary)
       Text(text).foregroundStyle(.secondary)
     }

--- a/app/Taskmato/Views/Stats/Components/DailyBarChart.swift
+++ b/app/Taskmato/Views/Stats/Components/DailyBarChart.swift
@@ -24,16 +24,16 @@ struct DailyBarChart: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: .groupGap) {
       Text("Daily Focus")
-        .font(.headline)
+        .font(.chartTitle)
 
       Chart(totals) { total in
         BarMark(
           x: .value("Day", total.day, unit: .day),
           y: .value("Minutes", total.minutes)
         )
-        .cornerRadius(2)
+        .cornerRadius(.barCornerRadius)
         .foregroundStyle(by: .value("Provider", labelByID[total.providerID] ?? total.providerID))
       }
       .chartForegroundStyleScale(

--- a/app/Taskmato/Views/Stats/Components/RankedTaskList.swift
+++ b/app/Taskmato/Views/Stats/Components/RankedTaskList.swift
@@ -14,13 +14,13 @@ struct RankedTaskList: View {
   let slices: [SessionSummary.TaskSlice]
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: .groupGap) {
       Text("By Task")
-        .font(.headline)
+        .font(.chartTitle)
 
-      VStack(spacing: 6) {
+      VStack(spacing: .iconLabel) {
         ForEach(slices) { slice in
-          HStack(spacing: 8) {
+          HStack(spacing: .contentGap) {
             Text(slice.label)
               .lineLimit(1)
             Spacer()

--- a/app/Taskmato/Views/Stats/Components/StatCardView.swift
+++ b/app/Taskmato/Views/Stats/Components/StatCardView.swift
@@ -13,21 +13,19 @@ struct StatCardView: View {
   let label: String
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 4) {
+    VStack(alignment: .leading, spacing: .rowVertical) {
       Image(systemName: icon)
         .font(.title2)
         .foregroundStyle(.secondary)
       Text(value)
-        .font(.title)
-        .fontWeight(.semibold)
-        .monospacedDigit()
+        .font(.statValue)
       Text(label)
-        .font(.caption)
+        .font(.statLabel)
         .foregroundStyle(.secondary)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .padding(12)
-    .background(.background.secondary)
-    .clipShape(RoundedRectangle(cornerRadius: 8))
+    .padding(.cardPadding)
+    .background(Color.cardSurface)
+    .clipShape(RoundedRectangle.card)
   }
 }

--- a/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
+++ b/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
@@ -18,19 +18,14 @@ struct TaskDonutChart: View {
   /// Total focus seconds in the period, used to compute each slice's percentage.
   let totalSeconds: TimeInterval
 
-  /// Ordered palette assigned to slices by index.
-  private static let palette: [Color] = [
-    .blue, .green, .orange, .purple, .red, .teal, .indigo, .pink,
-  ]
-
   private func color(_ index: Int) -> Color {
-    Self.palette[index % Self.palette.count]
+    Color.chartPalette[index % Color.chartPalette.count]
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: .groupGap) {
       Text("Task Breakdown")
-        .font(.headline)
+        .font(.chartTitle)
 
       Chart(slices) { slice in
         SectorMark(
@@ -38,7 +33,7 @@ struct TaskDonutChart: View {
           innerRadius: .ratio(0.5),
           angularInset: 1.5
         )
-        .cornerRadius(3)
+        .cornerRadius(.barCornerRadius)
         .foregroundStyle(by: .value("Task", slice.label))
       }
       .chartForegroundStyleScale(
@@ -48,9 +43,9 @@ struct TaskDonutChart: View {
       .chartLegend(.hidden)
       .frame(height: 160)
 
-      VStack(spacing: 6) {
+      VStack(spacing: .iconLabel) {
         ForEach(Array(slices.enumerated()), id: \.element.id) { index, slice in
-          HStack(spacing: 8) {
+          HStack(spacing: .contentGap) {
             Circle()
               .fill(color(index))
               .frame(width: 10, height: 10)

--- a/app/Taskmato/Views/Stats/StatsTabView.swift
+++ b/app/Taskmato/Views/Stats/StatsTabView.swift
@@ -47,13 +47,13 @@ struct StatsTabView: View {
   private func scopeContent(_ summary: SessionSummary) -> some View {
     switch statsViewModel.scope {
     case .allTime:
-      VStack(alignment: .leading, spacing: 20) {
+      VStack(alignment: .leading, spacing: .sectionGap) {
         statGrid(summary).padding([.horizontal, .top])
         AllTimeTaskTable(rows: statsViewModel.allTaskRows)
       }
     default:
       ScrollView {
-        VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: .sectionGap) {
           statGrid(summary)
           scopeCharts(summary)
         }
@@ -92,7 +92,7 @@ struct StatsTabView: View {
     .pickerStyle(.segmented)
     .labelsHidden()
     .padding([.horizontal, .top])
-    .padding(.bottom, 16)
+    .padding(.bottom, .sectionGap)
   }
 
   // MARK: - Period navigation
@@ -101,7 +101,7 @@ struct StatsTabView: View {
   /// Time (which has no period navigation) to keep the layout from jumping.
   private var navigationRow: some View {
     let showsArrows = statsViewModel.canNavigateBack
-    return HStack(spacing: 8) {
+    return HStack(spacing: .contentGap) {
       Button {
         statsViewModel.navigateBack()
       } label: {
@@ -112,7 +112,7 @@ struct StatsTabView: View {
       .accessibilityLabel("Previous period")
 
       Text(periodLabel)
-        .font(.subheadline.weight(.medium))
+        .font(.sectionHeader)
         .monospacedDigit()
         .frame(width: 160)
 
@@ -128,7 +128,7 @@ struct StatsTabView: View {
     .buttonStyle(.borderless)
     .frame(maxWidth: .infinity)
     .padding(.horizontal)
-    .padding(.bottom, 8)
+    .padding(.bottom, .contentGap)
   }
 
   /// The navigated period rendered for the current scope and offset.
@@ -156,7 +156,7 @@ struct StatsTabView: View {
   // MARK: - Stat grid
 
   private func statGrid(_ summary: SessionSummary) -> some View {
-    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: .groupGap) {
       StatCardView(icon: "target", value: "\(summary.focusCount)", label: "Sessions")
       StatCardView(
         icon: "timer",

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -41,9 +41,9 @@ struct AddTaskView: View {
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 16) {
+    VStack(alignment: .leading, spacing: .sectionGap) {
       Text(sheetTitle)
-        .font(.headline)
+        .font(.sheetTitle)
 
       TextField("Task title", text: $title)
         .textFieldStyle(.roundedBorder)

--- a/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
@@ -19,9 +19,9 @@ struct TaskCardView: View {
   @State private var showDeleteConfirmation = false
 
   var body: some View {
-    HStack(alignment: .top, spacing: 6) {
+    HStack(alignment: .top, spacing: .iconLabel) {
       leadingButton
-      VStack(alignment: .leading, spacing: 4) {
+      VStack(alignment: .leading, spacing: .rowVertical) {
         titleRow
         if let notes = task.notes {
           TaskNoteView(notes: notes, format: task.format)
@@ -35,13 +35,13 @@ struct TaskCardView: View {
       }
       trailingButton
     }
-    .padding(10)
+    .padding(.cardPadding)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     .background(
-      RoundedRectangle(cornerRadius: 10)
-        .fill(.secondary.opacity(0.1))
+      RoundedRectangle.card
+        .fill(Color.cardSurface)
     )
-    .contentShape(RoundedRectangle(cornerRadius: 10))
+    .contentShape(RoundedRectangle.card)
     .onHover { hover in
       if case .completed = kind { isHovered = hover }
     }
@@ -79,11 +79,11 @@ struct TaskCardView: View {
   }
 
   private var titleRow: some View {
-    HStack(alignment: .firstTextBaseline, spacing: 3) {
+    HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
       if let icon = task.priority.icon {
         Image(systemName: icon)
           .foregroundStyle(task.priority.accentColor)
-          .font(.callout)
+          .font(.taskTitle)
       }
       TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: 3)
     }
@@ -95,18 +95,18 @@ struct TaskCardView: View {
     case .active:
       if let due = task.dueDate {
         Text(due, format: .dateTime.month(.abbreviated).day().year())
-          .font(.caption2)
-          .foregroundStyle(due.isUrgentDueDate ? Color.red : Color.secondary)
+          .font(.taskMetadata)
+          .foregroundStyle(due.isUrgentDueDate ? Color.dueUrgent : Color.secondary)
       }
     case .completed:
       Text(completedSubtitle)
-        .font(.caption2)
+        .font(.taskMetadata)
         .foregroundStyle(.tertiary)
     }
   }
 
   private func lineageRow(_ lin: TaskLineage) -> some View {
-    HStack(spacing: 3) {
+    HStack(spacing: .iconLabel) {
       if let icon = lin.providerIcon {
         Image(systemName: icon)
       }
@@ -117,7 +117,7 @@ struct TaskCardView: View {
         Text(ctx)
       }
     }
-    .font(.caption2)
+    .font(.taskLineage)
     .foregroundStyle(.tertiary)
   }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskMarkdownTitle.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskMarkdownTitle.swift
@@ -17,7 +17,7 @@ struct TaskMarkdownTitle: View {
 
   var body: some View {
     Text(task.markdownTitle)
-      .font(.callout)
+      .font(.taskTitle)
       .foregroundStyle(isCompleted ? .secondary : .primary)
       .lineLimit(lineLimit)
       .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/Taskmato/Views/Tasks/Components/TaskPriority+Styling.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskPriority+Styling.swift
@@ -10,8 +10,8 @@ extension TaskPriority {
   /// The accent color used to tint priority icons in task views.
   var accentColor: Color {
     switch self {
-    case .highest, .high, .medium: return .orange
-    case .low, .lowest, .none: return .primary
+    case .highest, .high, .medium: return .priorityHigh
+    case .low, .lowest, .none: return .priorityNeutral
     }
   }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskRowView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskRowView.swift
@@ -20,9 +20,9 @@ struct TaskRowView: View {
   @State private var showDeleteConfirmation = false
 
   var body: some View {
-    HStack(alignment: .top, spacing: 8) {
+    HStack(alignment: .top, spacing: .contentGap) {
       leadingButton
-      VStack(alignment: .leading, spacing: 2) {
+      VStack(alignment: .leading, spacing: .stackTight) {
         titleRow
         if let notes = task.notes {
           TaskNoteView(notes: notes, format: task.format)
@@ -34,7 +34,7 @@ struct TaskRowView: View {
       }
       trailingButton
     }
-    .padding(.vertical, 4)
+    .padding(.vertical, .rowVertical)
     .contentShape(Rectangle())
     .onHover { hover in
       if case .completed = kind { isHovered = hover }
@@ -73,11 +73,11 @@ struct TaskRowView: View {
   }
 
   private var titleRow: some View {
-    HStack(alignment: .firstTextBaseline, spacing: 3) {
+    HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
       if let icon = task.priority.icon {
         Image(systemName: icon)
           .foregroundStyle(task.priority.accentColor)
-          .font(.callout)
+          .font(.taskTitle)
       }
       TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: 2)
     }
@@ -89,18 +89,18 @@ struct TaskRowView: View {
     case .active:
       if let due = task.dueDate {
         Text(due, format: .dateTime.month(.abbreviated).day())
-          .font(.caption2)
-          .foregroundStyle(due.isUrgentDueDate ? Color.red : Color.secondary)
+          .font(.taskMetadata)
+          .foregroundStyle(due.isUrgentDueDate ? Color.dueUrgent : Color.secondary)
       }
     case .completed:
       Text(completedSubtitle)
-        .font(.caption2)
+        .font(.taskMetadata)
         .foregroundStyle(.tertiary)
     }
   }
 
   private func lineageRow(_ lin: TaskLineage) -> some View {
-    HStack(spacing: 3) {
+    HStack(spacing: .iconLabel) {
       if let icon = lin.providerIcon {
         Image(systemName: icon)
       }
@@ -111,7 +111,7 @@ struct TaskRowView: View {
         Text(ctx)
       }
     }
-    .font(.caption2)
+    .font(.taskLineage)
     .foregroundStyle(.tertiary)
   }
 

--- a/app/Taskmato/Views/Tasks/ProviderSidebarView.swift
+++ b/app/Taskmato/Views/Tasks/ProviderSidebarView.swift
@@ -70,8 +70,8 @@ struct ProviderSidebarView: View {
         VStack(spacing: 0) {
           Divider()
           addProviderMenu
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.horizontal, .groupGap)
+            .padding(.vertical, .contentGap)
         }
         .background(.bar)
       }
@@ -116,14 +116,14 @@ struct ProviderSidebarView: View {
         newListRow(providerID: provider.id)
       }
     } header: {
-      HStack(spacing: 6) {
+      HStack(spacing: .iconLabel) {
         Image(systemName: provider.icon)
           .imageScale(.small)
         Text(provider.displayName)
         Spacer()
       }
       .font(.callout)
-      .padding(.vertical, 2)
+      .padding(.vertical, .stackTight)
       .contentShape(Rectangle())
       .contextMenu {
         if let configurable = provider as? (any ConfigurableTaskProvider) {
@@ -152,7 +152,7 @@ struct ProviderSidebarView: View {
     let writable = provider as? (any WritableTaskProvider)
     let isDefaultList = isDefault(list.id, for: provider)
 
-    HStack(spacing: 6) {
+    HStack(spacing: .iconLabel) {
       Image(systemName: "list.bullet")
         .imageScale(.small)
         .foregroundStyle(.secondary)
@@ -170,7 +170,7 @@ struct ProviderSidebarView: View {
             .imageScale(.small)
         }
         .buttonStyle(.borderless)
-        .foregroundStyle(isDefaultList ? Color.yellow : Color.secondary)
+        .foregroundStyle(isDefaultList ? Color.favoriteStar : Color.secondary)
         .help(isDefaultList ? "Default list" : "Set as default list")
       }
     }
@@ -279,7 +279,7 @@ struct ProviderSidebarView: View {
       set: { newListName[providerID] = $0 }
     )
 
-    HStack(spacing: 6) {
+    HStack(spacing: .iconLabel) {
       Image(systemName: "plus")
         .imageScale(.small)
         .foregroundStyle(.secondary)

--- a/app/Taskmato/Views/Tasks/TasksTabView.swift
+++ b/app/Taskmato/Views/Tasks/TasksTabView.swift
@@ -198,13 +198,13 @@ struct TasksTabView: View {
   private var detailColumn: some View {
     VStack(spacing: 0) {
       if let info = navigationContext {
-        HStack(spacing: 6) {
+        HStack(spacing: .iconLabel) {
           Image(systemName: info.icon).foregroundStyle(Color.accentColor)
           Text(info.label).foregroundStyle(.secondary)
           Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
+        .padding(.horizontal, .sectionGap)
+        .padding(.vertical, .contentGap)
       }
       detailContent
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -291,7 +291,7 @@ struct TasksTabView: View {
       }
     } header: {
       if shouldShowHeader(section) {
-        Text(section.header).font(.subheadline).fontWeight(.semibold)
+        Text(section.header).font(.sectionHeader)
       }
     }
   }
@@ -344,17 +344,17 @@ struct TasksTabView: View {
   // MARK: - Grid layout
 
   private var taskGrid: some View {
-    let columns = [GridItem(.adaptive(minimum: 180), spacing: 10)]
+    let columns = [GridItem(.adaptive(minimum: 180), spacing: .groupGap)]
     return ScrollView {
-      VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: .sectionGap) {
         ForEach(sections) { section in
-          VStack(alignment: .leading, spacing: 8) {
+          VStack(alignment: .leading, spacing: .contentGap) {
             if shouldShowHeader(section) {
               Text(section.header)
-                .font(.subheadline).fontWeight(.semibold).padding(.horizontal, 2)
+                .font(.sectionHeader).padding(.horizontal, .stackTight)
             }
 
-            LazyVGrid(columns: columns, spacing: 10) {
+            LazyVGrid(columns: columns, spacing: .groupGap) {
               ForEach(section.tasks) { task in
                 Button {
                   select(task)
@@ -374,16 +374,16 @@ struct TasksTabView: View {
         }
 
         if showCompleted && !completedTasks.isEmpty {
-          VStack(alignment: .leading, spacing: 8) {
+          VStack(alignment: .leading, spacing: .contentGap) {
             completedSectionHeader
-              .padding(.horizontal, 2)
-            LazyVGrid(columns: columns, spacing: 10) {
+              .padding(.horizontal, .stackTight)
+            LazyVGrid(columns: columns, spacing: .groupGap) {
               ForEach(completedTasks) { task in completedCard(task) }
             }
           }
         }
       }
-      .padding(10)
+      .padding(.cardPadding)
     }
   }
 
@@ -391,7 +391,7 @@ struct TasksTabView: View {
   private var completedSectionHeader: some View {
     HStack {
       Text("\(completedTasks.count) Completed")
-        .font(.subheadline).fontWeight(.semibold)
+        .font(.sectionHeader)
       Spacer()
       Button("Hide") { showCompleted = false }
         .buttonStyle(.plain)

--- a/app/Taskmato/Views/Timer/ActiveTaskView.swift
+++ b/app/Taskmato/Views/Timer/ActiveTaskView.swift
@@ -34,20 +34,20 @@ struct ActiveTaskView: View {
           taskRow(for: task)
         }
       }
-      .padding(.horizontal, 16)
-      .padding(.vertical, 8)
+      .padding(.horizontal, .sectionGap)
+      .padding(.vertical, .contentGap)
     }
   }
 
   // MARK: - Row variants
 
   private func taskRow(for task: TaskItem) -> some View {
-    HStack(alignment: .top, spacing: 8) {
+    HStack(alignment: .top, spacing: .contentGap) {
       leadingIndicator(for: task)
 
-      VStack(alignment: .leading, spacing: 2) {
+      VStack(alignment: .leading, spacing: .stackTight) {
         Text(displayTitle(for: task))
-          .font(.callout)
+          .font(.taskTitle)
           .lineLimit(1)
           .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -96,7 +96,7 @@ struct ActiveTaskView: View {
 
   /// An inline prompt that replaces the normal row while a destructive action awaits confirmation.
   private func confirmationRow(for action: ConfirmAction, task: TaskItem) -> some View {
-    HStack(spacing: 8) {
+    HStack(spacing: .contentGap) {
       Image(systemName: "exclamationmark.triangle")
         .font(.caption2)
         .foregroundStyle(.secondary)

--- a/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
+++ b/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
@@ -21,7 +21,7 @@ struct CircularTimerView: View {
   var body: some View {
     ZStack {
       Circle()
-        .stroke(Color.secondary.opacity(0.2), lineWidth: strokeWidth)
+        .stroke(Color.timerRingTrack, lineWidth: strokeWidth)
 
       // Elapsed arc grows clockwise from 12 o'clock as time passes.
       Circle()
@@ -33,12 +33,12 @@ struct CircularTimerView: View {
         .rotationEffect(.degrees(-90))
         .animation(.linear(duration: 1), value: progress)
 
-      VStack(spacing: 4) {
+      VStack(spacing: .rowVertical) {
         Text(label)
-          .font(.system(size: 36, weight: .light, design: .monospaced))
+          .font(.timerCountdown)
           .foregroundStyle(.primary)
         Text(phase)
-          .font(.subheadline)
+          .font(.timerPhaseLabel)
           .foregroundStyle(.secondary)
       }
     }

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -32,19 +32,19 @@ struct TimerTabView: View {
       controls
         .frame(height: 44)
         .padding(.top, 20)
-        .padding(.bottom, 24)
+        .padding(.bottom, .screenPadding)
 
       Spacer()
 
       Divider()
-        .padding(.horizontal, 24)
+        .padding(.horizontal, .screenPadding)
 
       if selectionStore.activeTask != nil {
         ActiveTaskView(
           engine: engine, selectionStore: selectionStore, registry: registry, nav: nav,
           showNotes: true
         )
-        .padding(.horizontal, 8)
+        .padding(.horizontal, .contentGap)
       } else {
         Button {
           nav.browseTasksAndPick()
@@ -54,26 +54,26 @@ struct TimerTabView: View {
         }
         .buttonStyle(.plain)
         .foregroundStyle(.secondary)
-        .padding(.horizontal, 24)
-        .padding(.vertical, 6)
+        .padding(.horizontal, .screenPadding)
+        .padding(.vertical, .iconLabel)
       }
 
       Divider()
-        .padding(.horizontal, 24)
+        .padding(.horizontal, .screenPadding)
 
       SessionStatsView(
         count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes,
         streak: statsViewModel.currentStreak
       )
-      .padding(.horizontal, 24)
-      .padding(.vertical, 12)
+      .padding(.horizontal, .screenPadding)
+      .padding(.vertical, .groupGap)
     }
   }
 
   // MARK: - Controls
 
   private var controls: some View {
-    HStack(spacing: 12) {
+    HStack(spacing: .groupGap) {
       if engine.isRunning {
         ControlButton(
           label: AppLabels.Timer.pause.title,

--- a/docs/reference/styling.md
+++ b/docs/reference/styling.md
@@ -23,6 +23,7 @@ are used directly — they are not re-exported as tokens.
 | `statLabel` | `.caption` | Caption describing a stat value |
 | `sectionHeader` | `.subheadline.weight(.semibold)` | Header above a section of rows or cards |
 | `chartTitle` | `.headline` | Title above a chart or stats visualization |
+| `sheetTitle` | `.title2.weight(.semibold)` | Title at the top of a modal sheet |
 
 ## Color
 
@@ -36,7 +37,11 @@ are used directly — they are not re-exported as tokens.
 | `timerRingTrack` | `.secondary.opacity(.muted)` | Unfilled portion of the circular timer ring |
 | `cardSurface` | `.secondary.opacity(.subtle)` | Fill behind a card to lift it off the background |
 | `favoriteStar` | `.yellow` | Marker on a provider's default (favorite) list |
+| `statusError` | `.red` | Error or warning indicator (permission failure, validation) |
+| `statusSuccess` | `.green` | Success or authorized-state indicator |
 | `chartPalette` | `[.blue, .green, .orange, .purple, .red, .teal, .indigo, .pink]` | Ordered colors for chart slices/series |
+
+`statusError` shares the `.red` value with `dueUrgent` — same color, distinct semantics.
 
 ## Spacing
 
@@ -49,6 +54,7 @@ are used directly — they are not re-exported as tokens.
 | `iconLabel` | `6` | Gap between an icon and its adjacent label |
 | `contentGap` | `8` | Standard gap between sibling elements in a group |
 | `cardPadding` | `10` | Interior padding of a card |
+| `groupGap` | `12` | Gap between grouped items or grid cells; one step looser than `contentGap` |
 | `sectionGap` | `16` | Gap between distinct sections of content |
 | `screenPadding` | `24` | Padding between content and a screen/sheet/popover edge |
 


### PR DESCRIPTION
## Summary

Mechanical adoption of the #415 design-token vocabulary across every existing view, plus a small vocabulary extension so views have canonical values to consume instead of new literals.

## Linked issue

Closes #416

## Motivation

The tokens from #415 only deliver value once views consume them. This PR is the bridge: every magic number, literal color, and duplicated font specifier becomes a token reference, and the inconsistencies the #415 audit surfaced are resolved. It sets up the styling surface `TimerPresenter` (#405) and `TaskItemPresenter` (#406) will encode, and the accessibility pass (#411).

## Changes

**Vocabulary extension** (4 new tokens + `docs/reference/styling.md`) — the audit found real inconsistencies with no existing token, so rather than leave literals or abuse a wrong-semantic token, new tokens were added (a deliberate divergence from #415's "no new tokens" note):

- Spacing `groupGap` = `12` — grouped items / grid cells (between `contentGap` and `sectionGap`)
- Font `sheetTitle` = `.title2.weight(.semibold)` — modal sheet titles
- Color `statusError` = `.red` / `statusSuccess` = `.green` — state indicators (`statusError` shares `.red` with `dueUrgent`; same value, distinct semantics)

**Audit findings resolved** (from #415):

- [x] Card corner radius → `RoundedRectangle.card` / `.cardCornerRadius` (8); `TaskCardView` 10 → 8
- [x] Card surface fill → `Color.cardSurface` (`StatCardView` `.background.secondary` → tokenized surface)
- [x] Section header weight → `Font.sectionHeader`
- [x] Sheet title font → new `Font.sheetTitle` (`.title2 + .semibold`); `AddTaskView` bumped up to match
- [x] Inline HStack spacing 3/6/8 → `.iconLabel` / `.contentGap`
- [x] Section gap 16/20 → `.sectionGap` (16)
- [x] Grid spacing 10/12 → unified on **12** (`.groupGap`)
- [x] Chart bar / legend radius 2/3 → `.barCornerRadius` (2)
- [x] `taskMetadata` vs `taskLineage` → kept both (same value, distinct semantics)
- [x] Priority color → `Color.priorityHigh` / `.priorityNeutral` in `TaskPriority+Styling`
- [x] Timer ring track → `Color.timerRingTrack`
- [x] Due-urgent → `Color.dueUrgent`
- [x] Timer countdown → `Font.timerCountdown`
- [x] Chart palette → `Color.chartPalette` (dropped `TaskDonutChart`'s local copy)

**Scope**: 23 view files + `docs/reference/styling.md`. No domain, service, or composition changes; no new files.

## Validation

- [x] Lint passes locally (`0 violations, 0 serious in 117 files`)
- [x] Unit tests pass locally (only `TaskmatoUITests/testExample` flaked on a 90s app-termination timeout — unrelated to a presentational change)
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable — **visual sweep screenshots pending** (see Reviewer notes)

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

**Intentional visual changes** (consequences of tokenization):

- Task grid cards: corner radius 10 → 8.
- `StatCardView`: surface material `.background.secondary` → `Color.cardSurface` (`.secondary.opacity(.subtle)`); interior padding 12 → 10; value text drops `.semibold` (the `statValue` token has no weight).
- Icon↔label gaps of 3 → 6 (`.iconLabel`).
- Stats: section spacing 20 → 16; stats grid 12 (task grid 10 → 12).
- `AddTaskView` sheet title `.headline` → `.title2.semibold`.

**Two scoping decisions:**

1. **Font tokens applied by semantic, not by value.** `.callout` becomes `.taskTitle` only where it is a task title; on a sidebar provider header or settings body text it stays a bare Dynamic Type style — same treatment #415 gives `.primary`/`.secondary`. A handful of bare `.callout`/`.caption`/`.caption2` remain intentionally (settings help text, icon-sizing on buttons, chart legend). No new per-site tokens (`.sidebarTitle`, etc.) were introduced — single-call-site tokens don't earn their keep.
2. **Left as literals**: component dimensions (frame widths/heights, ring diameter, stroke width), `Color.accentColor`, `ProviderTint` data-layer colors, structural `spacing: 0`, and one bespoke `TimerTabView` `.padding(.top, 20)` nudge with no matching semantic token.

**Visual sweep still owed**: the DoD asks for before/after screenshots of Today / Tasks list / Tasks grid / Timer / Stats / Settings. Happy to capture the "after" set; a true before/after needs a `main` build for comparison.
