### PR TITLE
chore(audit): adopt changelog-sections from template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,10 @@ Allowed types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `ci`
 
 Breaking changes: append `!` (e.g., `feat!: rename public API`) or include a `BREAKING CHANGE:` footer.
 
+### CHANGELOG sections
+
+`release-please-config.json` sets `changelog-sections` so the generated `CHANGELOG.md` surfaces substantive work, not just `feat`/`fix`. Visible sections: `feat` (Features), `fix` (Bug Fixes), `perf` (Performance Improvements), `refactor` (Code Refactoring), `docs` (Documentation), `chore` (Miscellaneous Chores). The remaining types (`build`, `ci`, `test`, `style`) are hidden to keep dependency-bump and CI churn out of release notes. This affects only what is listed in the changelog — it does not change which types trigger a version bump.
+
 ## Branching
 
 - `main` is the default branch and is protected by a ruleset.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,19 @@
       "bump-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
-      "extra-files": ["version.txt"]
+      "extra-files": ["version.txt"],
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "refactor", "section": "Code Refactoring" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true },
+        { "type": "chore", "section": "Miscellaneous Chores" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Adopt the `changelog-sections` configuration from the `richwklein/repo-template-base`
template, surfaced by a `/repo-template-audit` run.

## Linked issue

_No tracked issue — surfaced by the template-drift audit._

## Motivation

The audit found `release-please-config.json` drifted from the template but the
config's `changelog-sections` block was never adopted (the audit classifies that
file as presence-only, so content drift slipped through). Without it, release-please
falls back to defaults and `CHANGELOG.md` only shows Features and Bug Fixes — hiding
`perf`, `refactor`, and `docs` work that the `Allowed types` list in `AGENTS.md`
already sanctions.

## Changes

- **`release-please-config.json`** — add the `changelog-sections` block. Visible:
  `feat`, `fix`, `perf`, `refactor`, `docs`, `chore`. Hidden: `build`, `ci`, `test`,
  `style`. Project-specific keys (`package-name`, `include-component-in-tag`,
  `extra-files`) are left untouched.
- **`AGENTS.md`** — add a `### CHANGELOG sections` subsection under `## Commits`
  documenting the grouping, in the repo's local voice.

Intentional Swift-specific drift flagged by the audit (`code-codeql.yaml`,
`detect-relevant-changes/action.yaml`, `.vscode/*`, `.gitignore`) was reviewed and
deliberately left as-is.

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

Config/docs only — no Swift sources touched, so `make lint`/tests were not run.
`changelog-sections` affects only how the next release's `CHANGELOG.md` is grouped;
it does not change which commit types trigger a version bump. Validated the config
against the template with a direct diff.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The `changelog-sections` grouping takes effect on the next release-please run; the
existing `CHANGELOG.md` is unaffected. Audit also noted 4 extra repo labels
(`blocked`, `github_actions`, `needs-triage`, `release-blocker`) — reviewed and kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016naeV9u7gN9SLnDzcUNujJ
