### PR TITLE
feat(errors): surface provider errors via ErrorPresenter (#410)

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -32,6 +32,7 @@ struct AppComposition {
   let remindersProvider: RemindersProvider
   let urlHandler: URLSchemeHandler
   let nav: MainNavigation
+  let errorPresenter: ErrorPresenter
 
   /// Constructs every service, registers providers, and wires the phase-ended callback.
   init() {
@@ -67,10 +68,11 @@ struct AppComposition {
     }
     // A notification tap opens the main window at Timer (design doc 0008, D5).
     notifications.onNotificationTapped = { nav.showTimerInMainWindow() }
+    let errorPresenter = ErrorPresenter()
     let urlHandler = URLSchemeHandler(
       registry: registry, queryService: queryService, selectionStore: selectionStore,
       engine: engine, settings: settings,
-      nav: nav
+      nav: nav, errorPresenter: errorPresenter
     )
     self.engine = engine
     self.settings = settings
@@ -87,6 +89,7 @@ struct AppComposition {
     self.remindersProvider = remindersProvider
     self.urlHandler = urlHandler
     self.nav = nav
+    self.errorPresenter = errorPresenter
     engine.onPhaseEnded = makePhaseEndedHandler()
   }
 

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -47,7 +47,8 @@ struct TaskmatoApp: App {
         registry: composition.registry,
         queryService: composition.queryService,
         sidebarSelection: composition.sidebarSelection,
-        nav: composition.nav
+        nav: composition.nav,
+        errorPresenter: composition.errorPresenter
       )
       // Task-disambiguation for `taskmato://` deep links presents on the main window, the
       // app's primary surface (design doc 0008, D5). `URLSchemeHandler` opens the window
@@ -71,10 +72,14 @@ struct TaskmatoApp: App {
         if let params = composition.urlHandler.pendingAdHocParams {
           Button("Create new \"\(params.title)\"") {
             Task {
-              let task = await composition.urlHandler.makeAdHocTask(from: params)
-              composition.selectionStore.select(task)
               composition.urlHandler.pendingDisambiguation = nil
-              composition.nav.showTimerInMainWindow()
+              composition.urlHandler.pendingAdHocParams = nil
+              // On failure the handler surfaces the error on the banner and returns nil,
+              // so no session is started on an unsaved task.
+              if let task = await composition.urlHandler.makeAdHocTask(from: params) {
+                composition.selectionStore.select(task)
+                composition.nav.showTimerInMainWindow()
+              }
             }
           }
         }

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -51,6 +51,7 @@ final class URLSchemeHandler {
   private let engine: SessionEngine
   private let settings: AppSettings
   private let nav: MainNavigation
+  private let errorPresenter: ErrorPresenter
 
   init(
     registry: ProviderRegistry,
@@ -58,7 +59,8 @@ final class URLSchemeHandler {
     selectionStore: TaskSelectionStore,
     engine: SessionEngine,
     settings: AppSettings,
-    nav: MainNavigation
+    nav: MainNavigation,
+    errorPresenter: ErrorPresenter
   ) {
     self.registry = registry
     self.queryService = queryService
@@ -66,6 +68,7 @@ final class URLSchemeHandler {
     self.engine = engine
     self.settings = settings
     self.nav = nav
+    self.errorPresenter = errorPresenter
   }
 
   /// Handles the given URL, selecting the resolved task and starting a focus session if
@@ -96,9 +99,9 @@ final class URLSchemeHandler {
   /// 3. ``ProviderRegistry/firstEnabledWritableProvider`` — the first enabled writable provider
   ///    in registration order.
   ///
-  /// Falls back to a transient ``TaskItem`` (providerID `"adhoc"`) when no enabled writable
-  /// provider is available.
-  func makeAdHocTask(from adHocParams: AdHocTaskParams) async -> TaskItem {
+  /// Returns `nil` after surfacing an error on the window-root banner when no enabled writable
+  /// provider is available or the write fails; the caller then starts no session.
+  func makeAdHocTask(from adHocParams: AdHocTaskParams) async -> TaskItem? {
     // Level 1: URL param targets a specific provider (strict — no implicit fallback within level).
     let urlTargeted = adHocParams.providerID.flatMap(registry.enabledWritableProvider(id:))
     // Level 2 & 3: settings default, then first enabled writable provider.
@@ -106,49 +109,35 @@ final class URLSchemeHandler {
       urlTargeted
       ?? registry.resolveDefaultWritableProvider(preferredID: settings.defaultWritableProviderID)
 
-    if let writable {
-      var draft = TaskDraft()
-      draft.title = adHocParams.title
-      draft.priority = adHocParams.priority
-      draft.dueDate = adHocParams.dueDate
-      if let name = adHocParams.listName {
-        let lists: [TaskList]
-        if let cached = registry.providerLists[writable.id] {
-          lists = cached
-        } else {
-          lists = (try? await writable.lists()) ?? []
-        }
-        draft.listID =
-          lists.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }?.id
-          ?? writable.defaultListID
-      }
-      if let item = try? await writable.addTask(draft) {
-        return item
-      }
+    guard let writable else {
+      errorPresenter.present(
+        TransientError(
+          title: AppLabels.Error.adhocCreateFailed,
+          detail: "No writable task list is available."))
+      return nil
     }
 
-    let list = adHocParams.listName.map { name in
-      TaskList(
-        id: name.lowercased().replacingOccurrences(of: " ", with: "-"),
-        providerID: "adhoc",
-        name: name
-      )
+    var draft = TaskDraft()
+    draft.title = adHocParams.title
+    draft.priority = adHocParams.priority
+    draft.dueDate = adHocParams.dueDate
+    if let name = adHocParams.listName {
+      let lists: [TaskList]
+      if let cached = registry.providerLists[writable.id] {
+        lists = cached
+      } else {
+        lists = (try? await writable.lists()) ?? []
+      }
+      draft.listID =
+        lists.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }?.id
+        ?? writable.defaultListID
     }
-    return TaskItem(
-      id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
-      title: adHocParams.title,
-      notes: nil,
-      format: .plainText,
-      priority: adHocParams.priority,
-      dueDate: adHocParams.dueDate,
-      scheduledDate: nil,
-      startDate: nil,
-      list: list,
-      section: nil,
-      sourceURL: nil,
-      completedAt: nil,
-      createdAt: Date()
-    )
+    do {
+      return try await writable.addTask(draft)
+    } catch {
+      errorPresenter.present(title: AppLabels.Error.adhocCreateFailed, error: error)
+      return nil
+    }
   }
 
   // MARK: - Resolution

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -19,6 +19,7 @@ struct AppSidebarView: View {
   var presenter: TimerPresenter
   var registry: ProviderRegistry
   var settings: AppSettings
+  var errorPresenter: ErrorPresenter
   /// Called after a task is successfully added from the list context-menu "Add Task…" item.
   var onTaskAdded: (() -> Void)?
 
@@ -103,6 +104,7 @@ struct AppSidebarView: View {
         AddTaskView(
           provider: target.provider,
           isPresented: $isAddingTask,
+          errorPresenter: errorPresenter,
           initialListID: target.listID
         )
       }
@@ -202,7 +204,11 @@ struct AppSidebarView: View {
       if writable != nil {
         Button {
           let id = list.id
-          Task { try? await writable?.setDefaultList(id) }
+          Task {
+            await errorPresenter.attempt(AppLabels.Error.setDefaultFailed) {
+              try await writable?.setDefaultList(id)
+            }
+          }
         } label: {
           Image(systemName: isDefaultList ? "star.fill" : "star")
             .imageScale(.small)
@@ -246,7 +252,11 @@ struct AppSidebarView: View {
 
     Button {
       let id = list.id
-      Task { try? await writable.setDefaultList(id) }
+      Task {
+        await errorPresenter.attempt(AppLabels.Error.setDefaultFailed) {
+          try await writable.setDefaultList(id)
+        }
+      }
     } label: {
       Label(
         AppLabels.Sidebar.setDefault.title, systemImage: AppLabels.Sidebar.setDefault.systemImage)
@@ -265,7 +275,9 @@ struct AppSidebarView: View {
 
     Button(role: .destructive) {
       Task {
-        try? await writable.deleteList(list.id)
+        await errorPresenter.attempt(AppLabels.Error.listDeleteFailed) {
+          try await writable.deleteList(list.id)
+        }
         await loadLists(for: provider)
       }
     } label: {
@@ -340,7 +352,9 @@ struct AppSidebarView: View {
           else { return }
           newListName[providerID] = ""
           Task {
-            _ = try? await writable.createList(name: trimmed)
+            await errorPresenter.attempt(AppLabels.Error.listCreateFailed) {
+              _ = try await writable.createList(name: trimmed)
+            }
             await loadLists(for: writable)
           }
         }
@@ -431,7 +445,9 @@ struct AppSidebarView: View {
     }
     renamingListID = nil
     Task {
-      try? await writable.renameList(list.id, name: trimmed)
+      await errorPresenter.attempt(AppLabels.Error.listRenameFailed) {
+        try await writable.renameList(list.id, name: trimmed)
+      }
       await loadLists(for: provider)
     }
   }
@@ -440,16 +456,21 @@ struct AppSidebarView: View {
     renamingListID = nil
     renameBuffer = ""
   }
+}
 
-  // MARK: - Async list loading
+// MARK: - Async list loading
 
-  private func loadAllLists() async {
+extension AppSidebarView {
+
+  /// Loads every enabled provider's lists into the registry.
+  fileprivate func loadAllLists() async {
     for provider in enabledProviders {
       await loadLists(for: provider)
     }
   }
 
-  private func loadLists(for provider: any TaskProvider) async {
+  /// Loads and caches a single provider's lists, ignoring read failures.
+  fileprivate func loadLists(for provider: any TaskProvider) async {
     let loaded = (try? await provider.lists()) ?? []
     registry.setLists(loaded, forProviderID: provider.id)
   }
@@ -488,7 +509,8 @@ private struct SidebarTimerRow: View {
       settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
     presenter: TimerPresenter(engine: SessionEngine(), settings: settings),
     registry: registry,
-    settings: settings
+    settings: settings,
+    errorPresenter: ErrorPresenter()
   )
   .frame(width: 220, height: 500)
 }

--- a/app/Taskmato/Views/App/ErrorBannerView.swift
+++ b/app/Taskmato/Views/App/ErrorBannerView.swift
@@ -1,0 +1,79 @@
+//
+//  ErrorBannerView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A top banner that surfaces the ``ErrorPresenter``'s current transient error.
+///
+/// Rendered at the window root above the detail column so failures from any destination —
+/// task, timer, or sidebar — appear in one place. Shows nothing when the queue is empty.
+struct ErrorBannerView: View {
+
+  var presenter: ErrorPresenter
+
+  var body: some View {
+    if let error = presenter.current {
+      HStack(alignment: .top, spacing: .iconLabel) {
+        Image(systemName: error.severity.systemImage)
+          .foregroundStyle(error.severity.tint)
+          .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: .stackTight) {
+          Text(error.title)
+            .font(.callout.weight(.semibold))
+          if let detail = error.detail {
+            Text(detail)
+              .font(.taskMetadata)
+              .foregroundStyle(.secondary)
+          }
+        }
+        Spacer(minLength: .contentGap)
+        Button {
+          presenter.dismiss()
+        } label: {
+          Image(systemName: "xmark")
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Dismiss")
+        .accessibilityLabel("Dismiss")
+      }
+      .padding(.horizontal, .cardPadding)
+      .padding(.vertical, .contentGap)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .background(error.severity.tint.opacity(.subtle))
+      .transition(.move(edge: .top).combined(with: .opacity))
+    }
+  }
+}
+
+extension ErrorSeverity {
+
+  /// The SF Symbol paired with the severity in the banner.
+  fileprivate var systemImage: String {
+    switch self {
+    case .warning: return "exclamationmark.triangle.fill"
+    case .error: return "exclamationmark.octagon.fill"
+    }
+  }
+
+  /// The tint applied to the severity icon and banner background.
+  fileprivate var tint: Color {
+    switch self {
+    case .warning: return .priorityHigh
+    case .error: return .statusError
+    }
+  }
+}
+
+#Preview {
+  let presenter = ErrorPresenter()
+  presenter.present(
+    TransientError(
+      title: "Couldn't complete task",
+      detail: "Reminders access has been revoked in System Settings.",
+      severity: .error))
+  return ErrorBannerView(presenter: presenter)
+    .frame(width: 420)
+}

--- a/app/Taskmato/Views/App/ErrorPresenter.swift
+++ b/app/Taskmato/Views/App/ErrorPresenter.swift
@@ -1,0 +1,111 @@
+//
+//  ErrorPresenter.swift
+//  Taskmato
+//
+
+import Foundation
+import Observation
+
+/// How prominently a transient error is surfaced to the user.
+enum ErrorSeverity {
+  /// A recoverable problem that the user may want to know about but that did not block them.
+  case warning
+  /// An operation the user asked for that failed.
+  case error
+}
+
+/// A short-lived, user-facing error with a title, optional detail, and severity.
+struct TransientError: Identifiable, Equatable {
+  /// Stable identity so the banner can animate between successive errors.
+  let id = UUID()
+  /// Short, human-readable summary of what failed.
+  let title: String
+  /// Optional supporting detail, typically an error's `localizedDescription`.
+  let detail: String?
+  /// How prominently the error is surfaced.
+  let severity: ErrorSeverity
+
+  init(title: String, detail: String? = nil, severity: ErrorSeverity = .error) {
+    self.title = title
+    self.detail = detail
+    self.severity = severity
+  }
+}
+
+/// Holds a queue of transient errors for the window-root banner, surfacing them one at a
+/// time with an auto-dismiss timer and manual dismissal.
+///
+/// Errors are shown head-first: ``present(_:)`` enqueues, ``current`` is what the banner
+/// renders, and each head auto-dismisses after `autoDismiss`. The `sleep` closure is
+/// injectable so tests can drive the timer deterministically.
+@Observable
+@MainActor
+final class ErrorPresenter {
+
+  /// The pending errors, head-first; the banner renders ``current``.
+  private(set) var queue: [TransientError] = []
+
+  /// The error currently shown in the banner, or `nil` when the queue is empty.
+  var current: TransientError? { queue.first }
+
+  @ObservationIgnored private let autoDismiss: Duration
+  @ObservationIgnored private let sleep: @Sendable (Duration) async throws -> Void
+  /// The in-flight auto-dismiss timer for the current head; exposed for deterministic tests.
+  @ObservationIgnored var dismissTask: Task<Void, Never>?
+
+  /// - Parameters:
+  ///   - autoDismiss: How long the current error stays before it auto-dismisses.
+  ///   - sleep: The delay primitive; defaults to `Task.sleep`, overridable in tests.
+  init(
+    autoDismiss: Duration = .seconds(5),
+    sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) }
+  ) {
+    self.autoDismiss = autoDismiss
+    self.sleep = sleep
+  }
+
+  /// Enqueues an error, starting the auto-dismiss timer when it becomes the head.
+  func present(_ error: TransientError) {
+    queue.append(error)
+    if queue.count == 1 { scheduleDismiss() }
+  }
+
+  /// Enqueues a caught error under `title`, using its `localizedDescription` as the detail.
+  func present(title: String, error: Error, severity: ErrorSeverity = .error) {
+    present(TransientError(title: title, detail: error.localizedDescription, severity: severity))
+  }
+
+  /// Runs a throwing operation, surfacing `title` with the error's description on failure.
+  ///
+  /// Keeps user-initiated provider mutations to a single `await` at the call site instead of a
+  /// `do`/`catch`.
+  func attempt(
+    _ title: String, severity: ErrorSeverity = .error, _ operation: () async throws -> Void
+  ) async {
+    do {
+      try await operation()
+    } catch {
+      present(title: title, error: error, severity: severity)
+    }
+  }
+
+  /// Dismisses the current error and surfaces the next queued one, if any.
+  func dismiss() {
+    guard !queue.isEmpty else { return }
+    queue.removeFirst()
+    dismissTask?.cancel()
+    if !queue.isEmpty { scheduleDismiss() }
+  }
+
+  /// Starts (or restarts) the auto-dismiss timer for the current head.
+  private func scheduleDismiss() {
+    dismissTask?.cancel()
+    let autoDismiss = self.autoDismiss
+    let sleep = self.sleep
+    dismissTask = Task { [weak self] in
+      try? await sleep(autoDismiss)
+      guard !Task.isCancelled, let self else { return }
+      self.dismiss()
+    }
+  }
+}

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -23,6 +23,7 @@ struct MainWindowView: View {
   var queryService: TaskQueryService
   var sidebarSelection: SelectionStore
   var nav: MainNavigation
+  var errorPresenter: ErrorPresenter
 
   @Environment(\.openWindow) private var openWindow
 
@@ -46,11 +47,13 @@ struct MainWindowView: View {
         presenter: presenter,
         registry: registry,
         settings: settings,
+        errorPresenter: errorPresenter,
         onTaskAdded: { taskAddedToken += 1 }
       )
       .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 300)
     } detail: {
       VStack(spacing: 0) {
+        ErrorBannerView(presenter: errorPresenter)
         detail
         if indicators.showStrip {
           Divider()
@@ -59,6 +62,7 @@ struct MainWindowView: View {
           }
         }
       }
+      .animation(.default, value: errorPresenter.current)
     }
     .frame(minWidth: 640, minHeight: 400)
     .focusedSceneValue(\.destination, nav.destination)
@@ -90,7 +94,8 @@ struct MainWindowView: View {
         statsViewModel: statsViewModel,
         selectionStore: selectionStore,
         registry: registry,
-        nav: nav
+        nav: nav,
+        errorPresenter: errorPresenter
       )
     case .today, .list:
       TaskDetailView(
@@ -100,6 +105,7 @@ struct MainWindowView: View {
         sidebarSelection: sidebarSelection,
         nav: nav,
         settings: settings,
+        errorPresenter: errorPresenter,
         refreshToken: taskAddedToken
       )
     case .stats:
@@ -138,6 +144,7 @@ struct MainWindowView: View {
     queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
     sidebarSelection: selectionStore,
     nav: MainNavigation(
-      settings: settings, selectionStore: selectionStore, statsViewModel: .preview)
+      settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+    errorPresenter: ErrorPresenter()
   )
 }

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -17,6 +17,7 @@ struct AddTaskView: View {
 
   var provider: any WritableTaskProvider
   @Binding var isPresented: Bool
+  var errorPresenter: ErrorPresenter
   var taskToEdit: TaskItem?
   /// List to pre-select in add mode. Ignored when `taskToEdit` is non-nil.
   var initialListID: String?
@@ -144,9 +145,17 @@ struct AddTaskView: View {
     draft.listID = selectedListID.isEmpty ? nil : selectedListID
     isPresented = false
     if let task = taskToEdit {
-      Task { try? await provider.updateTask(task.id, draft: draft) }
+      Task {
+        await errorPresenter.attempt(AppLabels.Error.updateFailed) {
+          try await provider.updateTask(task.id, draft: draft)
+        }
+      }
     } else {
-      Task { try? await provider.addTask(draft) }
+      Task {
+        await errorPresenter.attempt(AppLabels.Error.addFailed) {
+          try await provider.addTask(draft)
+        }
+      }
     }
   }
 }

--- a/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
@@ -110,6 +110,31 @@ enum AppLabels {
     static let stats = AppLabel("Stats", systemImage: "chart.bar")
   }
 
+  /// Banner titles for failed user-initiated provider operations — sentence-style
+  /// capitalization; the failing error's `localizedDescription` supplies the detail.
+  enum Error {
+    /// A task could not be marked completed.
+    static let completeFailed = "Couldn't complete task"
+    /// A completed task could not be restored.
+    static let restoreFailed = "Couldn't restore task"
+    /// A task could not be deleted.
+    static let deleteFailed = "Couldn't delete task"
+    /// A new task could not be added.
+    static let addFailed = "Couldn't add task"
+    /// An edited task could not be saved.
+    static let updateFailed = "Couldn't save task"
+    /// A new list could not be created.
+    static let listCreateFailed = "Couldn't create list"
+    /// A list could not be renamed.
+    static let listRenameFailed = "Couldn't rename list"
+    /// A list could not be deleted.
+    static let listDeleteFailed = "Couldn't delete list"
+    /// A list could not be set as the provider default.
+    static let setDefaultFailed = "Couldn't set default list"
+    /// An ad-hoc task from a `taskmato://` link could not be created.
+    static let adhocCreateFailed = "Couldn't create task"
+  }
+
   /// Labels for provider sidebar actions.
   enum Sidebar {
     /// Opens the Add Task sheet targeted at a specific list.

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -21,6 +21,7 @@ struct TaskDetailView: View {
   var sidebarSelection: SelectionStore
   var nav: MainNavigation
   @Bindable var settings: AppSettings
+  var errorPresenter: ErrorPresenter
   /// Bumped by the sidebar after adding a task, so the detail reloads the affected list.
   var refreshToken: Int = 0
 
@@ -81,12 +82,15 @@ struct TaskDetailView: View {
     trackedDetail
       .sheet(isPresented: $isAddingTask) {
         if let provider = writableProvider {
-          AddTaskView(provider: provider, isPresented: $isAddingTask)
+          AddTaskView(
+            provider: provider, isPresented: $isAddingTask, errorPresenter: errorPresenter)
         }
       }
       .sheet(isPresented: $isEditingTask) {
         if let task = taskToEdit, let provider = registry.writableProvider(for: task.id) {
-          AddTaskView(provider: provider, isPresented: $isEditingTask, taskToEdit: task)
+          AddTaskView(
+            provider: provider, isPresented: $isEditingTask, errorPresenter: errorPresenter,
+            taskToEdit: task)
         }
       }
       .toolbar {
@@ -496,7 +500,9 @@ extension TaskDetailView {
   private func handleComplete(_ task: TaskItem) {
     Task {
       if let provider = registry.closableProvider(for: task.id) {
-        try? await provider.complete(task.id)
+        await errorPresenter.attempt(AppLabels.Error.completeFailed) {
+          try await provider.complete(task.id)
+        }
       }
       await refresh()
     }
@@ -505,7 +511,9 @@ extension TaskDetailView {
   private func handleRestore(_ task: TaskItem) {
     Task {
       if let provider = registry.closableProvider(for: task.id) {
-        try? await provider.reopen(task.id)
+        await errorPresenter.attempt(AppLabels.Error.restoreFailed) {
+          try await provider.reopen(task.id)
+        }
       }
       await refresh()
     }
@@ -514,7 +522,9 @@ extension TaskDetailView {
   private func handleDelete(_ task: TaskItem) {
     Task {
       if let provider = registry.provider(for: task.id) as? (any WritableTaskProvider) {
-        try? await provider.deleteTask(task.id)
+        await errorPresenter.attempt(AppLabels.Error.deleteFailed) {
+          try await provider.deleteTask(task.id)
+        }
       }
       await loadCompleted()
     }
@@ -533,6 +543,7 @@ extension TaskDetailView {
     sidebarSelection: selectionStore,
     nav: MainNavigation(
       settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
-    settings: settings
+    settings: settings,
+    errorPresenter: ErrorPresenter()
   )
 }

--- a/app/Taskmato/Views/Timer/ActiveTaskView.swift
+++ b/app/Taskmato/Views/Timer/ActiveTaskView.swift
@@ -17,6 +17,7 @@ struct ActiveTaskView: View {
   var selectionStore: TaskSelectionStore
   var registry: ProviderRegistry
   var nav: MainNavigation
+  var errorPresenter: ErrorPresenter
   /// When `true`, renders task notes and source link below the title.
   var showNotes: Bool = false
 
@@ -142,7 +143,9 @@ struct ActiveTaskView: View {
           let ref = task.id
           Task {
             if let provider = registry.closableProvider(for: ref) {
-              try? await provider.complete(ref)
+              await errorPresenter.attempt(AppLabels.Error.completeFailed) {
+                try await provider.complete(ref)
+              }
             }
             selectionStore.clearActiveTask()
           }
@@ -173,7 +176,9 @@ struct ActiveTaskView: View {
       let ref = task.id
       engine.stop()
       Task {
-        try? await provider.complete(ref)
+        await errorPresenter.attempt(AppLabels.Error.completeFailed) {
+          try await provider.complete(ref)
+        }
         selectionStore.clearActiveTask()
         nav.showTasks()
       }

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -14,6 +14,7 @@ struct TimerTabView: View {
   var selectionStore: TaskSelectionStore
   var registry: ProviderRegistry
   var nav: MainNavigation
+  var errorPresenter: ErrorPresenter
 
   var body: some View {
     VStack(spacing: 0) {
@@ -42,6 +43,7 @@ struct TimerTabView: View {
       if selectionStore.activeTask != nil {
         ActiveTaskView(
           engine: engine, selectionStore: selectionStore, registry: registry, nav: nav,
+          errorPresenter: errorPresenter,
           showNotes: true
         )
         .padding(.horizontal, .contentGap)
@@ -83,6 +85,7 @@ struct TimerTabView: View {
     registry: registry,
     nav: MainNavigation(
       settings: settings, selectionStore: SelectionStore(registry: registry),
-      statsViewModel: .preview)
+      statsViewModel: .preview),
+    errorPresenter: ErrorPresenter()
   )
 }

--- a/app/TaskmatoTests/ErrorPresenterTests.swift
+++ b/app/TaskmatoTests/ErrorPresenterTests.swift
@@ -1,0 +1,118 @@
+//
+//  ErrorPresenterTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+@MainActor
+struct ErrorPresenterTests {
+
+  /// Builds a presenter whose auto-dismiss sleep returns instantly, so timing is driven by
+  /// awaiting ``ErrorPresenter/dismissTask`` rather than the wall clock. Because the type is
+  /// `@MainActor`, a scheduled dismiss cannot preempt a test until it awaits.
+  private func makePresenter() -> ErrorPresenter {
+    ErrorPresenter(autoDismiss: .zero, sleep: { _ in })
+  }
+
+  private func error(_ title: String) -> TransientError {
+    TransientError(title: title)
+  }
+
+  /// A `LocalizedError` with a fixed description for the mapping test.
+  private struct SampleError: LocalizedError {
+    let errorDescription: String? = "The store is unavailable."
+  }
+
+  /// A sleep primitive that returns instantly for its first `immediate` calls, then suspends
+  /// indefinitely — so a chained auto-dismiss can be observed before the next one fires.
+  ///
+  /// The presenter invokes this from its `@MainActor` dismiss task, so the counter is only ever
+  /// touched on the main actor and needs no additional synchronization.
+  @MainActor
+  private final class SleepController {
+    private var count = 0
+    let immediate: Int
+
+    init(immediate: Int) { self.immediate = immediate }
+
+    func sleep() async {
+      count += 1
+      if count > immediate { try? await Task.sleep(for: .seconds(3600)) }
+    }
+  }
+
+  // MARK: - Queueing
+
+  @Test func presentSurfacesTheError() {
+    let presenter = makePresenter()
+    let err = error("First")
+    presenter.present(err)
+    #expect(presenter.current == err)
+    #expect(presenter.queue.count == 1)
+  }
+
+  @Test func secondPresentKeepsTheFirstAsCurrent() {
+    let presenter = makePresenter()
+    let first = error("First")
+    let second = error("Second")
+    presenter.present(first)
+    presenter.present(second)
+    #expect(presenter.current == first)
+    #expect(presenter.queue.count == 2)
+  }
+
+  @Test func presentMapsCaughtErrorIntoDetail() {
+    let presenter = makePresenter()
+    presenter.present(title: "Couldn't save", error: SampleError())
+    #expect(presenter.current?.title == "Couldn't save")
+    #expect(presenter.current?.detail == "The store is unavailable.")
+    #expect(presenter.current?.severity == .error)
+  }
+
+  // MARK: - Manual dismissal
+
+  @Test func dismissAdvancesToTheNextError() {
+    let presenter = makePresenter()
+    let first = error("First")
+    let second = error("Second")
+    presenter.present(first)
+    presenter.present(second)
+    presenter.dismiss()
+    #expect(presenter.current == second)
+    #expect(presenter.queue.count == 1)
+  }
+
+  @Test func dismissOnEmptyQueueIsANoop() {
+    let presenter = makePresenter()
+    presenter.dismiss()
+    #expect(presenter.current == nil)
+    #expect(presenter.queue.isEmpty)
+  }
+
+  // MARK: - Auto-dismiss
+
+  @Test func autoDismissClearsTheCurrentError() async {
+    let presenter = makePresenter()
+    presenter.present(error("First"))
+    await presenter.dismissTask?.value
+    #expect(presenter.current == nil)
+    #expect(presenter.queue.isEmpty)
+  }
+
+  @Test func autoDismissAdvancesToTheNextError() async {
+    // Only the first dismissal fires; the second stays parked so the advance is observable.
+    let controller = SleepController(immediate: 1)
+    let presenter = ErrorPresenter(autoDismiss: .zero, sleep: { _ in await controller.sleep() })
+    let first = error("First")
+    let second = error("Second")
+    presenter.present(first)
+    presenter.present(second)
+    await presenter.dismissTask?.value
+    #expect(presenter.current == second)
+    #expect(presenter.queue.count == 1)
+  }
+}

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -16,6 +16,7 @@ private struct HandlerContext {
   let selectionStore: TaskSelectionStore
   let localProvider: LocalProvider
   let settings: AppSettings
+  let errorPresenter: ErrorPresenter
 }
 
 // MARK: - Fakes
@@ -123,6 +124,7 @@ struct URLSchemeHandlerTests {
       registry.enable(stub)
     }
 
+    let errorPresenter = ErrorPresenter()
     let handler = URLSchemeHandler(
       registry: registry,
       queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
@@ -132,14 +134,16 @@ struct URLSchemeHandlerTests {
       nav: MainNavigation(
         settings: settings,
         selectionStore: SelectionStore(registry: registry, defaults: defaults),
-        statsViewModel: .preview)
+        statsViewModel: .preview),
+      errorPresenter: errorPresenter
     )
     return HandlerContext(
       handler: handler,
       registry: registry,
       selectionStore: selectionStore,
       localProvider: localProvider,
-      settings: settings
+      settings: settings,
+      errorPresenter: errorPresenter
     )
   }
 
@@ -185,13 +189,14 @@ struct URLSchemeHandlerTests {
     #expect(tasks.first?.list != nil)
   }
 
-  // MARK: - Ad-hoc task creation (LocalProvider disabled — transient)
+  // MARK: - Ad-hoc task creation (no writable provider — error, no fallback)
 
-  @Test func adHocTaskIsTransientWhenLocalDisabled() async {
+  @Test func adHocTaskSurfacesErrorWhenNoWritableProvider() async {
     let ctx = makeHandler(enableLocalProvider: false)
     await ctx.handler.handle(URL(string: "taskmato://start?title=Transient+Task")!)
-    #expect(ctx.selectionStore.activeTask?.title == "Transient Task")
-    #expect(ctx.selectionStore.activeTask?.id.providerID == "adhoc")
+    // No enabled writable provider → no session starts and the failure is surfaced.
+    #expect(ctx.selectionStore.activeTask == nil)
+    #expect(ctx.errorPresenter.current != nil)
   }
 
   @Test func adHocTaskWithHighPriority() async {
@@ -217,14 +222,14 @@ struct URLSchemeHandlerTests {
     #expect(items.map(\.title).contains("Override"))
   }
 
-  @Test func adHocTaskURLProviderParamFallsBackWhenProviderDisabled() async {
-    // provider= refers to a disabled/unknown provider → falls back to settings/firstEnabled
+  @Test func adHocTaskURLProviderParamSurfacesErrorWhenNoEnabledWritable() async {
+    // provider= refers to a disabled provider and none other is enabled → error, no session.
     let ctx = makeHandler(enableLocalProvider: true)
     ctx.registry.disable(providerID: LocalProvider.providerID)
     await ctx.handler.handle(
       URL(string: "taskmato://start?title=Fallback&provider=\(LocalProvider.providerID)")!)
-    // No enabled writable provider → transient
-    #expect(ctx.selectionStore.activeTask?.id.providerID == "adhoc")
+    #expect(ctx.selectionStore.activeTask == nil)
+    #expect(ctx.errorPresenter.current != nil)
   }
 
   @Test func adHocTaskURLProviderParamFallsBackToSettingsDefaultWhenDisabled() async {
@@ -263,8 +268,9 @@ struct URLSchemeHandlerTests {
       defaultWritableProviderID: LocalProvider.providerID
     )
     await ctx.handler.handle(URL(string: "taskmato://start?title=No+Provider")!)
-    // Settings points at disabled provider → falls through to transient
-    #expect(ctx.selectionStore.activeTask?.id.providerID == "adhoc")
+    // Settings points at a disabled provider and none is enabled → error, no session.
+    #expect(ctx.selectionStore.activeTask == nil)
+    #expect(ctx.errorPresenter.current != nil)
   }
 
   // MARK: - Step 1: Lookup by provider + ID
@@ -368,7 +374,7 @@ struct URLSchemeHandlerTests {
     let ctx = makeHandler(stubProviderTasks: [task1, task2], enableLocalProvider: true)
     await ctx.handler.handle(URL(string: "taskmato://start?title=Deploy")!)
     let params = ctx.handler.pendingAdHocParams!
-    let task = await ctx.handler.makeAdHocTask(from: params)
+    let task = try #require(await ctx.handler.makeAdHocTask(from: params))
     #expect(task.id.providerID == LocalProvider.providerID)
     let localItems = try await ctx.localProvider.tasks(in: nil)
     #expect(localItems.map(\.title).contains("Deploy"))

--- a/docs/how-to/reset-stale-dev-builds.md
+++ b/docs/how-to/reset-stale-dev-builds.md
@@ -1,0 +1,66 @@
+<!-- cspell:words DerivedData lsregister deriveddata Frameworks LaunchServices richwklein worktree worktrees -->
+# How to clear stale dev builds and fix `taskmato://` routing
+
+Use this runbook when a `taskmato://` invocation (via `scripts/taskmato`) appears to hit an
+**old build** — for example, a change you just made is not reflected, or the URL launches an
+unexpected copy of the app.
+
+## Why this happens
+
+Every Debug build lands in a per-project-path `DerivedData` folder, so each git worktree
+produces its **own** `Taskmato.app`. They all share the bundle id `com.richwklein.Taskmato`
+and all register a claim on the `taskmato:` URL scheme. `scripts/taskmato` ends in
+`open "taskmato://…"`, which lets **LaunchServices** pick one of those registered copies —
+with no guarantee it is the build you just made.
+
+The result: dozens of registered handlers accumulate over time, and URL events route to a
+stale (or deleted) bundle.
+
+## Diagnose
+
+```bash
+# How many copies of the scheme are registered
+LSREG="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+"$LSREG" -dump | grep -c "claimed schemes:.*taskmato:"
+
+# Which registered Taskmato bundles still exist on disk (should be exactly one)
+"$LSREG" -dump | grep -oE "/[^ ]*Taskmato\.app" | sort -u | while read -r p; do
+  [ -e "$p" ] && echo "EXISTS: $p"
+done
+```
+
+If more than one path `EXISTS`, or the surviving path is not your current worktree's build,
+run the cleanup.
+
+## Clean up
+
+```bash
+# 1. Quit any running (possibly stale) instances
+killall Taskmato 2>/dev/null
+
+# 2. Remove every Taskmato build product across all worktrees
+#    (safe — DerivedData is regenerated on the next build; `make clean` only cleans the
+#    current worktree, so use this glob to catch the others)
+rm -rf ~/Library/Developer/Xcode/DerivedData/Taskmato-*
+
+# 3. Rescan LaunchServices so deleted bundles drop out of resolution
+#    (the old `-kill` flag was removed on recent macOS; a plain rescan is enough because
+#    LaunchServices skips registrations whose bundle no longer exists on disk)
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister \
+  -r -domain local -domain system -domain user
+
+# 4. Rebuild the current worktree and launch it once so it re-registers as the handler
+make build
+open "$(find ~/Library/Developer/Xcode/DerivedData -path '*/Build/Products/Debug/Taskmato.app' -maxdepth 6 | head -1)"
+```
+
+After step 4 the freshly built app is the only `Taskmato.app` on disk, so `taskmato://`
+resolves to it. Dangling registrations may still appear in `lsregister -dump`; they are
+harmless because LaunchServices ignores registrations whose bundle is missing.
+
+## Prevent recurrence
+
+Because every worktree builds the same bundle id, building a second worktree re-introduces
+the ambiguity. Either keep only one build on disk (delete other worktrees' DerivedData as
+you go), or pin the wrapper to a specific build so LaunchServices never guesses — see the
+`open` call in `scripts/taskmato`.


### PR DESCRIPTION
## Summary

Introduce an `ErrorPresenter` that surfaces provider errors to the user, replacing the
silent `try?` calls on user-initiated provider mutations with explicit, visible error
handling. Also adds a dev runbook for clearing stale builds.

## Linked issue

Closes #410

## Motivation

Every user-initiated provider operation that failed did so **silently** via `try?`. Tapping
the complete circle on a Reminders task after EventKit access was revoked, adding a task whose
write failed, or renaming a list all failed with no signal — a real UX hole and a future
support burden (design doc 0005, Finding K).

The issue predates the window-first shell (ADR-0007 / design doc 0008), which replaced the
tabbed `TasksTabView` with a single-surface root `NavigationSplitView`. The banner therefore
lives at the **window root** so errors from any destination surface in one place.

## Changes

- **New `ErrorPresenter`** (`@Observable @MainActor`): a transient, auto-dismissing error
  queue with manual dismiss; injected through `AppComposition`. Auto-dismiss modeled on the
  existing `Debouncer` (cancellable `Task` + `Task.sleep`), with an injectable sleep for
  deterministic tests.
- **New `ErrorBannerView`** at the window root (above the detail and timer strip), reusing the
  `statusError` / `priorityHigh` design tokens; no new tokens.
- **Replaced `try?`** on all in-window user-initiated mutations via a small
  `errorPresenter.attempt(_:_:)` helper: `TaskDetailView` (complete/restore/delete),
  `AddTaskView.submit`, `ActiveTaskView` (complete), and `AppSidebarView` list ops
  (create/rename/delete/set-default).
- **`URLSchemeHandler.makeAdHocTask` → `TaskItem?`**: on no writable provider or a write
  failure it surfaces an error and returns `nil` (no silent transient fallback); the caller
  starts no session on an unsaved task.
- **Tests**: new `ErrorPresenterTests` (queueing, manual + auto dismiss, error→detail
  mapping); `URLSchemeHandlerTests` updated for the no-fallback behavior.
- **Docs**: `docs/how-to/reset-stale-dev-builds.md` — runbook for clearing accumulated
  per-worktree DerivedData builds and resetting the `taskmato://` LaunchServices handler.

Settings/Obsidian keep their existing inline error UI (separate window, own idiom) — out of
scope here.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

End-to-end manual verification of the banner **via the `taskmato://` scheme is currently
blocked by #460** (URL events are dropped on cold launch until scenes report ready). The
ErrorPresenter logic and every mutation call site are covered by unit tests and verified in
code; the banner render path is exercised in previews. Once #460 is fixed, a failed ad-hoc
creation will surface on the same banner. #460 is intentionally left as separate work.
