### PR TITLE
feat(timer): persistent timer strip and sidebar countdown

### DIFF
--- a/app/Taskmato/Views/ActiveTaskTitle.swift
+++ b/app/Taskmato/Views/ActiveTaskTitle.swift
@@ -1,0 +1,18 @@
+//
+//  ActiveTaskTitle.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The active task's title prefixed with its coloured priority mark, when the priority carries one.
+///
+/// Shared by every surface that names the active task (the slim popover line and the window's
+/// timer strip) so priority-mark and markdown rendering stay identical across them.
+func activeTaskDisplayTitle(for task: TaskItem) -> AttributedString {
+  let mark = task.priority.mark
+  guard !mark.isEmpty else { return task.markdownTitle }
+  var prefix = AttributedString(mark + " ")
+  prefix.swiftUI.foregroundColor = task.priority.accentColor
+  return prefix + task.markdownTitle
+}

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct AppSidebarView: View {
 
   @Bindable var nav: MainNavigation
+  var presenter: TimerPresenter
   var registry: ProviderRegistry
   var settings: AppSettings
   /// Called after a task is successfully added from the list context-menu "Add Task…" item.
@@ -59,7 +60,7 @@ struct AppSidebarView: View {
 
   var body: some View {
     List(selection: $nav.destination) {
-      Label("Timer", systemImage: "timer")
+      SidebarTimerRow(presenter: presenter)
         .tag(AppDestination.timer)
       Label("Today", systemImage: "calendar")
         .tag(AppDestination.today)
@@ -454,6 +455,30 @@ struct AppSidebarView: View {
   }
 }
 
+/// The pinned Timer sidebar row with its ambient countdown.
+///
+/// Renders the countdown as trailing text rather than a `.badge`, which on a `.sidebar`-style
+/// `List` blocks the row's hit-testing and makes it unselectable. Reads the presenter directly
+/// so the countdown updates live. The countdown shows whenever the session is non-idle — the
+/// ambient half of the ``SessionIndicators`` contract.
+private struct SidebarTimerRow: View {
+
+  /// The presenter supplying the non-idle state and countdown label.
+  let presenter: TimerPresenter
+
+  var body: some View {
+    HStack(spacing: .iconLabel) {
+      Label("Timer", systemImage: "timer")
+      Spacer(minLength: .contentGap)
+      if presenter.canStop {
+        Text(presenter.label)
+          .font(.callout.monospacedDigit())
+          .foregroundStyle(.secondary)
+      }
+    }
+  }
+}
+
 #Preview {
   let registry = ProviderRegistry()
   let settings = AppSettings()
@@ -461,6 +486,7 @@ struct AppSidebarView: View {
   return AppSidebarView(
     nav: MainNavigation(
       settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+    presenter: TimerPresenter(engine: SessionEngine(), settings: settings),
     registry: registry,
     settings: settings
   )

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -26,6 +26,11 @@ struct MainWindowView: View {
   /// Bumped when the sidebar adds a task, forwarded into the task detail so it reloads.
   @State private var taskAddedToken = 0
 
+  /// Which session indicators (strip / sidebar badge) the window shows right now.
+  private var indicators: SessionIndicators {
+    SessionIndicators(isNonIdle: presenter.canStop, onTimer: nav.destination == .timer)
+  }
+
   var body: some View {
     NavigationSplitView(
       columnVisibility: Binding(
@@ -35,13 +40,22 @@ struct MainWindowView: View {
     ) {
       AppSidebarView(
         nav: nav,
+        presenter: presenter,
         registry: registry,
         settings: settings,
         onTaskAdded: { taskAddedToken += 1 }
       )
       .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 300)
     } detail: {
-      detail
+      VStack(spacing: 0) {
+        detail
+        if indicators.showStrip {
+          Divider()
+          TimerStripView(presenter: presenter, selectionStore: selectionStore) {
+            nav.destination = .timer
+          }
+        }
+      }
     }
     .frame(minWidth: 640, minHeight: 400)
     .focusedSceneValue(\.destination, nav.destination)

--- a/app/Taskmato/Views/App/SessionIndicators.swift
+++ b/app/Taskmato/Views/App/SessionIndicators.swift
@@ -1,0 +1,27 @@
+//
+//  SessionIndicators.swift
+//  Taskmato
+//
+
+/// Which session indicators the window shows for a given engine state and destination.
+///
+/// Encodes the ambient-badge / working-strip contract: the sidebar Timer badge is an
+/// always-on ambient countdown whenever the session is non-idle, while the pinned strip is
+/// the working control surface shown only away from the Timer destination. The two are not
+/// mutually exclusive — off the Timer destination both appear together.
+struct SessionIndicators: Equatable {
+
+  /// Whether the pinned timer strip is shown below the detail column.
+  let showStrip: Bool
+  /// Whether the sidebar Timer row shows its countdown badge.
+  let showBadge: Bool
+
+  /// Resolves the indicators from the non-idle predicate and whether Timer is the destination.
+  /// - Parameters:
+  ///   - isNonIdle: Whether a session is running or paused (`false` only when idle).
+  ///   - onTimer: Whether the current destination is the Timer surface.
+  init(isNonIdle: Bool, onTimer: Bool) {
+    showBadge = isNonIdle
+    showStrip = isNonIdle && !onTimer
+  }
+}

--- a/app/Taskmato/Views/MenuBar/PopoverActiveTaskLine.swift
+++ b/app/Taskmato/Views/MenuBar/PopoverActiveTaskLine.swift
@@ -22,21 +22,12 @@ struct PopoverActiveTaskLine: View {
           .font(.caption2)
           .foregroundStyle(Color.accentColor)
 
-        Text(displayTitle(for: task))
+        Text(activeTaskDisplayTitle(for: task))
           .font(.taskTitle)
           .lineLimit(1)
           .frame(maxWidth: .infinity, alignment: .leading)
       }
     }
-  }
-
-  /// The task title prefixed with its coloured priority mark, when the priority carries one.
-  private func displayTitle(for task: TaskItem) -> AttributedString {
-    let mark = task.priority.mark
-    guard !mark.isEmpty else { return task.markdownTitle }
-    var prefix = AttributedString(mark + " ")
-    prefix.swiftUI.foregroundColor = task.priority.accentColor
-    return prefix + task.markdownTitle
   }
 }
 

--- a/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
+++ b/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
@@ -20,21 +20,8 @@ struct CircularTimerView: View {
 
   var body: some View {
     ZStack {
-      Circle()
-        .stroke(Color.timerRingTrack, lineWidth: strokeWidth)
-
-      // Elapsed arc grows clockwise from 12 o'clock as time passes.
-      Circle()
-        .trim(from: 0, to: 1 - progress)
-        .stroke(
-          Color.accentColor,
-          style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
-        )
-        .rotationEffect(.degrees(-90))
-        .animation(.linear(duration: 1), value: progress)
-
+      TimerRing(progress: progress, diameter: ringDiameter, strokeWidth: strokeWidth)
       TimerReadout(label: label, phase: phase)
     }
-    .frame(width: ringDiameter, height: ringDiameter)
   }
 }

--- a/app/Taskmato/Views/Timer/Components/TimerRing.swift
+++ b/app/Taskmato/Views/Timer/Components/TimerRing.swift
@@ -1,0 +1,38 @@
+//
+//  TimerRing.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A circular progress ring: a full track with an elapsed arc growing clockwise from 12 o'clock.
+///
+/// The single source of truth for the timer's ring appearance, sized by its ``diameter`` and
+/// ``strokeWidth`` so both the large window ring and the compact strip glyph share one look.
+struct TimerRing: View {
+
+  /// Fraction of time remaining, from 1.0 (full) down to 0.0 (elapsed).
+  let progress: Double
+  /// Outer diameter of the ring.
+  var diameter: CGFloat = 180
+  /// Width of the track and arc stroke.
+  var strokeWidth: CGFloat = 10
+
+  var body: some View {
+    ZStack {
+      Circle()
+        .stroke(Color.timerRingTrack, lineWidth: strokeWidth)
+
+      // Elapsed arc grows clockwise from 12 o'clock as time passes.
+      Circle()
+        .trim(from: 0, to: 1 - progress)
+        .stroke(
+          Color.accentColor,
+          style: StrokeStyle(lineWidth: strokeWidth, lineCap: .round)
+        )
+        .rotationEffect(.degrees(-90))
+        .animation(.linear(duration: 1), value: progress)
+    }
+    .frame(width: diameter, height: diameter)
+  }
+}

--- a/app/Taskmato/Views/Timer/TimerStripView.swift
+++ b/app/Taskmato/Views/Timer/TimerStripView.swift
@@ -1,0 +1,87 @@
+//
+//  TimerStripView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A compact session bar pinned below the detail column while a session is non-idle.
+///
+/// Keeps the countdown and core controls visible from any non-Timer destination: a mini
+/// progress ring, the phase and countdown, the active task, and the shared pause/resume ·
+/// skip · stop controls. Clicking the readout jumps to the Timer destination. The window
+/// gates visibility via ``SessionIndicators``; this view assumes it is only shown when
+/// non-idle, so its controls never surface Start.
+struct TimerStripView: View {
+
+  /// The presenter supplying timer display values and receiving control intents.
+  let presenter: TimerPresenter
+  /// The store naming the active task shown beneath the countdown.
+  var selectionStore: TaskSelectionStore
+  /// Invoked when the user clicks the readout to jump to the Timer surface.
+  var onSelectTimer: () -> Void
+
+  var body: some View {
+    HStack(spacing: .groupGap) {
+      Button(action: onSelectTimer) {
+        readout
+      }
+      .buttonStyle(.plain)
+
+      Spacer()
+
+      TimerControlsView(presenter: presenter, size: .compact)
+    }
+    .padding(.horizontal, .screenPadding)
+    .padding(.vertical, .contentGap)
+    .background(Color.cardSurface)
+  }
+
+  /// The clickable readout: a mini ring beside the phase/countdown and active task.
+  private var readout: some View {
+    HStack(spacing: .contentGap) {
+      TimerRing(progress: presenter.progress, diameter: 22, strokeWidth: 3)
+
+      VStack(alignment: .leading, spacing: .stackTight) {
+        Text("\(presenter.phaseName) — \(presenter.label)")
+          .font(.timerPhaseLabel.monospacedDigit())
+
+        if let task = selectionStore.activeTask {
+          Text(activeTaskDisplayTitle(for: task))
+            .font(.taskMetadata)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+      }
+    }
+    .contentShape(.rect)
+  }
+}
+
+#Preview {
+  let engine = SessionEngine()
+  let settings = AppSettings()
+  let selectionStore = TaskSelectionStore()
+  selectionStore.select(
+    TaskItem(
+      id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
+      title: "Draft window-first design doc",
+      notes: nil,
+      format: .plainText,
+      priority: .high,
+      dueDate: nil,
+      scheduledDate: nil,
+      startDate: nil,
+      list: nil,
+      section: nil,
+      sourceURL: nil,
+      completedAt: nil,
+      createdAt: Date()
+    )
+  )
+  return TimerStripView(
+    presenter: TimerPresenter(engine: engine, settings: settings),
+    selectionStore: selectionStore
+  ) {}
+  .frame(width: 560)
+}

--- a/app/TaskmatoTests/SessionIndicatorsTests.swift
+++ b/app/TaskmatoTests/SessionIndicatorsTests.swift
@@ -1,0 +1,36 @@
+//
+//  SessionIndicatorsTests.swift
+//  TaskmatoTests
+//
+
+import Testing
+
+@testable import Taskmato
+
+@Suite("SessionIndicators(isNonIdle:onTimer:)")
+struct SessionIndicatorsTests {
+
+  @Test func idleShowsNeither() {
+    let indicators = SessionIndicators(isNonIdle: false, onTimer: false)
+    #expect(indicators.showStrip == false)
+    #expect(indicators.showBadge == false)
+  }
+
+  @Test func idleOnTimerShowsNeither() {
+    let indicators = SessionIndicators(isNonIdle: false, onTimer: true)
+    #expect(indicators.showStrip == false)
+    #expect(indicators.showBadge == false)
+  }
+
+  @Test func nonIdleOnTimerShowsBadgeOnly() {
+    let indicators = SessionIndicators(isNonIdle: true, onTimer: true)
+    #expect(indicators.showStrip == false)
+    #expect(indicators.showBadge == true)
+  }
+
+  @Test func nonIdleOffTimerShowsStripAndBadge() {
+    let indicators = SessionIndicators(isNonIdle: true, onTimer: false)
+    #expect(indicators.showStrip == true)
+    #expect(indicators.showBadge == true)
+  }
+}


### PR DESCRIPTION
## Summary

Keeps the running session visible from any non-Timer destination in the window-first shell. A compact **timer strip** pins below the detail column while a session is non-idle and the destination is not Timer — mini ring, phase + countdown, active task, and pause/resume · skip · stop — and clicking the readout navigates to Timer. The pinned sidebar **Timer row** shows an ambient countdown whenever a session is non-idle. Implements design doc 0008, decision **D7** (the final slice of the window-first shell).

## Linked issue

Closes #446

## Approach

- **Extract `TimerRing`** from `CircularTimerView` so the large window ring and the strip's mini ring share one source of truth; `CircularTimerView` now composes `TimerRing` + `TimerReadout` with unchanged appearance.
- **`TimerStripView`** reuses `TimerControlsView(size: .compact)` for the controls (so paused state gets its resume affordance for free) and a shared `activeTaskDisplayTitle(_:)` helper factored out of `PopoverActiveTaskLine`.
- **`SessionIndicators`** is a small pure resolver for strip/badge visibility, unit-tested across the idle / on-Timer / off-Timer contract. `MainWindowView` gates the strip on `showStrip`.
- **Sidebar countdown** renders as trailing `Text` in an extracted `SidebarTimerRow`, **not** `.badge(...)` — `.badge` on a `.sidebar` `List(selection:)` row blocks the row's hit-testing and makes it unclickable on macOS (⌘1 still worked, mouse did not).
- No `SessionEngine` / state-machine change; visibility derives entirely from the existing `TimerPresenter.canStop` non-idle predicate.

## Out of scope

- Floating always-on-top timer panel (#260, separate issue).
- Any change to the timer state machine or persistence (visibility is derived, no new keys).

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

`make lint` → 0 violations · `make format-check` → clean · build succeeds · `SessionIndicatorsTests` 4/4 pass. Ran the app and drove the strip/badge across destinations, pause, and stop.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- **AC #5 wording:** the issue's "badge and strip never both visible" contradicts the confirmed behavior (ambient badge always-on while non-idle; strip additionally off-Timer, matching the `feature-sidebar-prototype`). The issue AC should be reworded — behavior here is intentional.
- `SessionIndicators.showBadge` is currently exercised only by tests; the sidebar row uses the equivalent `presenter.canStop` directly (the badge doesn't depend on destination). Kept for contract documentation — happy to inline if preferred.
- The pre-existing `TaskmatoUITests.testExample` "Failed to terminate" flake reproduces identically on `main` (window-first lifecycle keeps the app alive after last window closes); unrelated to this PR.
