### PR TITLE
refactor(timer): centralize timer display and intent in TimerPresenter

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -19,6 +19,7 @@ struct AppComposition {
 
   let engine: SessionEngine
   let settings: AppSettings
+  let timerPresenter: TimerPresenter
   let store: SessionStore
   let statsViewModel: StatsViewModel
   let selectionStore: TaskSelectionStore
@@ -62,6 +63,7 @@ struct AppComposition {
     )
     self.engine = engine
     self.settings = settings
+    self.timerPresenter = TimerPresenter(engine: engine, settings: settings)
     self.store = store
     self.statsViewModel = statsViewModel
     self.selectionStore = selectionStore
@@ -120,9 +122,7 @@ struct AppComposition {
       self.statsViewModel.recordAppended(session)
       guard wasCompleted else { return }
       self.notifications.send(phase: phase)
-      self.engine.focusDuration = self.settings.focusDuration
-      self.engine.shortBreakDuration = self.settings.shortBreakDuration
-      self.engine.longBreakDuration = self.settings.longBreakDuration
+      self.engine.applyDurations(from: self.settings)
       let next: SessionPhase
       switch phase {
       case .focus:

--- a/app/Taskmato/Session/SessionEngine.swift
+++ b/app/Taskmato/Session/SessionEngine.swift
@@ -249,6 +249,17 @@ final class SessionEngine {
     queuedPhase = phase
   }
 
+  /// Copies the configured phase durations from `settings` into the engine.
+  ///
+  /// The single point where user-configured durations enter the engine — call it at each
+  /// phase boundary (start, skip, auto-advance) so a mid-session settings change takes
+  /// effect on the next phase rather than the current one.
+  func applyDurations(from settings: AppSettings) {
+    focusDuration = settings.focusDuration
+    shortBreakDuration = settings.shortBreakDuration
+    longBreakDuration = settings.longBreakDuration
+  }
+
   // Recomputes timeRemaining from the stored start timestamp.
   // Called on each timer tick and immediately before pausing.
   // Detects natural phase completion when remaining time reaches zero.

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -24,15 +24,12 @@ struct TaskmatoApp: App {
   var body: some Scene {
     MenuBarExtra {
       MenuBarPopoverView(
+        presenter: composition.timerPresenter,
         engine: composition.engine,
-        settings: composition.settings,
         statsViewModel: composition.statsViewModel,
         selectionStore: composition.selectionStore,
         registry: composition.registry,
-        nav: composition.nav,
-        nextStartPhase: composition.engine.queuedPhase ?? .focus,
-        nextBreakPhase: composition.engine.nextBreakPhase(
-          longBreakAfter: composition.settings.longBreakAfterSessions)
+        nav: composition.nav
       )
       .confirmationDialog(
         "Multiple tasks match — which one?",
@@ -68,13 +65,14 @@ struct TaskmatoApp: App {
     } label: {
       HStack(spacing: 4) {
         Image("MenuIcon")
-        Text(menuBarLabel)
+        Text(composition.timerPresenter.label)
       }
     }
     .menuBarExtraStyle(.window)
 
     Window(Bundle.main.appName, id: "main") {
       MainWindowView(
+        presenter: composition.timerPresenter,
         engine: composition.engine,
         settings: composition.settings,
         statsViewModel: composition.statsViewModel,
@@ -98,22 +96,6 @@ struct TaskmatoApp: App {
       )
     }
     .windowResizability(.contentSize)
-  }
-
-  /// Formats the active or idle time as `"MM:SS"` for display in the menu bar.
-  private var menuBarLabel: String {
-    let seconds: Int
-    if case .idle = composition.engine.state {
-      let phase = composition.engine.queuedPhase ?? SessionPhase.focus
-      switch phase {
-      case .focus: seconds = Int(composition.settings.focusDuration)
-      case .shortBreak: seconds = Int(composition.settings.shortBreakDuration)
-      case .longBreak: seconds = Int(composition.settings.longBreakDuration)
-      }
-    } else {
-      seconds = Int(composition.engine.timeRemaining)
-    }
-    return String(format: "%02d:%02d", seconds / 60, seconds % 60)
   }
 }
 

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -79,9 +79,7 @@ final class URLSchemeHandler {
     selectionStore.select(task)
     nav.showTimerInMainWindow()
     if case .idle = engine.state, settings.autoStartNextPhase {
-      engine.focusDuration = settings.focusDuration
-      engine.shortBreakDuration = settings.shortBreakDuration
-      engine.longBreakDuration = settings.longBreakDuration
+      engine.applyDurations(from: settings)
       engine.start(phase: .focus)
     }
   }

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -22,6 +22,7 @@ enum MainTab: Int {
 /// injected ``MainNavigation`` model.
 struct MainWindowView: View {
 
+  var presenter: TimerPresenter
   var engine: SessionEngine
   var settings: AppSettings
   var statsViewModel: StatsViewModel
@@ -48,14 +49,12 @@ struct MainWindowView: View {
         value: MainTab.timer
       ) {
         TimerTabView(
+          presenter: presenter,
           engine: engine,
-          settings: settings,
           statsViewModel: statsViewModel,
           selectionStore: selectionStore,
           registry: registry,
-          nav: nav,
-          nextStartPhase: engine.queuedPhase ?? .focus,
-          nextBreakPhase: engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+          nav: nav
         )
       }
 
@@ -70,47 +69,36 @@ struct MainWindowView: View {
     .focusedSceneValue(\.selectedTab, nav.selectedTab)
     .focusedSceneValue(\.timerToggle, timerToggleAction)
     .focusedSceneValue(\.timerToggleTitle, timerToggleTitleValue)
-    .focusedSceneValue(\.timerSkip, { skipPhase() })
-    .focusedSceneValue(\.timerStop, engine.state != .idle ? { engine.stop() } : nil)
+    .focusedSceneValue(\.timerSkip, { presenter.skip() })
+    .focusedSceneValue(\.timerStop, presenter.canStop ? { presenter.stop() } : nil)
   }
 
   // MARK: - Timer command helpers
 
   private var timerToggleAction: (() -> Void)? {
-    if engine.isRunning { return { engine.pause() } }
-    if case .paused = engine.state { return { engine.resume() } }
+    if presenter.isRunning { return { presenter.pause() } }
+    if presenter.isPaused { return { presenter.resume() } }
     guard selectionStore.activeTask != nil else { return nil }
-    return { startSession() }
+    return { presenter.start() }
   }
 
   private var timerToggleTitleValue: String {
-    if engine.isRunning { return AppLabels.Timer.pause.title }
-    if case .paused = engine.state { return AppLabels.Timer.resume.title }
+    if presenter.isRunning { return AppLabels.Timer.pause.title }
+    if presenter.isPaused { return AppLabels.Timer.resume.title }
     return AppLabels.Timer.start.title
-  }
-
-  private func startSession() {
-    engine.focusDuration = settings.focusDuration
-    engine.shortBreakDuration = settings.shortBreakDuration
-    engine.longBreakDuration = settings.longBreakDuration
-    engine.start(phase: engine.queuedPhase ?? .focus)
-  }
-
-  private func skipPhase() {
-    engine.focusDuration = settings.focusDuration
-    engine.shortBreakDuration = settings.shortBreakDuration
-    engine.longBreakDuration = settings.longBreakDuration
-    engine.skip(nextBreak: engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions))
   }
 }
 
 #Preview {
-  MainWindowView(
-    engine: SessionEngine(),
-    settings: AppSettings(),
+  let engine = SessionEngine()
+  let settings = AppSettings()
+  return MainWindowView(
+    presenter: TimerPresenter(engine: engine, settings: settings),
+    engine: engine,
+    settings: settings,
     statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
-    nav: MainNavigation(settings: AppSettings())
+    nav: MainNavigation(settings: settings)
   )
 }

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -14,16 +14,12 @@ import SwiftUI
 /// and reports the menu-bar scene ready to drain any buffered cold-launch URLs.
 struct MenuBarPopoverView: View {
 
+  var presenter: TimerPresenter
   var engine: SessionEngine
-  var settings: AppSettings
   var statsViewModel: StatsViewModel
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   var nav: MainNavigation
-  /// The phase to start when the user presses Start from idle.
-  var nextStartPhase: SessionPhase
-  /// The break type to use when skipping from a focus session.
-  var nextBreakPhase: SessionPhase
 
   @Environment(\.openSettings) private var openSettings
   @Environment(\.openWindow) private var openWindow
@@ -60,15 +56,19 @@ struct MenuBarPopoverView: View {
       .padding(.bottom, .contentGap)
 
       CircularTimerView(
-        progress: progress,
-        label: formattedTimeRemaining,
-        phase: phaseName
+        progress: presenter.progress,
+        label: presenter.label,
+        phase: presenter.phaseName
       )
 
-      controls
-        .frame(height: 44)
-        .padding(.top, .sectionGap)
-        .padding(.bottom, .groupGap)
+      TimerControlsView(
+        presenter: presenter,
+        startDisabled: selectionStore.activeTask == nil,
+        startDisabledHelp: AppLabels.Tooltip.selectTaskFirst
+      )
+      .frame(height: 44)
+      .padding(.top, .sectionGap)
+      .padding(.bottom, .groupGap)
 
       Divider()
         .padding(.horizontal, .sectionGap)
@@ -116,118 +116,17 @@ struct MenuBarPopoverView: View {
       (NSApp.delegate as? AppDelegate)?.reportScenesReady()
     }
   }
-
-  // MARK: - Controls
-
-  private var controls: some View {
-    HStack(spacing: .groupGap) {
-      if engine.isRunning {
-        ControlButton(
-          label: AppLabels.Timer.pause.title,
-          icon: AppLabels.Timer.pause.systemImage
-        ) { engine.pause() }
-      } else if case .paused = engine.state {
-        ControlButton(
-          label: AppLabels.Timer.resume.title,
-          icon: AppLabels.Timer.resume.systemImage
-        ) { engine.resume() }
-      } else {
-        ControlButton(
-          label: AppLabels.Timer.start.title,
-          icon: AppLabels.Timer.start.systemImage
-        ) { startSession() }
-        .disabled(selectionStore.activeTask == nil)
-        .help(selectionStore.activeTask == nil ? AppLabels.Tooltip.selectTaskFirst : "")
-      }
-
-      ControlButton(
-        label: AppLabels.Timer.skip.title,
-        icon: AppLabels.Timer.skip.systemImage
-      ) { skipPhase() }
-
-      ControlButton(
-        label: AppLabels.Timer.stop.title,
-        icon: AppLabels.Timer.stop.systemImage
-      ) { engine.stop() }
-      .disabled(engine.state == .idle)
-    }
-  }
-
-  // MARK: - Actions
-
-  /// Syncs current settings into the engine, then starts the appropriate next phase.
-  private func startSession() {
-    engine.focusDuration = settings.focusDuration
-    engine.shortBreakDuration = settings.shortBreakDuration
-    engine.longBreakDuration = settings.longBreakDuration
-    engine.start(phase: nextStartPhase)
-  }
-
-  /// Syncs current settings into the engine, then skips to the next phase.
-  ///
-  /// The engine mirrors the current running state: running stays running, paused stays
-  /// paused (at the new phase's full duration), and idle queues the next phase.
-  private func skipPhase() {
-    engine.focusDuration = settings.focusDuration
-    engine.shortBreakDuration = settings.shortBreakDuration
-    engine.longBreakDuration = settings.longBreakDuration
-    engine.skip(nextBreak: nextBreakPhase)
-  }
-
-  // MARK: - Helpers
-
-  private var progress: Double {
-    switch engine.state {
-    case .idle:
-      return 1.0
-    case .running(_, _, let duration):
-      guard duration > 0 else { return 1 }
-      return engine.timeRemaining / duration
-    case .paused(let phase, _):
-      let duration: TimeInterval
-      switch phase {
-      case .focus: duration = engine.focusDuration
-      case .shortBreak: duration = engine.shortBreakDuration
-      case .longBreak: duration = engine.longBreakDuration
-      }
-      guard duration > 0 else { return 1 }
-      return engine.timeRemaining / duration
-    }
-  }
-
-  private var formattedTimeRemaining: String {
-    let seconds: Int
-    if case .idle = engine.state {
-      switch nextStartPhase {
-      case .focus: seconds = Int(settings.focusDuration)
-      case .shortBreak: seconds = Int(settings.shortBreakDuration)
-      case .longBreak: seconds = Int(settings.longBreakDuration)
-      }
-    } else {
-      seconds = Int(engine.timeRemaining)
-    }
-    return String(format: "%02d:%02d", seconds / 60, seconds % 60)
-  }
-
-  private var phaseName: String {
-    switch engine.state {
-    case .idle:
-      return nextStartPhase.idleLabel
-    case .running(let phase, _, _), .paused(let phase, _):
-      return phase.displayName
-    }
-  }
 }
 
 #Preview {
-  MenuBarPopoverView(
-    engine: SessionEngine(),
-    settings: AppSettings(),
+  let engine = SessionEngine()
+  let settings = AppSettings()
+  return MenuBarPopoverView(
+    presenter: TimerPresenter(engine: engine, settings: settings),
+    engine: engine,
     statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
-    nav: MainNavigation(settings: AppSettings()),
-    nextStartPhase: .focus,
-    nextBreakPhase: .shortBreak
+    nav: MainNavigation(settings: settings)
   )
 }

--- a/app/Taskmato/Views/Timer/Components/TimerControlsView.swift
+++ b/app/Taskmato/Views/Timer/Components/TimerControlsView.swift
@@ -1,0 +1,54 @@
+//
+//  TimerControlsView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The start/pause · skip · stop control row shared by every timer surface.
+///
+/// All intents route through the injected ``TimerPresenter``; the only surface-specific
+/// input is whether Start is disabled (typically when no task is selected).
+struct TimerControlsView: View {
+
+  /// The presenter supplying timer state and receiving control intents.
+  let presenter: TimerPresenter
+  /// Whether the Start button is disabled — typically when no task is selected.
+  var startDisabled: Bool = false
+  /// Tooltip shown on the Start button while it is disabled.
+  var startDisabledHelp: String = ""
+
+  var body: some View {
+    HStack(spacing: .groupGap) {
+      if presenter.isRunning {
+        ControlButton(
+          label: AppLabels.Timer.pause.title,
+          icon: AppLabels.Timer.pause.systemImage
+        ) { presenter.pause() }
+      } else if presenter.isPaused {
+        ControlButton(
+          label: AppLabels.Timer.resume.title,
+          icon: AppLabels.Timer.resume.systemImage
+        ) { presenter.resume() }
+      } else {
+        ControlButton(
+          label: AppLabels.Timer.start.title,
+          icon: AppLabels.Timer.start.systemImage
+        ) { presenter.start() }
+        .disabled(startDisabled)
+        .help(startDisabled ? startDisabledHelp : "")
+      }
+
+      ControlButton(
+        label: AppLabels.Timer.skip.title,
+        icon: AppLabels.Timer.skip.systemImage
+      ) { presenter.skip() }
+
+      ControlButton(
+        label: AppLabels.Timer.stop.title,
+        icon: AppLabels.Timer.stop.systemImage
+      ) { presenter.stop() }
+      .disabled(!presenter.canStop)
+    }
+  }
+}

--- a/app/Taskmato/Views/Timer/TimerPresenter.swift
+++ b/app/Taskmato/Views/Timer/TimerPresenter.swift
@@ -1,0 +1,140 @@
+//
+//  TimerPresenter.swift
+//  Taskmato
+//
+
+import Foundation
+import Observation
+
+/// The single source of the timer's display values and user intents.
+///
+/// Wraps ``SessionEngine`` and ``AppSettings`` so every timer surface — the menu bar
+/// countdown label, the popover, and the main-window timer — reads one `progress`,
+/// `label`, and `phaseName`, and routes start/pause/resume/stop/skip through one place.
+/// The latest durations are copied into the engine (via
+/// ``SessionEngine/applyDurations(from:)``) on each `start` and `skip`, so a mid-session
+/// duration change takes effect on the next phase.
+@Observable
+@MainActor
+final class TimerPresenter {
+
+  private let engine: SessionEngine
+  private let settings: AppSettings
+
+  /// - Parameters:
+  ///   - engine: The session state machine driving the countdown.
+  ///   - settings: The user-configured phase durations and cadence.
+  init(engine: SessionEngine, settings: AppSettings) {
+    self.engine = engine
+    self.settings = settings
+  }
+
+  // MARK: - Display
+
+  /// Fraction of the current phase remaining, from 1.0 (full) down to 0.0 (elapsed).
+  var progress: Double {
+    switch engine.state {
+    case .idle:
+      return 1.0
+    case .running(_, _, let duration):
+      guard duration > 0 else { return 1 }
+      return engine.timeRemaining / duration
+    case .paused(let phase, _):
+      let duration = engineDuration(for: phase)
+      guard duration > 0 else { return 1 }
+      return engine.timeRemaining / duration
+    }
+  }
+
+  /// The countdown formatted as `"MM:SS"` — the configured next-phase length while idle,
+  /// otherwise the live time remaining.
+  var label: String {
+    let seconds: Int
+    if case .idle = engine.state {
+      seconds = Int(settingsDuration(for: nextStartPhase))
+    } else {
+      seconds = Int(engine.timeRemaining)
+    }
+    return String(format: "%02d:%02d", seconds / 60, seconds % 60)
+  }
+
+  /// The phase name — the idle "ready" label while idle, otherwise the active phase's name.
+  var phaseName: String {
+    switch engine.state {
+    case .idle:
+      return nextStartPhase.idleLabel
+    case .running(let phase, _, _), .paused(let phase, _):
+      return phase.displayName
+    }
+  }
+
+  // MARK: - State
+
+  /// `true` while a phase is actively counting down.
+  var isRunning: Bool { engine.isRunning }
+
+  /// `true` while a phase is paused mid-countdown.
+  var isPaused: Bool {
+    if case .paused = engine.state { return true }
+    return false
+  }
+
+  /// `true` when no session is active.
+  var isIdle: Bool { engine.state == .idle }
+
+  /// `true` when there is a session to stop (running or paused).
+  var canStop: Bool { engine.state != .idle }
+
+  // MARK: - Intents
+
+  /// Syncs the latest durations into the engine, then starts the queued (or focus) phase.
+  func start() {
+    engine.applyDurations(from: settings)
+    engine.start(phase: nextStartPhase)
+  }
+
+  /// Suspends the current phase.
+  func pause() { engine.pause() }
+
+  /// Resumes a paused phase from where it left off.
+  func resume() { engine.resume() }
+
+  /// Stops the session and returns to idle.
+  func stop() { engine.stop() }
+
+  /// Syncs the latest durations into the engine, then skips to the next phase.
+  func skip() {
+    engine.applyDurations(from: settings)
+    engine.skip(nextBreak: nextBreakPhase)
+  }
+
+  // MARK: - Helpers
+
+  /// The phase Start begins from idle: a queued phase, or focus by default.
+  private var nextStartPhase: SessionPhase {
+    engine.queuedPhase ?? .focus
+  }
+
+  /// The break phase that follows the current focus phase on skip.
+  private var nextBreakPhase: SessionPhase {
+    engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+  }
+
+  /// The engine's current duration for `phase` — used to scale paused progress.
+  private func engineDuration(for phase: SessionPhase) -> TimeInterval {
+    switch phase {
+    case .focus: return engine.focusDuration
+    case .shortBreak: return engine.shortBreakDuration
+    case .longBreak: return engine.longBreakDuration
+    }
+  }
+
+  /// The configured duration for `phase` — used for the idle countdown label.
+  private func settingsDuration(for phase: SessionPhase) -> TimeInterval {
+    switch phase {
+    case .focus: return settings.focusDuration
+    case .shortBreak: return settings.shortBreakDuration
+    case .longBreak: return settings.longBreakDuration
+    }
+  }
+}

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -8,31 +8,31 @@ import SwiftUI
 /// The timer tab shown in the main application window.
 struct TimerTabView: View {
 
+  var presenter: TimerPresenter
   var engine: SessionEngine
-  var settings: AppSettings
   var statsViewModel: StatsViewModel
   var selectionStore: TaskSelectionStore
   var registry: TaskRegistry
   var nav: MainNavigation
-  /// The phase to start when the user presses Start from idle.
-  var nextStartPhase: SessionPhase
-  /// The break type to use when skipping from a focus session.
-  var nextBreakPhase: SessionPhase
 
   var body: some View {
     VStack(spacing: 0) {
       Spacer()
 
       CircularTimerView(
-        progress: progress,
-        label: formattedTimeRemaining,
-        phase: phaseName
+        progress: presenter.progress,
+        label: presenter.label,
+        phase: presenter.phaseName
       )
 
-      controls
-        .frame(height: 44)
-        .padding(.top, 20)
-        .padding(.bottom, .screenPadding)
+      TimerControlsView(
+        presenter: presenter,
+        startDisabled: selectionStore.activeTask == nil,
+        startDisabledHelp: AppLabels.Tooltip.selectTaskFirst
+      )
+      .frame(height: 44)
+      .padding(.top, 20)
+      .padding(.bottom, .screenPadding)
 
       Spacer()
 
@@ -69,118 +69,17 @@ struct TimerTabView: View {
       .padding(.vertical, .groupGap)
     }
   }
-
-  // MARK: - Controls
-
-  private var controls: some View {
-    HStack(spacing: .groupGap) {
-      if engine.isRunning {
-        ControlButton(
-          label: AppLabels.Timer.pause.title,
-          icon: AppLabels.Timer.pause.systemImage
-        ) { engine.pause() }
-      } else if case .paused = engine.state {
-        ControlButton(
-          label: AppLabels.Timer.resume.title,
-          icon: AppLabels.Timer.resume.systemImage
-        ) { engine.resume() }
-      } else {
-        ControlButton(
-          label: AppLabels.Timer.start.title,
-          icon: AppLabels.Timer.start.systemImage
-        ) { startSession() }
-        .disabled(selectionStore.activeTask == nil)
-        .help(selectionStore.activeTask == nil ? AppLabels.Tooltip.selectTaskFirst : "")
-      }
-
-      ControlButton(
-        label: AppLabels.Timer.skip.title,
-        icon: AppLabels.Timer.skip.systemImage
-      ) { skipPhase() }
-
-      ControlButton(
-        label: AppLabels.Timer.stop.title,
-        icon: AppLabels.Timer.stop.systemImage
-      ) { engine.stop() }
-      .disabled(engine.state == .idle)
-    }
-  }
-
-  // MARK: - Actions
-
-  /// Syncs current settings into the engine, then starts the appropriate next phase.
-  private func startSession() {
-    engine.focusDuration = settings.focusDuration
-    engine.shortBreakDuration = settings.shortBreakDuration
-    engine.longBreakDuration = settings.longBreakDuration
-    engine.start(phase: nextStartPhase)
-  }
-
-  /// Syncs current settings into the engine, then skips to the next phase.
-  ///
-  /// The engine mirrors the current running state: running stays running, paused stays
-  /// paused (at the new phase's full duration), and idle queues the next phase.
-  private func skipPhase() {
-    engine.focusDuration = settings.focusDuration
-    engine.shortBreakDuration = settings.shortBreakDuration
-    engine.longBreakDuration = settings.longBreakDuration
-    engine.skip(nextBreak: nextBreakPhase)
-  }
-
-  // MARK: - Helpers
-
-  private var progress: Double {
-    switch engine.state {
-    case .idle:
-      return 1.0
-    case .running(_, _, let duration):
-      guard duration > 0 else { return 1 }
-      return engine.timeRemaining / duration
-    case .paused(let phase, _):
-      let duration: TimeInterval
-      switch phase {
-      case .focus: duration = engine.focusDuration
-      case .shortBreak: duration = engine.shortBreakDuration
-      case .longBreak: duration = engine.longBreakDuration
-      }
-      guard duration > 0 else { return 1 }
-      return engine.timeRemaining / duration
-    }
-  }
-
-  private var formattedTimeRemaining: String {
-    let seconds: Int
-    if case .idle = engine.state {
-      switch nextStartPhase {
-      case .focus: seconds = Int(settings.focusDuration)
-      case .shortBreak: seconds = Int(settings.shortBreakDuration)
-      case .longBreak: seconds = Int(settings.longBreakDuration)
-      }
-    } else {
-      seconds = Int(engine.timeRemaining)
-    }
-    return String(format: "%02d:%02d", seconds / 60, seconds % 60)
-  }
-
-  private var phaseName: String {
-    switch engine.state {
-    case .idle:
-      return nextStartPhase.idleLabel
-    case .running(let phase, _, _), .paused(let phase, _):
-      return phase.displayName
-    }
-  }
 }
 
 #Preview {
-  TimerTabView(
-    engine: SessionEngine(),
-    settings: AppSettings(),
+  let engine = SessionEngine()
+  let settings = AppSettings()
+  return TimerTabView(
+    presenter: TimerPresenter(engine: engine, settings: settings),
+    engine: engine,
     statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
     registry: TaskRegistry(),
-    nav: MainNavigation(settings: AppSettings()),
-    nextStartPhase: .focus,
-    nextBreakPhase: .shortBreak
+    nav: MainNavigation(settings: settings)
   )
 }

--- a/app/TaskmatoTests/SessionEngineTests.swift
+++ b/app/TaskmatoTests/SessionEngineTests.swift
@@ -62,6 +62,18 @@ struct SessionEngineTests {
     #expect(engine.state == .idle)
   }
 
+  @Test func applyDurationsCopiesSettingsIntoEngine() {
+    let engine = SessionEngine(focusDuration: 1, shortBreakDuration: 1, longBreakDuration: 1)
+    let settings = AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    settings.focusMinutes = 25
+    settings.shortBreakMinutes = 5
+    settings.longBreakMinutes = 15
+    engine.applyDurations(from: settings)
+    #expect(engine.focusDuration == 25 * 60)
+    #expect(engine.shortBreakDuration == 5 * 60)
+    #expect(engine.longBreakDuration == 15 * 60)
+  }
+
   @Test func skipFocusStartsShortBreak() {
     let engine = SessionEngine()
     engine.start()

--- a/app/TaskmatoTests/TimerPresenterTests.swift
+++ b/app/TaskmatoTests/TimerPresenterTests.swift
@@ -1,0 +1,102 @@
+//
+//  TimerPresenterTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+@MainActor
+struct TimerPresenterTests {
+
+  /// Builds isolated settings with the given phase lengths (in minutes).
+  private func makeSettings(focus: Int = 25, short: Int = 5, long: Int = 15) -> AppSettings {
+    let settings = AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    settings.focusMinutes = focus
+    settings.shortBreakMinutes = short
+    settings.longBreakMinutes = long
+    return settings
+  }
+
+  // MARK: - Display
+
+  @Test func labelWhenIdleShowsConfiguredFocusDuration() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings(focus: 25))
+    #expect(presenter.label == "25:00")
+  }
+
+  @Test func labelWhileActiveReflectsTimeRemaining() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    now = now.addingTimeInterval(20)
+    presenter.pause()
+    #expect(presenter.label == "00:40")
+  }
+
+  @Test func progressIsFullWhenIdle() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    #expect(presenter.progress == 1.0)
+  }
+
+  @Test func progressReflectsElapsedFraction() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    now = now.addingTimeInterval(15)
+    presenter.pause()
+    #expect(presenter.progress == 0.75)
+  }
+
+  @Test func idleReportsReadyLabelAndCannotStop() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    #expect(presenter.isIdle)
+    #expect(!presenter.canStop)
+    #expect(presenter.phaseName == SessionPhase.focus.idleLabel)
+  }
+
+  // MARK: - Intents
+
+  @Test func startFromIdleBeginsFocus() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    presenter.start()
+    #expect(presenter.isRunning)
+    #expect(presenter.phaseName == SessionPhase.focus.displayName)
+  }
+
+  @Test func startAppliesSettingsDurationsToEngine() {
+    let engine = SessionEngine(focusDuration: 99)
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    #expect(engine.focusDuration == 60)
+    #expect(engine.timeRemaining == 60)
+  }
+
+  @Test func skipFromFocusStartsBreak() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    presenter.start()
+    presenter.skip()
+    #expect(presenter.phaseName == SessionPhase.shortBreak.displayName)
+  }
+
+  @Test func pauseThenResumeReturnsToRunning() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    presenter.start()
+    presenter.pause()
+    #expect(presenter.isPaused)
+    presenter.resume()
+    #expect(presenter.isRunning)
+  }
+
+  @Test func stopReturnsToIdle() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    presenter.start()
+    presenter.stop()
+    #expect(presenter.isIdle)
+    #expect(!presenter.canStop)
+  }
+}


