### PR TITLE
feat(shell): persistence clean slate for navigation state

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -59,11 +59,12 @@ struct AppComposition {
       fallback: localProvider)
     let queryService = TaskQueryService(registry: registry, sorter: TaskSorter())
     let sidebarSelection = SelectionStore(registry: registry)
-    registry.onProviderStateChanged = { [weak sidebarSelection] in
-      sidebarSelection?.validateSelection()
-    }
     let nav = MainNavigation(
       settings: settings, selectionStore: sidebarSelection, statsViewModel: statsViewModel)
+    registry.onProviderStateChanged = { [weak sidebarSelection, weak nav] in
+      sidebarSelection?.validateSelection()
+      nav?.reconcileTaskScope()
+    }
     // A notification tap opens the main window at Timer (design doc 0008, D5).
     notifications.onNotificationTapped = { nav.showTimerInMainWindow() }
     let urlHandler = URLSchemeHandler(

--- a/app/Taskmato/Services/AppSettings.swift
+++ b/app/Taskmato/Services/AppSettings.swift
@@ -57,14 +57,6 @@ final class AppSettings {
     didSet { defaults.set(autoStartNextPhase, forKey: Keys.autoStartNextPhase) }
   }
 
-  /// Whether the app icon appears in the Dock and CMD+Tab switcher.
-  ///
-  /// Defaults to `false` — the app starts as a menu bar–only accessory. The user can
-  /// enable the Dock icon in Settings to make the main window behave like a regular app.
-  var showDockIcon: Bool {
-    didSet { defaults.set(showDockIcon, forKey: Keys.showDockIcon) }
-  }
-
   /// The display mode for the task picker (list rows or card grid).
   ///
   /// Defaults to `.grid`.
@@ -72,9 +64,10 @@ final class AppSettings {
     didSet { defaults.set(taskPickerLayout.rawValue, forKey: Keys.taskPickerLayout) }
   }
 
-  /// Whether the provider/list sidebar column is visible in the Tasks tab.
+  /// Whether the provider/list sidebar column is visible in the window-first shell.
   ///
-  /// Defaults to `false`; pick-flow entries (Browse Tasks…, swap-task) implicitly expand it.
+  /// Defaults to `true` — the sidebar is the app's primary navigation (design doc 0008, D9;
+  /// reverses design doc 0003 decision 4, whose tab-layout rationale no longer applies).
   var sidebarVisible: Bool {
     didSet { defaults.set(sidebarVisible, forKey: Keys.sidebarVisible) }
   }
@@ -132,10 +125,9 @@ final class AppSettings {
     soundName = defaults.string(forKey: Keys.soundName) ?? "Hero"
     notificationsEnabled = defaults.object(forKey: Keys.notificationsEnabled) as? Bool ?? true
     autoStartNextPhase = defaults.object(forKey: Keys.autoStartNextPhase) as? Bool ?? false
-    showDockIcon = defaults.object(forKey: Keys.showDockIcon) as? Bool ?? false
     let rawLayout = defaults.string(forKey: Keys.taskPickerLayout)
     taskPickerLayout = rawLayout.flatMap(TaskPickerLayout.init) ?? .grid
-    sidebarVisible = defaults.object(forKey: Keys.sidebarVisible) as? Bool ?? false
+    sidebarVisible = defaults.object(forKey: Keys.sidebarVisible) as? Bool ?? true
     taskSortField =
       defaults.string(forKey: Keys.taskSortField).flatMap(TaskSortField.init) ?? .dueDate
     taskSortDirection =
@@ -154,7 +146,6 @@ final class AppSettings {
     static let soundName = "soundName"
     static let notificationsEnabled = "notificationsEnabled"
     static let autoStartNextPhase = "autoStartNextPhase"
-    static let showDockIcon = "showDockIcon"
     static let taskPickerLayout = "taskPickerLayout"
     static let sidebarVisible = "taskRegistry.sidebarVisible"
     static let taskSortField = "taskSort.field"

--- a/app/Taskmato/Tasks/Registry/ProviderRegistry.swift
+++ b/app/Taskmato/Tasks/Registry/ProviderRegistry.swift
@@ -13,9 +13,6 @@ import Observation
 /// lives in ``TaskQueryService`` and sidebar selection in ``SelectionStore``; the registry
 /// notifies the latter via ``onProviderStateChanged`` whenever the enabled set or list cache
 /// changes.
-///
-/// **Migration**: on first launch after upgrading from the list-scope model, the initializer
-/// removes the abandoned `"taskRegistry.providerListScopes"` key from `UserDefaults`.
 @Observable
 @MainActor
 final class ProviderRegistry {
@@ -47,10 +44,6 @@ final class ProviderRegistry {
   /// - Parameter defaults: `UserDefaults` store for persistence. Override in tests.
   init(defaults: UserDefaults = .standard) {
     self.defaults = defaults
-
-    // One-shot migration: remove the abandoned list-scope blob from prior versions.
-    defaults.removeObject(forKey: "taskRegistry.providerListScopes")
-
     let stored = defaults.stringArray(forKey: Self.enabledKey) ?? []
     self.enabledIDs = Set(stored)
   }

--- a/app/Taskmato/Tasks/Registry/SelectionStore.swift
+++ b/app/Taskmato/Tasks/Registry/SelectionStore.swift
@@ -17,9 +17,6 @@ import Observation
 /// `.list(SelectedList)` (a specific provider list). The value is stored verbatim and validated
 /// once the registry's `providerLists` cache is populated. `.today` is always immediately valid;
 /// a `.list(...)` selection is treated as "no scope" until the cache confirms the list exists.
-///
-/// **Migration**: on first launch after upgrading from the list-scope model, the initializer
-/// removes the abandoned `"taskRegistry.selectedList"` key from `UserDefaults`.
 @Observable
 @MainActor
 final class SelectionStore {
@@ -46,10 +43,6 @@ final class SelectionStore {
   init(registry: ProviderRegistry, defaults: UserDefaults = .standard) {
     self.registry = registry
     self.defaults = defaults
-
-    // One-shot migration: remove the abandoned selected-list blob from prior versions.
-    defaults.removeObject(forKey: "taskRegistry.selectedList")
-
     self.selection =
       defaults.data(forKey: Self.selectionKey).flatMap {
         try? JSONDecoder().decode(SidebarSelection.self, from: $0)

--- a/app/Taskmato/Views/App/MainNavigation.swift
+++ b/app/Taskmato/Views/App/MainNavigation.swift
@@ -26,7 +26,10 @@ final class MainNavigation {
   /// Assignment forwards task scopes into ``SelectionStore`` and stats scopes into
   /// ``StatsViewModel``; `.timer` forwards nothing.
   var destination: AppDestination {
-    didSet { forward(destination) }
+    didSet {
+      forward(destination)
+      persistDestination()
+    }
   }
 
   /// Whether the sidebar column is visible in the root split view.
@@ -41,18 +44,33 @@ final class MainNavigation {
   @ObservationIgnored private let settings: AppSettings
   @ObservationIgnored private let selectionStore: SelectionStore
   @ObservationIgnored private let statsViewModel: StatsViewModel
+  @ObservationIgnored private let defaults: UserDefaults
   @ObservationIgnored private var openMainWindowAction: (() -> Void)?
 
   /// - Parameters:
   ///   - settings: App settings that persist `sidebarVisible`.
   ///   - selectionStore: The task-scope selection sink that task destinations forward into.
   ///   - statsViewModel: The stats view model whose scope stats destinations forward into.
-  init(settings: AppSettings, selectionStore: SelectionStore, statsViewModel: StatsViewModel) {
+  ///   - defaults: `UserDefaults` store for the persisted destination. Override in tests.
+  init(
+    settings: AppSettings, selectionStore: SelectionStore, statsViewModel: StatsViewModel,
+    defaults: UserDefaults = .standard
+  ) {
     self.settings = settings
     self.selectionStore = selectionStore
     self.statsViewModel = statsViewModel
-    // Restore the last task scope (Today by default); Timer/Stats are not persisted until #445.
-    self.destination = AppDestination(taskSelection: selectionStore.selection) ?? .today
+    self.defaults = defaults
+    // Restore the last surface (design doc 0008, D9). `didSet` does not fire during `init`, so
+    // the Stats scope is forwarded explicitly; the task scope is owned by `SelectionStore`.
+    switch Self.decodePersistedDestination(from: defaults) {
+    case .timer:
+      self.destination = .timer
+    case .stats(let scope):
+      statsViewModel.scope = scope
+      self.destination = .stats(scope)
+    case .tasks, .none:
+      self.destination = AppDestination(taskSelection: selectionStore.selection) ?? .today
+    }
   }
 
   /// Forwards a destination into the sink that owns its state, for task and stats scopes.
@@ -63,6 +81,51 @@ final class MainNavigation {
     if case .stats(let scope) = destination {
       statsViewModel.scope = scope
     }
+  }
+
+  /// Mirrors ``SelectionStore``'s validated selection back into ``destination`` after its
+  /// vanished-list cascade, so a persisted list that no longer exists falls back to Today.
+  ///
+  /// A no-op unless the current destination is a task scope, and idempotent when the two are
+  /// already in sync — safe to call on every `onProviderStateChanged` (design doc 0008, D9).
+  func reconcileTaskScope() {
+    guard destination.taskSelection != nil else { return }
+    let mirrored = AppDestination(taskSelection: selectionStore.selection) ?? .today
+    if mirrored != destination { destination = mirrored }
+  }
+
+  // MARK: - Destination persistence
+
+  /// The last surface, persisted to restore navigation on the next launch. The task scope is
+  /// owned by ``SelectionStore``, so only the surface discriminator is stored here.
+  private enum PersistedDestination: Codable {
+    /// The Timer surface.
+    case timer
+    /// Any task scope; the specific list/Today is restored from ``SelectionStore``.
+    case tasks
+    /// The Stats surface at a specific scope.
+    case stats(StatScope)
+  }
+
+  private static let destinationKey = "shell.destination"
+
+  private static func decodePersistedDestination(
+    from defaults: UserDefaults
+  ) -> PersistedDestination? {
+    defaults.data(forKey: destinationKey).flatMap {
+      try? JSONDecoder().decode(PersistedDestination.self, from: $0)
+    }
+  }
+
+  private func persistDestination() {
+    let persisted: PersistedDestination
+    switch destination {
+    case .timer: persisted = .timer
+    case .today, .list: persisted = .tasks
+    case .stats(let scope): persisted = .stats(scope)
+    }
+    guard let data = try? JSONEncoder().encode(persisted) else { return }
+    defaults.set(data, forKey: Self.destinationKey)
   }
 
   // MARK: - Window binding

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -90,10 +90,6 @@ struct SettingsView: View {
 
       Section("Behavior") {
         Toggle("Auto-start next phase", isOn: $settings.autoStartNextPhase)
-        Toggle("Show Dock icon", isOn: $settings.showDockIcon)
-        Text("Takes effect the next time \(Bundle.main.appName) is launched.")
-          .font(.caption)
-          .foregroundStyle(.secondary)
       }
 
       Section("Tasks") {

--- a/app/Taskmato/Views/Stats/StatTypes.swift
+++ b/app/Taskmato/Views/Stats/StatTypes.swift
@@ -6,7 +6,10 @@
 import Foundation
 
 /// The time window a stats view is scoped to.
-enum StatScope: CaseIterable {
+///
+/// `String`-backed so the persisted shell destination (design doc 0008, D9) has a stable
+/// on-disk representation independent of case ordering.
+enum StatScope: String, CaseIterable, Codable {
 
   /// The current calendar day.
   case today

--- a/app/TaskmatoTests/AppSettingsTests.swift
+++ b/app/TaskmatoTests/AppSettingsTests.swift
@@ -72,6 +72,10 @@ struct AppSettingsTests {
     #expect(makeSettings().autoStartNextPhase == false)
   }
 
+  @Test func defaultSidebarVisibleIsTrue() {
+    #expect(makeSettings().sidebarVisible == true)
+  }
+
   // MARK: - Sort defaults
 
   @Test func defaultTaskSortFieldIsDueDate() {

--- a/app/TaskmatoTests/MainNavigationTests.swift
+++ b/app/TaskmatoTests/MainNavigationTests.swift
@@ -1,0 +1,102 @@
+//
+//  MainNavigationTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+// MARK: - Fakes
+
+private final class NavStubProvider: TaskProvider {
+  let id: String
+  let displayName: String
+  let icon: String = "square"
+  let entitlement: ProviderEntitlement = .free
+
+  init(id: String) {
+    self.id = id
+    self.displayName = id
+  }
+
+  func authorize() async throws {}
+  func lists() async throws -> [TaskList] { [] }
+  func tasks(in _: TaskList?) async throws -> [TaskItem] { [] }
+  func observe() -> AsyncStream<[TaskItem]>? { nil }
+}
+
+// MARK: - Tests
+
+@Suite("MainNavigation")
+@MainActor
+struct MainNavigationTests {
+
+  /// The wired navigation model and its collaborators over one `UserDefaults` suite.
+  private struct NavContext {
+    let registry: ProviderRegistry
+    let store: SelectionStore
+    let statsViewModel: StatsViewModel
+    let nav: MainNavigation
+  }
+
+  /// Builds a navigation model and its selection store over shared `defaults`, wiring
+  /// `onProviderStateChanged` exactly as the composition root does (validate, then reconcile).
+  private func makeNav(defaults: UserDefaults) -> NavContext {
+    let registry = ProviderRegistry(defaults: defaults)
+    let store = SelectionStore(registry: registry, defaults: defaults)
+    let statsViewModel = StatsViewModel.preview
+    let nav = MainNavigation(
+      settings: AppSettings(defaults: defaults), selectionStore: store,
+      statsViewModel: statsViewModel, defaults: defaults)
+    registry.onProviderStateChanged = { [weak store, weak nav] in
+      store?.validateSelection()
+      nav?.reconcileTaskScope()
+    }
+    return NavContext(registry: registry, store: store, statsViewModel: statsViewModel, nav: nav)
+  }
+
+  // MARK: - Defaults
+
+  @Test func destinationDefaultsToTodayOnFirstLaunch() {
+    let context = makeNav(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    #expect(context.nav.destination == .today)
+  }
+
+  // MARK: - Round-trip
+
+  @Test func timerDestinationRoundTripsAcrossInstances() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    makeNav(defaults: defaults).nav.destination = .timer
+    #expect(makeNav(defaults: defaults).nav.destination == .timer)
+  }
+
+  @Test func statsDestinationRoundTripsWithScope() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    makeNav(defaults: defaults).nav.destination = .stats(.thisMonth)
+
+    let restored = makeNav(defaults: defaults)
+    #expect(restored.nav.destination == .stats(.thisMonth))
+    #expect(restored.statsViewModel.scope == .thisMonth)
+  }
+
+  // MARK: - Reconcile
+
+  @Test func vanishedListReconcilesDestinationToToday() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let context = makeNav(defaults: defaults)
+    let registry = context.registry
+    let nav = context.nav
+    let provider = NavStubProvider(id: "alpha")
+    registry.register(provider)
+    registry.enable(provider)
+
+    nav.destination = .list(SelectedList(providerID: "alpha", listID: "old-list"))
+    // The list no longer exists: an empty cache fires the hook, which validates the selection
+    // to Today and reconciles the destination to match.
+    registry.setLists([], forProviderID: "alpha")
+
+    #expect(nav.destination == .today)
+  }
+}

--- a/app/TaskmatoTests/SelectionStoreTests.swift
+++ b/app/TaskmatoTests/SelectionStoreTests.swift
@@ -197,18 +197,4 @@ struct SelectionStoreTests {
     registry.setLists([], forProviderID: "alpha")
     #expect(store.selection == .today)
   }
-
-  // MARK: - Legacy key cleanup
-
-  @Test func legacyScopeKeysAreRemovedOnInit() {
-    let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    // Write dummy blobs for both legacy keys.
-    defaults.set(Data([1, 2, 3]), forKey: "taskRegistry.providerListScopes")
-    defaults.set(Data([4, 5, 6]), forKey: "taskRegistry.selectedList")
-    // The registry clears the list-scope key; the selection store clears the selected-list key.
-    let registry = ProviderRegistry(defaults: defaults)
-    _ = SelectionStore(registry: registry, defaults: defaults)
-    #expect(defaults.data(forKey: "taskRegistry.providerListScopes") == nil)
-    #expect(defaults.data(forKey: "taskRegistry.selectedList") == nil)
-  }
 }

--- a/docs/architecture/design/0008-window-first-shell.md
+++ b/docs/architecture/design/0008-window-first-shell.md
@@ -47,10 +47,15 @@ use one sidebar as the navigation root.
 
 The main window is the primary surface for every user, always. The menu bar extra keeps
 the countdown label and a slim popover: countdown, phase, start/pause/skip/stop, active
-task line, session summary, and "Open Taskmato". A "Hide Dock icon" setting survives but
-changes only the OS representation (`.accessory` policy, no ⌘Tab entry) — never what
-clicking the menu bar does and never what the popover contains. There is no mode enum
-and no primacy dispatch. #293 closes as superseded.
+task line, session summary, and "Open Taskmato". There is no mode enum and no primacy
+dispatch. #293 closes as superseded.
+
+> **Amendment (#445 implementation).** The planned "Hide Dock icon" setting was dropped.
+> The app is always `.regular` (Dock icon always shown). In the window-first shell an
+> `.accessory` app does not reliably present its menu bar, so hiding the Dock icon left no
+> usable way back to the window or Settings; runtime `.regular`⇄`.accessory` switching is
+> also the same class of window-server fragility #293 failed on. The Dock icon is the
+> guaranteed anchor back to the primary surface.
 
 `LSUIElement` is removed from `Info.plist`; the activation policy defaults to
 `.regular`. Deleted outright: `mainWindowWasVisible`, the `orderOut` restoration
@@ -175,16 +180,19 @@ joins the File menu (D2).
 
 ### D9 — Persistence: clean slate
 
-New keys with new defaults; obsolete keys (`showDockIcon`, tab-era state) are deleted
-on first launch of the shell; no value migration (pre-1.0 alpha install base). A
-changelog line covers the behavior flip.
+New keys with new defaults; no value migration (pre-1.0 alpha install base). A changelog
+line covers the behavior flip.
 
 | Key | Default | Note |
 | --- | --- | --- |
-| `hideDockIcon` | `false` | representation only (D1) |
 | `sidebarVisible` | `true` | reverses 0003 decision 4 — its rationale (tab layout shift) no longer exists |
 | `destination` | `today` | last-destination restore; falls back to Today if a persisted list vanished |
 | section expansion | all expanded | one entry per provider id + `stats` |
+
+> **Amendment (#445 implementation).** The `hideDockIcon` key was dropped along with the
+> Hide-Dock-icon setting (see D1). Obsolete keys are left in place rather than deleted on
+> launch: with a single pre-1.0 install, orphaned keys are harmless and the cleanup code is
+> not worth carrying.
 
 ### D10 — Sequencing: 0.9.0, five slices
 


### PR DESCRIPTION
## Summary

Resets shell navigation persistence for the window-first shell and drops the fragile "Hide Dock icon" setting — the last persistence slice of the window-first series. The sidebar is visible by default, the last destination (Timer / task scope / Stats) is restored on launch, and the app is always `.regular`.

## Linked issue

Closes #445

## Approach

- **`sidebarVisible` defaults to `true`** — the sidebar is the app's primary navigation (reverses design doc 0003 decision 4).
- **Destination persistence** — `MainNavigation` persists a surface discriminator `{timer, tasks, stats(scope)}`; the task scope stays owned by `SelectionStore` (no duplicate source of truth). On launch it restores the surface, and a persisted list that has vanished falls back to Today via a new `reconcileTaskScope()` chained after `SelectionStore.validateSelection()` — the sidebar binds `nav.destination` directly, so the fallback has to flow back into it. `StatScope` is now `String`-backed `Codable` for a stable on-disk representation.
- **Dropped "Hide Dock icon"** — the app is always `.regular`. In the window-first shell an `.accessory` app does not reliably present its menu bar, so hiding the dock icon left no usable way back to the window or Settings; runtime `.regular`⇄`.accessory` switching is also the same window-server fragility #293 failed on. The dock icon is the guaranteed anchor back to the primary surface. Design doc 0008 (D1, D9) amended.
- **Dead-code cleanup** (second commit) — removed two stale one-shot `UserDefaults` migrations (`taskRegistry.selectedList`, `taskRegistry.providerListScopes`) now that the sole pre-1.0 install has run past them.

No value migration (pre-1.0 alpha install base).

## Out of scope

- Independent Stats-scope memory — the scope is restored only when Stats was the last surface.
- Any menu-bar-only / dock-hiding capability — removed, not replaced.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [ ] Manually verified the new behavior
- [x] Documentation updated where appropriate

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- `make format-check` / `make lint` clean; full `TaskmatoTests` green, including the new `MainNavigationTests`.
- **Not yet manually verified in a running app** — destination restore across launch and sidebar-visible-on-first-launch are covered by unit tests but worth an eyeball during review.
- Branch prefix `refactor-` makes the labeler apply `task`; the primary change is a `feat`, so re-label to `enhancement` if you prefer.
- Two commits (`feat` + `chore`) collapse on squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
