### PR TITLE
feat(menubar): slim companion popover; move disambiguation to the window

### DIFF
--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -25,12 +25,33 @@ struct TaskmatoApp: App {
     MenuBarExtra {
       MenuBarPopoverView(
         presenter: composition.timerPresenter,
+        statsViewModel: composition.statsViewModel,
+        selectionStore: composition.selectionStore,
+        nav: composition.nav
+      )
+    } label: {
+      HStack(spacing: 4) {
+        Image("MenuIcon")
+        Text(composition.timerPresenter.label)
+      }
+    }
+    .menuBarExtraStyle(.window)
+
+    Window(Bundle.main.appName, id: "main") {
+      MainWindowView(
+        presenter: composition.timerPresenter,
         engine: composition.engine,
+        settings: composition.settings,
         statsViewModel: composition.statsViewModel,
         selectionStore: composition.selectionStore,
         registry: composition.registry,
+        queryService: composition.queryService,
+        sidebarSelection: composition.sidebarSelection,
         nav: composition.nav
       )
+      // Task-disambiguation for `taskmato://` deep links presents on the main window, the
+      // app's primary surface (design doc 0008, D5). `URLSchemeHandler` opens the window
+      // when a match is ambiguous so this dialog has a surface to appear on.
       .confirmationDialog(
         "Multiple tasks match — which one?",
         isPresented: Binding(
@@ -62,26 +83,6 @@ struct TaskmatoApp: App {
           composition.urlHandler.pendingAdHocParams = nil
         }
       }
-    } label: {
-      HStack(spacing: 4) {
-        Image("MenuIcon")
-        Text(composition.timerPresenter.label)
-      }
-    }
-    .menuBarExtraStyle(.window)
-
-    Window(Bundle.main.appName, id: "main") {
-      MainWindowView(
-        presenter: composition.timerPresenter,
-        engine: composition.engine,
-        settings: composition.settings,
-        statsViewModel: composition.statsViewModel,
-        selectionStore: composition.selectionStore,
-        registry: composition.registry,
-        queryService: composition.queryService,
-        sidebarSelection: composition.sidebarSelection,
-        nav: composition.nav
-      )
     }
     .defaultSize(width: 480, height: 520)
     .windowResizability(.contentMinSize)

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -187,6 +187,9 @@ final class URLSchemeHandler {
       } else if matches.count > 1 {
         pendingDisambiguation = matches
         pendingAdHocParams = buildAdHocParams(from: params, title: title)
+        // Open the main window so the relocated disambiguation dialog has a surface to
+        // present on (design doc 0008, D5); the success path opens it via the selection.
+        nav.openMainWindow()
         return nil
       }
       return await makeAdHocTask(from: buildAdHocParams(from: params, title: title))

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -7,36 +7,67 @@
 
 import SwiftUI
 
-/// The compact popover view shown when the user clicks the menu bar item.
+/// The slim companion popover shown when the user clicks the menu bar item.
 ///
-/// Provides quick timer controls and a button to open the main application window.
-/// On first appearance, binds the `openWindow` environment action onto ``MainNavigation``
-/// and reports the menu-bar scene ready to drain any buffered cold-launch URLs.
+/// Glanceable timer state and controls only — countdown, phase, start/pause/skip/stop, a
+/// display-only active-task line, today's session summary, and "Open Taskmato". Task
+/// browsing and swapping live in the main window (design doc 0008, D1). On first
+/// appearance, binds the `openWindow` environment action onto ``MainNavigation`` and
+/// reports the menu-bar scene ready to drain any buffered cold-launch URLs.
 struct MenuBarPopoverView: View {
 
   var presenter: TimerPresenter
-  var engine: SessionEngine
   var statsViewModel: StatsViewModel
   var selectionStore: TaskSelectionStore
-  var registry: ProviderRegistry
   var nav: MainNavigation
 
-  @Environment(\.openSettings) private var openSettings
   @Environment(\.openWindow) private var openWindow
 
   var body: some View {
     VStack(spacing: 0) {
+      TimerReadout(label: presenter.label, phase: presenter.phaseName)
+        .padding(.top, .groupGap)
+
+      TimerControlsView(
+        presenter: presenter,
+        size: .compact,
+        startDisabled: selectionStore.activeTask == nil,
+        startDisabledHelp: AppLabels.Tooltip.selectTaskFirst
+      )
+      .padding(.top, .sectionGap)
+      .padding(.bottom, .groupGap)
+
+      Divider()
+        .padding(.horizontal, .sectionGap)
+
+      if selectionStore.activeTask != nil {
+        PopoverActiveTaskLine(selectionStore: selectionStore)
+          .padding(.horizontal, .sectionGap)
+          .padding(.vertical, .contentGap)
+      } else {
+        Text(AppLabels.Tooltip.selectTaskFirst)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, .sectionGap)
+          .padding(.vertical, .contentGap)
+      }
+
+      Divider()
+        .padding(.horizontal, .sectionGap)
+
       HStack {
         Button {
           let popover = NSApp.keyWindow
-          NSApp.activate(ignoringOtherApps: true)
-          openSettings()
+          nav.showStatsInMainWindow()
           DispatchQueue.main.async { popover?.close() }
         } label: {
-          Image(systemName: "gearshape")
+          Text(summaryText)
+            .font(.statLabel)
             .foregroundStyle(.secondary)
         }
         .buttonStyle(.plain)
+        .help(AppLabels.Tab.stats.title)
 
         Spacer()
 
@@ -45,67 +76,12 @@ struct MenuBarPopoverView: View {
           nav.openMainWindow()
           DispatchQueue.main.async { popover?.close() }
         } label: {
-          Image(systemName: "arrow.up.forward.app")
-            .foregroundStyle(.secondary)
+          Text("Open \(Bundle.main.appName)")
         }
-        .buttonStyle(.plain)
-        .help("Open \(Bundle.main.appName)")
+        .controlSize(.small)
       }
       .padding(.horizontal, .sectionGap)
-      .padding(.top, .groupGap)
-      .padding(.bottom, .contentGap)
-
-      CircularTimerView(
-        progress: presenter.progress,
-        label: presenter.label,
-        phase: presenter.phaseName
-      )
-
-      TimerControlsView(
-        presenter: presenter,
-        startDisabled: selectionStore.activeTask == nil,
-        startDisabledHelp: AppLabels.Tooltip.selectTaskFirst
-      )
-      .frame(height: 44)
-      .padding(.top, .sectionGap)
-      .padding(.bottom, .groupGap)
-
-      Divider()
-        .padding(.horizontal, .sectionGap)
-
-      if selectionStore.activeTask != nil {
-        ActiveTaskView(engine: engine, selectionStore: selectionStore, registry: registry, nav: nav)
-      } else {
-        Button {
-          let popover = NSApp.keyWindow
-          nav.openMainWindow()
-          nav.showTasks()
-          DispatchQueue.main.async { popover?.close() }
-        } label: {
-          Label(AppLabels.View.browseTask.title, systemImage: AppLabels.View.browseTask.systemImage)
-            .font(.caption)
-        }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, .sectionGap)
-        .padding(.vertical, .iconLabel)
-      }
-
-      Divider()
-        .padding(.horizontal, .sectionGap)
-
-      Button {
-        let popover = NSApp.keyWindow
-        nav.showStatsInMainWindow()
-        DispatchQueue.main.async { popover?.close() }
-      } label: {
-        SessionStatsView(
-          count: statsViewModel.todayFocusCount, minutes: statsViewModel.todayFocusMinutes,
-          streak: statsViewModel.currentStreak)
-      }
-      .buttonStyle(.plain)
-      .padding(.horizontal, .sectionGap)
-      .padding(.vertical, .cardPadding)
+      .padding(.vertical, .groupGap)
     }
     .frame(width: 280)
     .onAppear {
@@ -116,6 +92,18 @@ struct MenuBarPopoverView: View {
       (NSApp.delegate as? AppDelegate)?.reportScenesReady()
     }
   }
+
+  /// A compact one-line focus summary for the bottom bar: sessions · minutes · streak.
+  private var summaryText: String {
+    let sessions =
+      statsViewModel.todayFocusCount == 1
+      ? "1 session" : "\(statsViewModel.todayFocusCount) sessions"
+    var text = "\(sessions) · \(statsViewModel.todayFocusMinutes) min"
+    if statsViewModel.currentStreak > 0 {
+      text += " · 🔥\(statsViewModel.currentStreak)"
+    }
+    return text
+  }
 }
 
 #Preview {
@@ -124,10 +112,8 @@ struct MenuBarPopoverView: View {
   let registry = ProviderRegistry()
   return MenuBarPopoverView(
     presenter: TimerPresenter(engine: engine, settings: settings),
-    engine: engine,
     statsViewModel: .preview,
     selectionStore: TaskSelectionStore(),
-    registry: registry,
     nav: MainNavigation(
       settings: settings, selectionStore: SelectionStore(registry: registry),
       statsViewModel: .preview)

--- a/app/Taskmato/Views/MenuBar/PopoverActiveTaskLine.swift
+++ b/app/Taskmato/Views/MenuBar/PopoverActiveTaskLine.swift
@@ -1,0 +1,65 @@
+//
+//  PopoverActiveTaskLine.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A display-only line naming the active task in the slim menu-bar popover.
+///
+/// Shows an accent dot and the task title with its priority mark. Unlike the window's
+/// ``ActiveTaskView`` it carries no complete/clear/swap actions — the popover is a
+/// companion surface, and task mutation happens in the main window. Renders nothing when
+/// no task is active, so the popover can show its own empty-state placeholder instead.
+struct PopoverActiveTaskLine: View {
+
+  var selectionStore: TaskSelectionStore
+
+  var body: some View {
+    if let task = selectionStore.activeTask {
+      HStack(alignment: .firstTextBaseline, spacing: .contentGap) {
+        Image(systemName: "circle.fill")
+          .font(.caption2)
+          .foregroundStyle(Color.accentColor)
+
+        Text(displayTitle(for: task))
+          .font(.taskTitle)
+          .lineLimit(1)
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+    }
+  }
+
+  /// The task title prefixed with its coloured priority mark, when the priority carries one.
+  private func displayTitle(for task: TaskItem) -> AttributedString {
+    let mark = task.priority.mark
+    guard !mark.isEmpty else { return task.markdownTitle }
+    var prefix = AttributedString(mark + " ")
+    prefix.swiftUI.foregroundColor = task.priority.accentColor
+    return prefix + task.markdownTitle
+  }
+}
+
+#Preview {
+  let store = TaskSelectionStore()
+  store.select(
+    TaskItem(
+      id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
+      title: "Write the quarterly report",
+      notes: nil,
+      format: .plainText,
+      priority: .high,
+      dueDate: nil,
+      scheduledDate: nil,
+      startDate: nil,
+      list: nil,
+      section: nil,
+      sourceURL: nil,
+      completedAt: nil,
+      createdAt: Date()
+    )
+  )
+  return PopoverActiveTaskLine(selectionStore: store)
+    .frame(width: 280)
+    .padding()
+}

--- a/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
+++ b/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
@@ -33,14 +33,7 @@ struct CircularTimerView: View {
         .rotationEffect(.degrees(-90))
         .animation(.linear(duration: 1), value: progress)
 
-      VStack(spacing: .rowVertical) {
-        Text(label)
-          .font(.timerCountdown)
-          .foregroundStyle(.primary)
-        Text(phase)
-          .font(.timerPhaseLabel)
-          .foregroundStyle(.secondary)
-      }
+      TimerReadout(label: label, phase: phase)
     }
     .frame(width: ringDiameter, height: ringDiameter)
   }

--- a/app/Taskmato/Views/Timer/Components/ControlButton.swift
+++ b/app/Taskmato/Views/Timer/Components/ControlButton.swift
@@ -5,22 +5,44 @@
 
 import SwiftUI
 
-/// A compact icon-only button used in the timer controls row.
+/// A circular icon-only button used in the timer controls row.
+///
+/// Renders with the system bordered styles clipped to a circle: the prominent (tinted)
+/// variant marks the primary action, the plain bordered variant the secondary ones. The
+/// diameter is supplied by the caller so the same button scales between the compact
+/// popover and the larger window Timer surface.
 struct ControlButton: View {
 
   /// The accessibility label and tooltip for this button.
   let label: String
   /// SF Symbol name for the button icon.
   let icon: String
+  /// Whether to render the tinted (prominent) style used for the primary action.
+  var isProminent: Bool = false
+  /// The icon frame's width and height; the bordered style adds its own padding.
+  var diameter: CGFloat = 44
   let action: () -> Void
 
   var body: some View {
-    Button(action: action) {
-      Label(label, systemImage: icon)
-        .labelStyle(.iconOnly)
-        .frame(width: 32, height: 32)
+    styledButton
+      .clipShape(Circle())
+      .help(label)
+      .accessibilityLabel(label)
+  }
+
+  @ViewBuilder
+  private var styledButton: some View {
+    if isProminent {
+      Button(action: action) { iconImage }
+        .buttonStyle(.borderedProminent)
+    } else {
+      Button(action: action) { iconImage }
+        .buttonStyle(.bordered)
     }
-    .buttonStyle(.bordered)
-    .help(label)
+  }
+
+  private var iconImage: some View {
+    Image(systemName: icon)
+      .frame(width: diameter, height: diameter)
   }
 }

--- a/app/Taskmato/Views/Timer/Components/TimerControlsView.swift
+++ b/app/Taskmato/Views/Timer/Components/TimerControlsView.swift
@@ -5,50 +5,82 @@
 
 import SwiftUI
 
+/// The size preset for ``TimerControlsView``, tuning the circular buttons and spacing.
+enum TimerControlsSize {
+  /// The compact preset used in the slim menu-bar popover.
+  case compact
+  /// The larger preset used on the window's Timer surface.
+  case regular
+
+  /// Diameter of the primary (start/pause/resume) button's icon frame.
+  var primaryDiameter: CGFloat { self == .compact ? 34 : 44 }
+  /// Diameter of the secondary (skip/stop) buttons' icon frames.
+  var secondaryDiameter: CGFloat { self == .compact ? 28 : 36 }
+  /// Horizontal spacing between the buttons.
+  var spacing: CGFloat { self == .compact ? .groupGap : .sectionGap }
+}
+
 /// The start/pause · skip · stop control row shared by every timer surface.
 ///
-/// All intents route through the injected ``TimerPresenter``; the only surface-specific
-/// input is whether Start is disabled (typically when no task is selected).
+/// All intents route through the injected ``TimerPresenter``; callers vary only the
+/// ``TimerControlsSize`` and whether Start is disabled (typically when no task is
+/// selected). The primary action renders tinted; skip and stop render bordered.
 struct TimerControlsView: View {
 
   /// The presenter supplying timer state and receiving control intents.
   let presenter: TimerPresenter
+  /// The button sizing preset for this surface.
+  var size: TimerControlsSize = .regular
   /// Whether the Start button is disabled — typically when no task is selected.
   var startDisabled: Bool = false
   /// Tooltip shown on the Start button while it is disabled.
   var startDisabledHelp: String = ""
 
   var body: some View {
-    HStack(spacing: .groupGap) {
-      if presenter.isRunning {
-        ControlButton(
-          label: AppLabels.Timer.pause.title,
-          icon: AppLabels.Timer.pause.systemImage
-        ) { presenter.pause() }
-      } else if presenter.isPaused {
-        ControlButton(
-          label: AppLabels.Timer.resume.title,
-          icon: AppLabels.Timer.resume.systemImage
-        ) { presenter.resume() }
-      } else {
-        ControlButton(
-          label: AppLabels.Timer.start.title,
-          icon: AppLabels.Timer.start.systemImage
-        ) { presenter.start() }
-        .disabled(startDisabled)
-        .help(startDisabled ? startDisabledHelp : "")
-      }
+    HStack(spacing: size.spacing) {
+      primaryButton
 
       ControlButton(
         label: AppLabels.Timer.skip.title,
-        icon: AppLabels.Timer.skip.systemImage
+        icon: AppLabels.Timer.skip.systemImage,
+        diameter: size.secondaryDiameter
       ) { presenter.skip() }
 
       ControlButton(
         label: AppLabels.Timer.stop.title,
-        icon: AppLabels.Timer.stop.systemImage
+        icon: AppLabels.Timer.stop.systemImage,
+        diameter: size.secondaryDiameter
       ) { presenter.stop() }
       .disabled(!presenter.canStop)
+    }
+  }
+
+  /// Start / Pause / Resume depending on engine state, rendered as the tinted primary.
+  @ViewBuilder
+  private var primaryButton: some View {
+    if presenter.isRunning {
+      ControlButton(
+        label: AppLabels.Timer.pause.title,
+        icon: AppLabels.Timer.pause.systemImage,
+        isProminent: true,
+        diameter: size.primaryDiameter
+      ) { presenter.pause() }
+    } else if presenter.isPaused {
+      ControlButton(
+        label: AppLabels.Timer.resume.title,
+        icon: AppLabels.Timer.resume.systemImage,
+        isProminent: true,
+        diameter: size.primaryDiameter
+      ) { presenter.resume() }
+    } else {
+      ControlButton(
+        label: AppLabels.Timer.start.title,
+        icon: AppLabels.Timer.start.systemImage,
+        isProminent: true,
+        diameter: size.primaryDiameter
+      ) { presenter.start() }
+      .disabled(startDisabled)
+      .help(startDisabled ? startDisabledHelp : "")
     }
   }
 }

--- a/app/Taskmato/Views/Timer/Components/TimerReadout.swift
+++ b/app/Taskmato/Views/Timer/Components/TimerReadout.swift
@@ -1,0 +1,30 @@
+//
+//  TimerReadout.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The countdown and phase name stacked vertically — the shared timer readout.
+///
+/// Used standalone by the slim menu-bar popover and centered inside
+/// ``CircularTimerView`` on the window's Timer surface, so both render one countdown and
+/// phase typography.
+struct TimerReadout: View {
+
+  /// The formatted time string, e.g. `"24:59"`.
+  let label: String
+  /// The phase name shown below the time, e.g. `"Focus"`.
+  let phase: String
+
+  var body: some View {
+    VStack(spacing: .rowVertical) {
+      Text(label)
+        .font(.timerCountdown)
+        .foregroundStyle(.primary)
+      Text(phase)
+        .font(.timerPhaseLabel)
+        .foregroundStyle(.secondary)
+    }
+  }
+}

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -27,10 +27,10 @@ struct TimerTabView: View {
 
       TimerControlsView(
         presenter: presenter,
+        size: .regular,
         startDisabled: selectionStore.activeTask == nil,
         startDisabledHelp: AppLabels.Tooltip.selectTaskFirst
       )
-      .frame(height: 44)
       .padding(.top, 20)
       .padding(.bottom, .screenPadding)
 


### PR DESCRIPTION
## Summary

Reduce the menu bar popover to the glanceable companion of the window-first shell
(design doc 0008 D1, ADR-0007): countdown + phase, circular start/pause/skip/stop, a
display-only active-task line, session summary, and Open Taskmato. Relocate the
`taskmato://` disambiguation dialog from the popover to the main window (D5). The popover
now matches the `PrototypeMenuBarCompanion` mockup.

## Linked issue

Closes #443

## Approach

- Extract the countdown+phase readout out of `CircularTimerView` into a shared
  `TimerReadout`, reused by the ring and the popover — closing the last piece of the
  #405 presenter/view extraction.
- Restyle the shared `ControlButton`/`TimerControlsView` to the prototype's native
  circular controls (`.borderedProminent`/`.bordered` clipped to a circle), parameterized
  by a `TimerControlsSize` preset so the compact popover and the larger window Timer
  surface share one control row.
- Trim `MenuBarPopoverView` to companion content: drop the settings gear, task browsing,
  and the swap flow (the window is one click away). Add a display-only
  `PopoverActiveTaskLine` (priority dot + title).
- Move the disambiguation `confirmationDialog` from the menu bar extra to the `Window`
  scene; `URLSchemeHandler` opens the window when a title match is ambiguous so the dialog
  has a surface to present on. Safe under the current `LSUIElement` because URL handling
  only runs after the popover's `onAppear` binds `openMainWindow`.

## Out of scope

- `LSUIElement` → `.regular` lifecycle flip and `AppDelegate`/`bindOpenMainWindow`
  deletions (#444)
- Persistence clean-slate (#445)
- Timer strip + sidebar badge (#446)

## Validation

- [x] Lint passes locally (SwiftLint 0 violations; swift-format clean)
- [x] Unit tests pass locally (`TaskmatoTests` bundle green)
- [ ] Added or updated tests covering the new behavior — view-layer only; no new tests
- [ ] Manually verified the new behavior — not yet run in a live app build
- [ ] Documentation updated where appropriate

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- The shared control restyle intentionally also changes the window's Timer surface (same
  circular buttons) — slightly beyond the literal "slim popover" wording, by design and
  matching the prototype (`PrototypeDetailViews` uses the same style).
- Full `make test` had one unrelated failure: `TaskmatoUITests/testLaunchPerformance`
  flaked on app termination after 83s (launch UI tests passed; unit bundle green on an
  isolated re-run).
- Prototype mockup (`PrototypeMenuBarCompanion`) to be attached to #443.