### PR DESCRIPTION
## Summary

Introduce `TimerPresenter` as the single source of the timer's display values and user intents, and add `SessionEngine.applyDurations(from:)` as the one place settings durations enter the engine. Every timer surface now consumes one presenter instead of re-deriving display and intent.

## Linked issue

Closes #405

## Motivation

`progress`, `formattedTimeRemaining`, `phaseName`, `startSession`, `skipPhase`, and the controls row were duplicated byte-for-byte between the popover and the timer tab, and `TaskmatoApp.menuBarLabel` reimplemented the label a third time. The same `engine.focusDuration = settings.focusDuration; …` sync appeared in five places, creating an only-half-applied-settings hazard. This is also the hard prerequisite for the window-first shell (design doc 0008 D10), which gives the presenter three consumers.

## Changes

- Add `Views/Timer/TimerPresenter.swift` (`@Observable @MainActor`) exposing `progress`, `label`, `phaseName`, state flags, and `start/pause/resume/stop/skip`; `applyDurations` runs inside `start`/`skip`.
- Add `SessionEngine.applyDurations(from:)` and route the auto-advance sync through it — the sole settings→engine copy site.
- Extract the shared start/pause · skip · stop row into `Views/Timer/Components/TimerControlsView.swift`.
- Refactor `MenuBarPopoverView`, `TimerTabView`, and `MainWindowView` to consume the presenter (wired once in `AppComposition`); `TaskmatoApp` menu bar label reads `presenter.label` and the old helper is removed.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

New `TimerPresenterTests` cover label formatting, progress, idle state, and the start/skip/pause/resume/stop transitions; a new `SessionEngineTests` case covers `applyDurations`. `make lint` (0 violations), `make format-check` (clean), and `make test` (exit 0) all pass.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The issue proposed extracting `Components/{CircularTimerView, ControlButton, SessionStatsView}`; this PR instead consolidates the shared control row into a single `TimerControlsView`, which satisfies the dedup goal with tighter componentization. The `task` label is applied automatically by the branch-prefix labeler.
