### PR TITLE
feat(shell): window-first NavigationSplitView shell (#442)

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -62,7 +62,8 @@ struct AppComposition {
     registry.onProviderStateChanged = { [weak sidebarSelection] in
       sidebarSelection?.validateSelection()
     }
-    let nav = MainNavigation(settings: settings)
+    let nav = MainNavigation(
+      settings: settings, selectionStore: sidebarSelection, statsViewModel: statsViewModel)
     let urlHandler = URLSchemeHandler(
       registry: registry, queryService: queryService, selectionStore: selectionStore,
       engine: engine, settings: settings,

--- a/app/Taskmato/Services/AppSettings.swift
+++ b/app/Taskmato/Services/AppSettings.swift
@@ -95,6 +95,16 @@ final class AppSettings {
     didSet { defaults.set(defaultWritableProviderID, forKey: Keys.defaultWritableProviderID) }
   }
 
+  /// Sidebar section IDs (a provider `id`, or `"stats"`) the user has collapsed.
+  ///
+  /// Empty by default, so every section starts expanded. Enabling or configuring a provider,
+  /// and programmatic list selection, re-expands a section by removing its ID from this set.
+  var collapsedSidebarSections: Set<String> {
+    didSet {
+      defaults.set(Array(collapsedSidebarSections), forKey: Keys.collapsedSidebarSections)
+    }
+  }
+
   /// `focusMinutes` expressed as a `TimeInterval` in seconds.
   var focusDuration: TimeInterval { TimeInterval(focusMinutes * 60) }
 
@@ -131,6 +141,8 @@ final class AppSettings {
     taskSortDirection =
       defaults.string(forKey: Keys.taskSortDirection).flatMap(TaskSortDirection.init) ?? .ascending
     defaultWritableProviderID = defaults.string(forKey: Keys.defaultWritableProviderID)
+    collapsedSidebarSections = Set(
+      defaults.stringArray(forKey: Keys.collapsedSidebarSections) ?? [])
   }
 
   private enum Keys {
@@ -148,6 +160,7 @@ final class AppSettings {
     static let taskSortField = "taskSort.field"
     static let taskSortDirection = "taskSort.direction"
     static let defaultWritableProviderID = "tasks.defaultWritableProviderID"
+    static let collapsedSidebarSections = "sidebar.collapsedSections"
   }
 }
 

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -86,7 +86,8 @@ struct TaskmatoApp: App {
     .defaultSize(width: 480, height: 520)
     .windowResizability(.contentMinSize)
     .commands {
-      TaskmatoCommands(nav: composition.nav, settings: composition.settings)
+      TaskmatoCommands(
+        nav: composition.nav, settings: composition.settings, registry: composition.registry)
     }
 
     Settings {
@@ -106,7 +107,7 @@ struct TaskmatoApp: App {
 /// Menu commands and keyboard shortcuts for the main application window.
 struct TaskmatoCommands: Commands {
 
-  @FocusedValue(\.selectedTab) private var selectedTab
+  @FocusedValue(\.destination) private var destination
   @FocusedValue(\.focusSearch) private var focusSearch
   @FocusedValue(\.addTask) private var addTask
   @FocusedValue(\.toggleCompleted) private var toggleCompleted
@@ -117,47 +118,84 @@ struct TaskmatoCommands: Commands {
   @FocusedValue(\.timerSkip) private var timerSkip
   @FocusedValue(\.timerStop) private var timerStop
 
-  /// The navigation model used to switch tabs from the View menu.
+  /// The navigation model used to switch destinations from the View menu.
   var nav: MainNavigation
   /// App settings used to read and write layout and sort state for View menu checkmarks.
   @Bindable var settings: AppSettings
+  /// The provider registry used to populate the File → Add Provider submenu.
+  var registry: ProviderRegistry
+
+  /// Whether the focused window is showing a task-scope destination (Today or a list).
+  ///
+  /// Read from the focused value so task-scope commands gate on what the window shows,
+  /// which absorbs the #426 pattern where Layout/Sort stayed enabled off the task surface.
+  private var isTaskScope: Bool {
+    if case .today = destination { return true }
+    if case .list = destination { return true }
+    return false
+  }
+
+  /// Whether the current navigation destination is any Stats scope.
+  private var isStatsDestination: Bool {
+    if case .stats = nav.destination { return true }
+    return false
+  }
+
+  /// Registered providers that are not currently enabled.
+  private var disabledProviders: [any TaskProvider] {
+    registry.providers.filter { !registry.isEnabled($0.id) }
+  }
 
   var body: some Commands {
-    // File → New Task (⌘N); disabled when no writable provider is available.
+    // File → New Task (⌘N) and Add Provider ▸.
     CommandGroup(replacing: .newItem) {
       Button(AppLabels.Task.add.title) { addTask?() }
         .keyboardShortcut("n")
         .disabled(addTask == nil)
+
+      // Disabled placeholder when every provider is already enabled — an empty submenu
+      // reads as broken, a greyed item reads as "nothing to add". Enabling here is picked up
+      // by the sidebar, which expands the section, opens configuration, and loads lists.
+      if disabledProviders.isEmpty {
+        Button(AppLabels.Sidebar.addProvider.title) {}
+          .disabled(true)
+      } else {
+        Menu(AppLabels.Sidebar.addProvider.title) {
+          ForEach(disabledProviders, id: \.id) { provider in
+            Button(provider.displayName) { registry.enable(provider) }
+          }
+        }
+      }
     }
-    // Edit → Find… (⌘F); disabled when not on the Tasks tab.
+    // Edit → Find… (⌘F); disabled when not on a task destination (focusSearch is only
+    // published by the task detail surface).
     CommandGroup(after: .textEditing) {
       Divider()
       Button(AppLabels.View.find.title) { focusSearch?() }
         .keyboardShortcut("f")
         .disabled(focusSearch == nil)
     }
-    // View → Suppress the default broken sidebar toggle; our replacement lives at the bottom below.
-    CommandGroup(replacing: .sidebar) {}
-    // View → tab navigation (⌘1/2/3), layout, completed toggle (⌘⇧C), Sort By, then Show/Hide
-    // Sidebar (⌘⌃S) — placed last so it sits directly above the system "Enter Full Screen" item.
+    // View → destination navigation (⌘1/2/3), layout, completed toggle (⌘⇧C), Sort By.
+    // The system Show/Hide Sidebar command (⌃⌘S) is restored automatically now that a
+    // single NavigationSplitView sits at the window root, so no custom toggle is needed.
     CommandGroup(after: .sidebar) {
       Divider()
       Button {
-        nav.showTasks()
+        nav.showTimer()
       } label: {
-        Label(AppLabels.Tab.tasks.title, systemImage: nav.selectedTab == .tasks ? "checkmark" : "")
+        Label(AppLabels.Tab.timer.title, systemImage: nav.destination == .timer ? "checkmark" : "")
       }
       .keyboardShortcut("1")
       Button {
-        nav.showTimer()
+        nav.destination = .today
       } label: {
-        Label(AppLabels.Tab.timer.title, systemImage: nav.selectedTab == .timer ? "checkmark" : "")
+        Label(AppLabels.Tab.today.title, systemImage: nav.destination == .today ? "checkmark" : "")
       }
       .keyboardShortcut("2")
       Button {
         nav.showStats()
       } label: {
-        Label(AppLabels.Tab.stats.title, systemImage: nav.selectedTab == .stats ? "checkmark" : "")
+        Label(AppLabels.Tab.stats.title, systemImage: isStatsDestination ? "checkmark" : "")
       }
       .keyboardShortcut("3")
       Divider()
@@ -168,7 +206,7 @@ struct TaskmatoCommands: Commands {
           .tag(TaskPickerLayout.grid)
       }
       .pickerStyle(.inline)
-      .disabled(selectedTab != .tasks)
+      .disabled(!isTaskScope)
       Divider()
       Button {
         toggleCompleted?()
@@ -210,16 +248,7 @@ struct TaskmatoCommands: Commands {
       } label: {
         Label(AppLabels.View.sort.title, systemImage: AppLabels.View.sort.systemImage)
       }
-      .disabled(selectedTab != .tasks)
-      Divider()
-      let sidebarSpec = nav.sidebarVisible ? AppLabels.View.hideSidebar : AppLabels.View.showSidebar
-      Button {
-        nav.sidebarVisible.toggle()
-      } label: {
-        Label(sidebarSpec.title, systemImage: sidebarSpec.systemImage)
-      }
-      .keyboardShortcut("s", modifiers: [.command, .control])
-      .disabled(selectedTab != .tasks)
+      .disabled(!isTaskScope)
     }
     // Timer menu — Start/Pause/Resume (⌘⏎), Skip Phase (⌘K), Stop (⌘.).
     CommandMenu("Timer") {

--- a/app/Taskmato/Views/App/AppDestination.swift
+++ b/app/Taskmato/Views/App/AppDestination.swift
@@ -1,0 +1,46 @@
+//
+//  AppDestination.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A destination in the window-first shell's universal sidebar.
+///
+/// Models every navigable surface as one value: the pinned Timer and Today rows, a specific
+/// provider list, and a stats scope. Owned by ``MainNavigation``; task-scope destinations
+/// (`.today` / `.list`) are forwarded one-way into the task-scope selection sink so the
+/// task-query layer never learns that Timer or Stats exist (design doc 0008, D4).
+enum AppDestination: Hashable {
+
+  /// The Timer surface — focus/break controls and the active task.
+  case timer
+
+  /// The Today smart view — tasks due on or before the end of today, across all providers.
+  case today
+
+  /// A specific provider list.
+  case list(SelectedList)
+
+  /// The Stats surface scoped to a time window.
+  case stats(StatScope)
+
+  /// The equivalent task-scope selection, or `nil` for non-task destinations (Timer, Stats).
+  var taskSelection: SidebarSelection? {
+    switch self {
+    case .today: return .today
+    case .list(let selectedList): return .list(selectedList)
+    case .timer, .stats: return nil
+    }
+  }
+
+  /// Builds the destination for a task-scope selection, or `nil` when there is no selection.
+  /// - Parameter taskSelection: A sidebar selection to mirror into a destination.
+  init?(taskSelection: SidebarSelection?) {
+    switch taskSelection {
+    case .today: self = .today
+    case .list(let selectedList): self = .list(selectedList)
+    case nil: return nil
+    }
+  }
+}

--- a/app/Taskmato/Views/App/AppFocusedValues.swift
+++ b/app/Taskmato/Views/App/AppFocusedValues.swift
@@ -43,27 +43,27 @@ private struct TimerStopKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
-private struct SelectedTabKey: FocusedValueKey {
-  typealias Value = MainTab
+private struct DestinationKey: FocusedValueKey {
+  typealias Value = AppDestination
 }
 
 // MARK: - FocusedValues extensions
 
 extension FocusedValues {
 
-  /// Moves keyboard focus into the Tasks tab search field. Published by ``TasksTabView``.
+  /// Moves keyboard focus into the Tasks tab search field. Published by ``TaskDetailView``.
   var focusSearch: (() -> Void)? {
     get { self[FocusSearchKey.self] }
     set { self[FocusSearchKey.self] = newValue }
   }
 
-  /// Opens the Add Task sheet. Published by ``TasksTabView`` when a writable provider is active.
+  /// Opens the Add Task sheet. Published by ``TaskDetailView`` when a writable provider is active.
   var addTask: (() -> Void)? {
     get { self[AddTaskKey.self] }
     set { self[AddTaskKey.self] = newValue }
   }
 
-  /// Toggles the completed tasks section. Published by ``TasksTabView`` when a closable provider is enabled.
+  /// Toggles the completed tasks section. Published by ``TaskDetailView`` when a closable provider is enabled.
   var toggleCompleted: (() -> Void)? {
     get { self[ToggleCompletedKey.self] }
     set { self[ToggleCompletedKey.self] = newValue }
@@ -105,9 +105,9 @@ extension FocusedValues {
     set { self[TimerStopKey.self] = newValue }
   }
 
-  /// The currently selected tab in the main window. Published by ``MainWindowView``.
-  var selectedTab: MainTab? {
-    get { self[SelectedTabKey.self] }
-    set { self[SelectedTabKey.self] = newValue }
+  /// The currently selected destination in the main window. Published by ``MainWindowView``.
+  var destination: AppDestination? {
+    get { self[DestinationKey.self] }
+    set { self[DestinationKey.self] = newValue }
   }
 }

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -1,22 +1,23 @@
 //
-//  ProviderSidebarView.swift
+//  AppSidebarView.swift
 //  Taskmato
 //
 
 import SwiftUI
 
-/// Sidebar column for the Tasks tab.
+/// The universal sidebar — the window-first shell's entire navigation.
 ///
-/// Shows each enabled task provider as a collapsible ``Section``. Inside each section,
-/// list rows carry a leading icon and, for writable providers, a star button to promote
-/// the default list. Writable provider sections also expose an inline "New list" row at
-/// the bottom. A context menu on each section header provides configure, rename, and
-/// delete actions. The "Add Provider" menu at the bottom enables any registered but
-/// currently disabled provider.
-struct ProviderSidebarView: View {
+/// A single `List` bound to ``MainNavigation/destination`` holds every destination: the
+/// pinned Timer and Today rows, one collapsible ``Section`` per enabled provider (list rows,
+/// inline rename, star-default, and a "New list" row for writable providers), and a
+/// collapsible Stats section of scope rows. Section expansion is persisted via
+/// ``AppSettings/collapsedSidebarSections``; enabling or configuring a provider re-expands
+/// its section. When no provider is enabled, the provider area is replaced by an add hint.
+struct AppSidebarView: View {
 
+  @Bindable var nav: MainNavigation
   var registry: ProviderRegistry
-  @Bindable var sidebarSelection: SelectionStore
+  var settings: AppSettings
   /// Called after a task is successfully added from the list context-menu "Add Task…" item.
   var onTaskAdded: (() -> Void)?
 
@@ -51,33 +52,36 @@ struct ProviderSidebarView: View {
     registry.providers.filter { !registry.isEnabled($0.id) }
   }
 
+  /// Section id used for the Stats section's persisted expansion state.
+  private static let statsSectionID = "stats"
+
   // MARK: - Body
 
   var body: some View {
-    List(selection: $sidebarSelection.selection) {
+    List(selection: $nav.destination) {
+      Label("Timer", systemImage: "timer")
+        .tag(AppDestination.timer)
       Label("Today", systemImage: "calendar")
-        .tag(SidebarSelection.today)
+        .tag(AppDestination.today)
 
-      ForEach(enabledProviders, id: \.id) { provider in
-        providerSection(provider)
+      if enabledProviders.isEmpty {
+        emptyProvidersHint
+      } else {
+        ForEach(enabledProviders, id: \.id) { provider in
+          providerSection(provider)
+        }
       }
+
+      statsSection
     }
     .listStyle(.sidebar)
-    .contextMenu(forSelectionType: SidebarSelection.self) { selections in
-      listContextMenu(for: selections)
-    }
-    .safeAreaInset(edge: .bottom, spacing: 0) {
-      if !disabledProviders.isEmpty {
-        VStack(spacing: 0) {
-          Divider()
-          addProviderMenu
-            .padding(.horizontal, .groupGap)
-            .padding(.vertical, .contentGap)
-        }
-        .background(.bar)
-      }
+    .contextMenu(forSelectionType: AppDestination.self) { selections in
+      sidebarContextMenu(for: selections)
     }
     .task { await loadAllLists() }
+    .onChange(of: registry.enabledIDs) { old, new in
+      handleNewlyEnabled(new.subtracting(old))
+    }
     .onChange(of: isAddingTask) { _, adding in
       if !adding { onTaskAdded?() }
     }
@@ -104,14 +108,30 @@ struct ProviderSidebarView: View {
     }
   }
 
+  // MARK: - Empty state
+
+  @ViewBuilder
+  private var emptyProvidersHint: some View {
+    VStack(spacing: .contentGap) {
+      Text("No providers enabled")
+        .font(.callout)
+        .foregroundStyle(.secondary)
+      addProviderMenu
+        .fixedSize()
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.vertical, .sectionGap)
+    .listRowSeparator(.hidden)
+  }
+
   // MARK: - Provider section
 
   @ViewBuilder
   private func providerSection(_ provider: any TaskProvider) -> some View {
-    Section {
+    Section(isExpanded: expansionBinding(for: provider.id)) {
       ForEach(lists(for: provider)) { list in
         listRow(list, provider: provider)
-          .tag(SidebarSelection.list(SelectedList(providerID: provider.id, listID: list.id)))
+          .tag(AppDestination.list(SelectedList(providerID: provider.id, listID: list.id)))
       }
       if provider is (any WritableTaskProvider) {
         newListRow(providerID: provider.id)
@@ -143,6 +163,22 @@ struct ProviderSidebarView: View {
           Label("Remove \(provider.displayName)", systemImage: AppLabels.Sidebar.remove.systemImage)
         }
       }
+    }
+  }
+
+  // MARK: - Stats section
+
+  @ViewBuilder
+  private var statsSection: some View {
+    Section(isExpanded: expansionBinding(for: Self.statsSectionID)) {
+      ForEach(StatScope.allCases, id: \.self) { scope in
+        Label(scope.sidebarLabel, systemImage: "chart.bar")
+          .tag(AppDestination.stats(scope))
+      }
+    } header: {
+      Text("Stats")
+        .font(.callout)
+        .padding(.vertical, .stackTight)
     }
   }
 
@@ -179,60 +215,67 @@ struct ProviderSidebarView: View {
 
   /// Builds the contextual menu for a control-clicked sidebar selection.
   ///
-  /// Activated via `contextMenu(forSelectionType:)` on the List, this looks up the
-  /// writable list referenced by the clicked row and renders "Add Task…" plus the standard
-  /// set/rename/delete management actions. Returns no items for `.today` or read-only rows.
+  /// Empty-area clicks (empty `selections`) surface the "Add Provider" menu; a control-click
+  /// on a writable list row surfaces "Add Task…" plus the set/rename/delete actions. Timer,
+  /// Today, Stats, and read-only rows produce no items.
   @ViewBuilder
-  private func listContextMenu(for selections: Set<SidebarSelection>) -> some View {
+  private func sidebarContextMenu(for selections: Set<AppDestination>) -> some View {
     if let resolved = resolveListAction(from: selections) {
-      let list = resolved.list
-      let provider = resolved.provider
-      let writable = resolved.writable
-      let isDefaultList = isDefault(list.id, for: provider)
-
-      Button {
-        addTaskTarget = AddTaskTarget(provider: writable, listID: list.id)
-        isAddingTask = true
-      } label: {
-        Label(AppLabels.Sidebar.addTask.title, systemImage: AppLabels.Sidebar.addTask.systemImage)
-      }
-
-      Divider()
-
-      Button {
-        let id = list.id
-        Task { try? await writable.setDefaultList(id) }
-      } label: {
-        Label(
-          AppLabels.Sidebar.setDefault.title, systemImage: AppLabels.Sidebar.setDefault.systemImage)
-      }
-      .disabled(isDefaultList)
-
-      Button {
-        renamingListID = list.id
-        renameBuffer = list.name
-        renameFocused = list.id
-      } label: {
-        Label(AppLabels.Sidebar.rename.title, systemImage: AppLabels.Sidebar.rename.systemImage)
-      }
-
-      Divider()
-
-      Button(role: .destructive) {
-        Task {
-          try? await writable.deleteList(list.id)
-          await loadLists(for: provider)
-        }
-      } label: {
-        Label(
-          AppLabels.Sidebar.deleteList.title, systemImage: AppLabels.Sidebar.deleteList.systemImage)
-      }
-      .disabled(isDefaultList)
+      listContextMenu(for: resolved)
+    } else if selections.isEmpty {
+      addProviderMenuItems
     }
   }
 
+  @ViewBuilder
+  private func listContextMenu(for resolved: ListAction) -> some View {
+    let list = resolved.list
+    let provider = resolved.provider
+    let writable = resolved.writable
+    let isDefaultList = isDefault(list.id, for: provider)
+
+    Button {
+      addTaskTarget = AddTaskTarget(provider: writable, listID: list.id)
+      isAddingTask = true
+    } label: {
+      Label(AppLabels.Sidebar.addTask.title, systemImage: AppLabels.Sidebar.addTask.systemImage)
+    }
+
+    Divider()
+
+    Button {
+      let id = list.id
+      Task { try? await writable.setDefaultList(id) }
+    } label: {
+      Label(
+        AppLabels.Sidebar.setDefault.title, systemImage: AppLabels.Sidebar.setDefault.systemImage)
+    }
+    .disabled(isDefaultList)
+
+    Button {
+      renamingListID = list.id
+      renameBuffer = list.name
+      renameFocused = list.id
+    } label: {
+      Label(AppLabels.Sidebar.rename.title, systemImage: AppLabels.Sidebar.rename.systemImage)
+    }
+
+    Divider()
+
+    Button(role: .destructive) {
+      Task {
+        try? await writable.deleteList(list.id)
+        await loadLists(for: provider)
+      }
+    } label: {
+      Label(
+        AppLabels.Sidebar.deleteList.title, systemImage: AppLabels.Sidebar.deleteList.systemImage)
+    }
+    .disabled(isDefaultList)
+  }
+
   /// Resolves the row-targeted context-menu action from a selection set, or `nil` for non-writable rows.
-  private func resolveListAction(from selections: Set<SidebarSelection>) -> ListAction? {
+  private func resolveListAction(from selections: Set<AppDestination>) -> ListAction? {
     guard let selection = selections.first,
       case .list(let selectedList) = selection,
       let provider = registry.providers.first(where: { $0.id == selectedList.providerID }),
@@ -296,7 +339,7 @@ struct ProviderSidebarView: View {
           else { return }
           newListName[providerID] = ""
           Task {
-            try? await writable.createList(name: trimmed)
+            _ = try? await writable.createList(name: trimmed)
             await loadLists(for: writable)
           }
         }
@@ -306,26 +349,65 @@ struct ProviderSidebarView: View {
 
   // MARK: - Add Provider menu
 
+  /// Menu items enabling any registered-but-disabled provider. Used by the empty-area
+  /// context menu and the empty-state hint. Post-enable handling (expand, configure, load
+  /// lists) runs in ``handleNewlyEnabled(_:)`` so it is uniform across every entry point,
+  /// including the File → Add Provider command.
+  @ViewBuilder
+  private var addProviderMenuItems: some View {
+    ForEach(disabledProviders, id: \.id) { provider in
+      Button {
+        registry.enable(provider)
+      } label: {
+        Label(provider.displayName, systemImage: provider.icon)
+      }
+    }
+  }
+
   private var addProviderMenu: some View {
     Menu {
-      ForEach(disabledProviders, id: \.id) { provider in
-        Button {
-          registry.enable(provider)
-          if let configurable = provider as? (any ConfigurableTaskProvider) {
-            configuringProvider = configurable
-          }
-          Task { await loadLists(for: provider) }
-        } label: {
-          Label(provider.displayName, systemImage: provider.icon)
-        }
-      }
+      addProviderMenuItems
     } label: {
       Label(
         AppLabels.Sidebar.addProvider.title, systemImage: AppLabels.Sidebar.addProvider.systemImage
       )
-      .frame(maxWidth: .infinity, alignment: .leading)
     }
     .menuStyle(.borderlessButton)
+  }
+
+  /// Reacts to providers becoming enabled from any source: re-expands each section, opens the
+  /// configuration sheet for a configurable provider that is not yet authorized (so lists can
+  /// load), and refreshes its list cache.
+  private func handleNewlyEnabled(_ addedIDs: Set<String>) {
+    guard !addedIDs.isEmpty else { return }
+    let added = registry.providers.filter { addedIDs.contains($0.id) }
+    for provider in added {
+      settings.collapsedSidebarSections.remove(provider.id)
+      if let configurable = provider as? (any ConfigurableTaskProvider), !provider.isAuthorized {
+        configuringProvider = configurable
+      }
+    }
+    Task {
+      for provider in added {
+        await loadLists(for: provider)
+      }
+    }
+  }
+
+  // MARK: - Expansion state
+
+  /// A binding that maps a section's persisted collapsed state to `Section(isExpanded:)`.
+  private func expansionBinding(for id: String) -> Binding<Bool> {
+    Binding(
+      get: { !settings.collapsedSidebarSections.contains(id) },
+      set: { expanded in
+        if expanded {
+          settings.collapsedSidebarSections.remove(id)
+        } else {
+          settings.collapsedSidebarSections.insert(id)
+        }
+      }
+    )
   }
 
   // MARK: - Data helpers
@@ -374,8 +456,13 @@ struct ProviderSidebarView: View {
 
 #Preview {
   let registry = ProviderRegistry()
-  return ProviderSidebarView(
-    registry: registry, sidebarSelection: SelectionStore(registry: registry)
+  let settings = AppSettings()
+  let selectionStore = SelectionStore(registry: registry)
+  return AppSidebarView(
+    nav: MainNavigation(
+      settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+    registry: registry,
+    settings: settings
   )
-  .frame(width: 200, height: 400)
+  .frame(width: 220, height: 500)
 }

--- a/app/Taskmato/Views/App/MainNavigation.swift
+++ b/app/Taskmato/Views/App/MainNavigation.swift
@@ -8,18 +8,28 @@ import Observation
 
 /// Observable navigation model for the main application window.
 ///
-/// `MainNavigation` is the single authority for tab selection and sidebar visibility.
+/// `MainNavigation` is the single authority for the current ``AppDestination`` and sidebar
+/// visibility. It forwards task-scope destinations (`.today` / `.list`) one-way into the
+/// ``SelectionStore`` sink and stats destinations into ``StatsViewModel/scope``, so the
+/// task-query and stats layers never learn about each other's surfaces (design doc 0008, D4).
+///
 /// The SwiftUI `openWindow` environment action is bound onto the model once from the
-/// menu-bar popover's `onAppear` via ``bindOpenMainWindow(_:)``; all subsequent
-/// window-open requests use the stored action instead of flowing through the scene graph.
+/// menu-bar popover's `onAppear` via ``bindOpenMainWindow(_:)``; while the app is still an
+/// accessory (`LSUIElement`), popover-originated navigation opens the window through the
+/// stored action. This plumbing is removed with the lifecycle flip (#444).
 @Observable
 @MainActor
 final class MainNavigation {
 
-  /// The currently selected tab in the main window.
-  var selectedTab: MainTab = .tasks
+  /// The currently selected destination in the main window.
+  ///
+  /// Assignment forwards task scopes into ``SelectionStore`` and stats scopes into
+  /// ``StatsViewModel``; `.timer` forwards nothing.
+  var destination: AppDestination {
+    didSet { forward(destination) }
+  }
 
-  /// Whether the provider/list sidebar column is visible in the Tasks tab.
+  /// Whether the sidebar column is visible in the root split view.
   ///
   /// Reads and writes forward to ``AppSettings/sidebarVisible`` so `UserDefaults`
   /// remains the single source of truth for persistence.
@@ -28,13 +38,34 @@ final class MainNavigation {
     set { settings.sidebarVisible = newValue }
   }
 
-  private let settings: AppSettings
-  private var openMainWindowAction: (() -> Void)?
+  @ObservationIgnored private let settings: AppSettings
+  @ObservationIgnored private let selectionStore: SelectionStore
+  @ObservationIgnored private let statsViewModel: StatsViewModel
+  @ObservationIgnored private var openMainWindowAction: (() -> Void)?
 
-  /// - Parameter settings: The app settings instance that persists `sidebarVisible`.
-  init(settings: AppSettings) {
+  /// - Parameters:
+  ///   - settings: App settings that persist `sidebarVisible`.
+  ///   - selectionStore: The task-scope selection sink that task destinations forward into.
+  ///   - statsViewModel: The stats view model whose scope stats destinations forward into.
+  init(settings: AppSettings, selectionStore: SelectionStore, statsViewModel: StatsViewModel) {
     self.settings = settings
+    self.selectionStore = selectionStore
+    self.statsViewModel = statsViewModel
+    // Restore the last task scope (Today by default); Timer/Stats are not persisted until #445.
+    self.destination = AppDestination(taskSelection: selectionStore.selection) ?? .today
   }
+
+  /// Forwards a destination into the sink that owns its state, for task and stats scopes.
+  private func forward(_ destination: AppDestination) {
+    if let taskSelection = destination.taskSelection {
+      selectionStore.select(taskSelection)
+    }
+    if case .stats(let scope) = destination {
+      statsViewModel.scope = scope
+    }
+  }
+
+  // MARK: - Window binding
 
   /// Stores the `openWindow` environment action so routing methods can open the main window.
   ///
@@ -44,33 +75,33 @@ final class MainNavigation {
     openMainWindowAction = action
   }
 
-  /// Switches to the Timer tab without opening the main window.
-  func showTimer() { selectedTab = .timer }
-
-  /// Switches to the Tasks tab without opening the main window.
-  func showTasks() { selectedTab = .tasks }
-
-  /// Switches to the Stats tab without opening the main window.
-  func showStats() { selectedTab = .stats }
-
-  /// Expands the provider sidebar and switches to the Tasks tab.
-  func browseTasksAndPick() {
-    sidebarVisible = true
-    selectedTab = .tasks
-  }
-
-  /// Opens the main window without changing the selected tab.
+  /// Opens the main window without changing the destination.
   func openMainWindow() { openMainWindowAction?() }
 
-  /// Opens the main window and switches to the Timer tab.
-  func showTimerInMainWindow() {
-    openMainWindowAction?()
-    selectedTab = .timer
+  // MARK: - In-window routing
+
+  /// Switches to the Timer destination.
+  func showTimer() { destination = .timer }
+
+  /// Switches to the last task-scope destination, falling back to Today.
+  func showTasks() {
+    destination = AppDestination(taskSelection: selectionStore.selection) ?? .today
   }
 
-  /// Opens the main window and switches to the Stats tab.
+  /// Switches to the Stats destination at the current scope.
+  func showStats() { destination = .stats(statsViewModel.scope) }
+
+  // MARK: - Window-opening routing (popover / external activation)
+
+  /// Opens the main window and switches to the Timer destination.
+  func showTimerInMainWindow() {
+    openMainWindowAction?()
+    destination = .timer
+  }
+
+  /// Opens the main window and switches to the Stats destination at the current scope.
   func showStatsInMainWindow() {
     openMainWindowAction?()
-    selectedTab = .stats
+    destination = .stats(statsViewModel.scope)
   }
 }

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -5,21 +5,12 @@
 
 import SwiftUI
 
-/// Tab ordering for the main window. Raw values are stable selection tags.
-enum MainTab: Int {
-  /// The Tasks tab — the landing tab; hosts the task browser and provider sidebar.
-  case tasks = 0
-  /// The Timer tab — focus/break controls; the popover handles most timer interaction.
-  case timer = 1
-  /// The Stats tab — Today / 7-day / All-time session summaries.
-  case stats = 2
-}
-
-/// The root view for the main application window, hosting three-tab navigation.
+/// The root view for the main application window.
 ///
-/// Tabs in order: Tasks (landing), Timer, Stats. Settings opens in a separate window
-/// via ⌘, or the app menu. Tab selection and sidebar visibility are owned by the
-/// injected ``MainNavigation`` model.
+/// A single ``NavigationSplitView`` places the universal ``AppSidebarView`` in the sidebar
+/// and the current destination's surface in the detail column. Selection is owned by the
+/// injected ``MainNavigation`` as an ``AppDestination``; the detail switches on it. Settings
+/// open in a separate window via ⌘, or the app menu.
 struct MainWindowView: View {
 
   var presenter: TimerPresenter
@@ -30,51 +21,62 @@ struct MainWindowView: View {
   var registry: ProviderRegistry
   var queryService: TaskQueryService
   var sidebarSelection: SelectionStore
-  @Bindable var nav: MainNavigation
+  var nav: MainNavigation
+
+  /// Bumped when the sidebar adds a task, forwarded into the task detail so it reloads.
+  @State private var taskAddedToken = 0
 
   var body: some View {
-    TabView(selection: $nav.selectedTab) {
-      Tab(
-        AppLabels.Tab.tasks.title, systemImage: AppLabels.Tab.tasks.systemImage,
-        value: MainTab.tasks
-      ) {
-        TasksTabView(
-          selectionStore: selectionStore,
-          registry: registry,
-          queryService: queryService,
-          sidebarSelection: sidebarSelection,
-          nav: nav,
-          settings: settings
-        )
-      }
-
-      Tab(
-        AppLabels.Tab.timer.title, systemImage: AppLabels.Tab.timer.systemImage,
-        value: MainTab.timer
-      ) {
-        TimerTabView(
-          presenter: presenter,
-          engine: engine,
-          statsViewModel: statsViewModel,
-          selectionStore: selectionStore,
-          registry: registry,
-          nav: nav
-        )
-      }
-
-      Tab(
-        AppLabels.Tab.stats.title, systemImage: AppLabels.Tab.stats.systemImage,
-        value: MainTab.stats
-      ) {
-        StatsTabView(statsViewModel: statsViewModel)
-      }
+    NavigationSplitView(
+      columnVisibility: Binding(
+        get: { nav.sidebarVisible ? .all : .detailOnly },
+        set: { nav.sidebarVisible = $0 != .detailOnly }
+      )
+    ) {
+      AppSidebarView(
+        nav: nav,
+        registry: registry,
+        settings: settings,
+        onTaskAdded: { taskAddedToken += 1 }
+      )
+      .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 300)
+    } detail: {
+      detail
     }
     .frame(minWidth: 640, minHeight: 400)
-    .focusedSceneValue(\.selectedTab, nav.selectedTab)
+    .focusedSceneValue(\.destination, nav.destination)
     .focusedSceneValue(\.timerToggle, timerToggleAction)
     .focusedSceneValue(\.timerToggleTitle, timerToggleTitleValue)
     .focusedSceneValue(\.timerSkip, { presenter.skip() })
     .focusedSceneValue(\.timerStop, presenter.canStop ? { presenter.stop() } : nil)
+  }
+
+  /// The detail surface for the current destination.
+  @ViewBuilder
+  private var detail: some View {
+    switch nav.destination {
+    case .timer:
+      TimerTabView(
+        presenter: presenter,
+        engine: engine,
+        statsViewModel: statsViewModel,
+        selectionStore: selectionStore,
+        registry: registry,
+        nav: nav
+      )
+    case .today, .list:
+      TaskDetailView(
+        selectionStore: selectionStore,
+        registry: registry,
+        queryService: queryService,
+        sidebarSelection: sidebarSelection,
+        nav: nav,
+        settings: settings,
+        refreshToken: taskAddedToken
+      )
+    case .stats:
+      StatsTabView(statsViewModel: statsViewModel)
+    }
   }
 
   // MARK: - Timer command helpers
@@ -97,6 +99,7 @@ struct MainWindowView: View {
   let engine = SessionEngine()
   let settings = AppSettings()
   let registry = ProviderRegistry()
+  let selectionStore = SelectionStore(registry: registry)
   return MainWindowView(
     presenter: TimerPresenter(engine: engine, settings: settings),
     engine: engine,
@@ -105,7 +108,8 @@ struct MainWindowView: View {
     selectionStore: TaskSelectionStore(),
     registry: registry,
     queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
-    sidebarSelection: SelectionStore(registry: registry),
-    nav: MainNavigation(settings: settings)
+    sidebarSelection: selectionStore,
+    nav: MainNavigation(
+      settings: settings, selectionStore: selectionStore, statsViewModel: .preview)
   )
 }

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -78,8 +78,8 @@ struct MenuBarPopoverView: View {
       } else {
         Button {
           let popover = NSApp.keyWindow
-          nav.browseTasksAndPick()
           nav.openMainWindow()
+          nav.showTasks()
           DispatchQueue.main.async { popover?.close() }
         } label: {
           Label(AppLabels.View.browseTask.title, systemImage: AppLabels.View.browseTask.systemImage)
@@ -121,12 +121,15 @@ struct MenuBarPopoverView: View {
 #Preview {
   let engine = SessionEngine()
   let settings = AppSettings()
+  let registry = ProviderRegistry()
   return MenuBarPopoverView(
     presenter: TimerPresenter(engine: engine, settings: settings),
     engine: engine,
     statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
-    registry: ProviderRegistry(),
-    nav: MainNavigation(settings: settings)
+    registry: registry,
+    nav: MainNavigation(
+      settings: settings, selectionStore: SelectionStore(registry: registry),
+      statsViewModel: .preview)
   )
 }

--- a/app/Taskmato/Views/Stats/StatTypes.swift
+++ b/app/Taskmato/Views/Stats/StatTypes.swift
@@ -32,6 +32,19 @@ enum StatScope: CaseIterable {
     case .allTime: return "All Time"
     }
   }
+
+  /// Human-readable title shown as a sidebar scope row.
+  ///
+  /// Names the specific period (unlike ``label``, which names the period *kind* for the
+  /// segmented picker), since the sidebar row is the whole selection affordance.
+  var sidebarLabel: String {
+    switch self {
+    case .today: return "Today"
+    case .thisWeek: return "7 Days"
+    case .thisMonth: return "This Month"
+    case .allTime: return "All Time"
+    }
+  }
 }
 
 /// One day's focus contribution from a single provider, used in the stacked bar chart.

--- a/app/Taskmato/Views/Stats/StatsTabView.swift
+++ b/app/Taskmato/Views/Stats/StatsTabView.swift
@@ -7,17 +7,17 @@ import SwiftUI
 
 /// The statistics tab shown in the main application window.
 ///
-/// Shows a scope picker and, for every scope except All Time, period back/forward navigation.
-/// Each scope renders its own visualisation — a task donut (Today), a stacked daily bar chart
-/// with a ranked task list (7 Days / This Month), or a sortable all-time task table. All data
-/// is derived from ``StatsViewModel``.
+/// The scope is chosen from the sidebar's Stats section (which sets ``StatsViewModel/scope``);
+/// for every scope except All Time this view shows period back/forward navigation. Each scope
+/// renders its own visualisation — a task donut (Today), a stacked daily bar chart with a
+/// ranked task list (7 Days / This Month), or a sortable all-time task table. All data is
+/// derived from ``StatsViewModel``.
 struct StatsTabView: View {
 
   @Bindable var statsViewModel: StatsViewModel
 
   var body: some View {
     VStack(spacing: 0) {
-      scopePicker
       navigationRow
       content
     }
@@ -81,20 +81,6 @@ struct StatsTabView: View {
     }
   }
 
-  // MARK: - Scope picker
-
-  private var scopePicker: some View {
-    Picker("Scope", selection: $statsViewModel.scope) {
-      ForEach(StatScope.allCases, id: \.self) { statScope in
-        Text(statScope.label).tag(statScope)
-      }
-    }
-    .pickerStyle(.segmented)
-    .labelsHidden()
-    .padding([.horizontal, .top])
-    .padding(.bottom, .sectionGap)
-  }
-
   // MARK: - Period navigation
 
   /// Always rendered so its height is constant across scopes; the arrows are hidden for All
@@ -127,7 +113,7 @@ struct StatsTabView: View {
     }
     .buttonStyle(.borderless)
     .frame(maxWidth: .infinity)
-    .padding(.horizontal)
+    .padding([.horizontal, .top])
     .padding(.bottom, .contentGap)
   }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
@@ -102,9 +102,10 @@ enum AppLabels {
     static let stop = AppLabel("Stop", systemImage: "stop.fill")
   }
 
-  /// Labels for the three main-window tabs.
+  /// Labels for the primary window destinations.
   enum Tab {
     static let tasks = AppLabel("Tasks", systemImage: "checklist")
+    static let today = AppLabel("Today", systemImage: "calendar")
     static let timer = AppLabel("Timer", systemImage: "timer")
     static let stats = AppLabel("Stats", systemImage: "chart.bar")
   }

--- a/app/Taskmato/Views/Tasks/TaskDetailSortMenu.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailSortMenu.swift
@@ -1,5 +1,5 @@
 //
-//  TasksTabSortMenu.swift
+//  TaskDetailSortMenu.swift
 //  Taskmato
 //
 
@@ -7,7 +7,7 @@ import SwiftUI
 
 // MARK: - Sort menu
 
-extension TasksTabView {
+extension TaskDetailView {
 
   /// Sort menu placed in the toolbar.
   ///

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -1,17 +1,19 @@
 //
-//  TasksTabView.swift
+//  TaskDetailView.swift
 //  Taskmato
 //
 
 import SwiftUI
 
-/// The task picker tab, showing tasks grouped into sections with live search.
+/// The task detail surface for the Today and list destinations of the window-first shell.
 ///
-/// A ``NavigationSplitView`` places the ``ProviderSidebarView`` in the sidebar and the
-/// task list/grid in the detail column. Supports list and grid layouts. When at least one
-/// enabled provider conforms to ``ClosableTaskProvider``, a "Show Completed" toolbar
-/// button becomes available.
-struct TasksTabView: View {
+/// Renders the current task-scope selection (``SelectionStore``) as a grouped list or grid
+/// with live search, an add/show-completed/layout/sort toolbar, and per-task context menus.
+/// It is placed in the root ``NavigationSplitView``'s detail column by ``MainWindowView``; the
+/// universal sidebar and column visibility live in the shell, not here. When at least one
+/// enabled provider conforms to ``ClosableTaskProvider``, a "Show Completed" toolbar button
+/// becomes available.
+struct TaskDetailView: View {
 
   var selectionStore: TaskSelectionStore
   var registry: ProviderRegistry
@@ -19,6 +21,8 @@ struct TasksTabView: View {
   var sidebarSelection: SelectionStore
   var nav: MainNavigation
   @Bindable var settings: AppSettings
+  /// Bumped by the sidebar after adding a task, so the detail reloads the affected list.
+  var refreshToken: Int = 0
 
   @State private var query: String = ""
   @State private var sections: [TaskSection] = []
@@ -74,7 +78,7 @@ struct TasksTabView: View {
   }
 
   var body: some View {
-    splitView
+    trackedDetail
       .sheet(isPresented: $isAddingTask) {
         if let provider = writableProvider {
           AddTaskView(provider: provider, isPresented: $isAddingTask)
@@ -149,12 +153,18 @@ struct TasksTabView: View {
       )
   }
 
-  /// Change-tracking modifiers applied on top of ``navigationView``.
+  /// The detail content plus search and change-tracking modifiers.
   ///
   /// Split from ``body`` to keep each property's modifier chain short enough
   /// for the Swift type-checker.
-  private var splitView: some View {
-    navigationView
+  private var trackedDetail: some View {
+    detailColumn
+      .searchable(text: $query, placement: .toolbar, prompt: "Search tasks")
+      .searchFocused($isSearchFocused)
+      .task(id: query) { await refresh() }
+      .task { await subscribeToProviderUpdates() }
+      .onAppear { Task { await refresh() } }
+      .onChange(of: refreshToken) { _, _ in Task { await refresh() } }
       .onChange(of: isAddingTask) { _, adding in
         if !adding { Task { await refresh() } }
       }
@@ -172,29 +182,6 @@ struct TasksTabView: View {
       .onChange(of: registry.providerAuthorizationStates) { _, _ in
         Task { await refresh() }
       }
-  }
-
-  /// The ``NavigationSplitView`` with search and initial data-loading modifiers.
-  private var navigationView: some View {
-    NavigationSplitView(
-      columnVisibility: Binding(
-        get: { nav.sidebarVisible ? .all : .detailOnly },
-        set: { nav.sidebarVisible = $0 != .detailOnly }
-      )
-    ) {
-      ProviderSidebarView(
-        registry: registry, sidebarSelection: sidebarSelection,
-        onTaskAdded: { Task { await refresh() } }
-      )
-      .navigationSplitViewColumnWidth(min: 160, ideal: 200, max: 280)
-    } detail: {
-      detailColumn
-    }
-    .searchable(text: $query, placement: .toolbar, prompt: "Search tasks")
-    .searchFocused($isSearchFocused)
-    .task(id: query) { await refresh() }
-    .task { await subscribeToProviderUpdates() }
-    .onAppear { Task { await refresh() } }
   }
 
   // MARK: - Detail content
@@ -408,7 +395,7 @@ struct TasksTabView: View {
 
 // MARK: - Data loading
 
-extension TasksTabView {
+extension TaskDetailView {
 
   private func subscribeToProviderUpdates() async {
     await withTaskGroup(of: Void.self) { group in
@@ -537,12 +524,15 @@ extension TasksTabView {
 
 #Preview {
   let registry = ProviderRegistry()
-  return TasksTabView(
+  let settings = AppSettings()
+  let selectionStore = SelectionStore(registry: registry)
+  return TaskDetailView(
     selectionStore: TaskSelectionStore(),
     registry: registry,
     queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
-    sidebarSelection: SelectionStore(registry: registry),
-    nav: MainNavigation(settings: AppSettings()),
-    settings: AppSettings()
+    sidebarSelection: selectionStore,
+    nav: MainNavigation(
+      settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+    settings: settings
   )
 }

--- a/app/Taskmato/Views/Timer/ActiveTaskView.swift
+++ b/app/Taskmato/Views/Timer/ActiveTaskView.swift
@@ -67,8 +67,8 @@ struct ActiveTaskView: View {
       if sessionIsActive {
         Button {
           if engine.isRunning { engine.pause() }
-          nav.browseTasksAndPick()
           nav.openMainWindow()
+          nav.showTasks()
         } label: {
           Image(systemName: "arrow.triangle.swap")
             .font(.caption2)

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -47,7 +47,7 @@ struct TimerTabView: View {
         .padding(.horizontal, .contentGap)
       } else {
         Button {
-          nav.browseTasksAndPick()
+          nav.showTasks()
         } label: {
           Label(AppLabels.View.browseTask.title, systemImage: AppLabels.View.browseTask.systemImage)
             .font(.caption)
@@ -74,12 +74,15 @@ struct TimerTabView: View {
 #Preview {
   let engine = SessionEngine()
   let settings = AppSettings()
+  let registry = ProviderRegistry()
   return TimerTabView(
     presenter: TimerPresenter(engine: engine, settings: settings),
     engine: engine,
     statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
-    registry: ProviderRegistry(),
-    nav: MainNavigation(settings: settings)
+    registry: registry,
+    nav: MainNavigation(
+      settings: settings, selectionStore: SelectionStore(registry: registry),
+      statsViewModel: .preview)
   )
 }

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -129,7 +129,10 @@ struct URLSchemeHandlerTests {
       selectionStore: selectionStore,
       engine: engine,
       settings: settings,
-      nav: MainNavigation(settings: settings)
+      nav: MainNavigation(
+        settings: settings,
+        selectionStore: SelectionStore(registry: registry, defaults: defaults),
+        statsViewModel: .preview)
     )
     return HandlerContext(
       handler: handler,


### PR DESCRIPTION
## Summary

Replaces the three-tab main window (`TabView` / `MainTab`) with a single root
`NavigationSplitView` whose sidebar is the app's entire navigation: pinned **Timer** and
**Today**, collapsible per-provider list sections, and a collapsible **Stats** scope
section. Selection is modeled by a new view-layer `AppDestination` enum owned by
`MainNavigation`, forwarded one-way into the task-scope selection sink — the task-query and
stats layers stay unaware of each other's surfaces. This implements ADR-0007 commitment 2
and design doc 0008 D2/D3/D4/D8, and is **slice 3 of 5** of the 0.9.0 shell rollout. It
ships while still `LSUIElement` (accessory) so the pure-UI change soaks separately from the
lifecycle flip.

## Linked issue

Closes #442

## Approach

Landed as four reviewable commits (one cohesive PR; only the final state builds green):

1. **`AppDestination` + forwarding** — `MainNavigation` owns `destination` (was
   `selectedTab: MainTab`) and forwards `.today` / `.list` into `SelectionStore` and
   `.stats(scope)` into `StatsViewModel` in a `didSet`. Focused value retargeted
   `selectedTab` → `destination`.
2. **Root `NavigationSplitView` + universal sidebar** — new `AppSidebarView` promotes
   `ProviderSidebarView` (pinned Timer/Today, collapsible `Section(isExpanded:)` per
   provider with persisted expansion via `AppSettings.collapsedSidebarSections`, a Stats
   scope section, an empty-provider hint). `TasksTabView` is demoted to a detail-only
   `TaskDetailView`; `MainTab`, the browse-and-pick flow, and `ProviderSidebarView` are
   deleted. Enabling a provider (from any entry point) now expands its section, opens
   configuration when the provider is unauthorized, and loads its lists.
3. **Stats scope rows** — the segmented picker is deleted; sidebar rows set the scope. No
   aggregation change (the view model was already scope-setter agnostic — amends #401).
4. **Commands remap + Add Provider** — ⌘1/⌘2/⌘3 → Timer/Today/Stats; the custom ⌘⌃S toggle
   and `.sidebar` suppression are removed so the system Show/Hide Sidebar command works;
   task-scope commands (Sort, Show Completed, Find) gate on the focused destination. Add
   Provider moves to the File menu, disabled when nothing can be added, and the sidebar's
   empty-area context menu.

Selection persistence is unchanged: `nav.destination` initializes from the existing
`SelectionStore` task-scope persistence.

## Out of scope

- Lifecycle flip / `LSUIElement` removal / `AppDelegate` suppression deletion / Dock-icon &
  window-first launch behavior → **#444**. `bindOpenMainWindow` plumbing stays; the window
  opens from the menu-bar popover, the Window menu, or a `taskmato://` URL, as before.
- Slim menu-bar popover → **#443**.
- Navigation-state persistence clean slate (`destination` key, `sidebarVisible` default
  flip, obsolete-key deletion) → **#445**. Section-expansion persistence lands here with a
  new `sidebar.collapsedSections` key that #445 will reconcile.
- Timer strip + sidebar Timer countdown badge → **#446** (this PR adds a plain Timer row).
- **#426 (Layout/Sort not disabled off the task surface) is not fixed here.** The Sort/Show
  Completed/Find commands do gate on the destination, but `.disabled` does not propagate to
  the inline Layout `Picker`'s rows in a menu; a satisfying fix is left to #426.

## Validation

- [x] Lint passes locally (`make lint` — 0 violations)
- [x] Unit tests pass locally (`make test` — 0 failures)
- [ ] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- **Still an accessory app** — the window doesn't auto-show on launch (that's #444). Open it
  from the menu-bar icon → ↗, the Window menu, or a URL/notification.
- **No new unit tests**: this is a view/navigation restructure with no new testable
  branching (forwarding is a thin `didSet`). The one test change updates
  `URLSchemeHandlerTests`' `MainNavigation` construction for the new initializer. Expansion
  state lives in `AppSettings`; if a dedicated store is preferred later it can carry a test.
- **Section-expansion persistence** is included here per the issue text; the persistence
  clean slate (#445) will finalize the key set.
- Manually verified: builds and launches cleanly; window opens and renders the split view;
  stats period selector spacing restored; Add Provider disables when all providers are
  enabled; enabling Obsidian auto-opens configuration and then shows its lists.
