### PR TITLE
refactor(settings): consolidate UserDefaults clients behind SettingsStore

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -37,15 +37,17 @@ struct AppComposition {
   /// Constructs every service, registers providers, and wires the phase-ended callback.
   init() {
     let engine = SessionEngine()
-    let settings = AppSettings()
+    let settingsStore = SettingsStore()
+    let settings = AppSettings(store: settingsStore)
     let sessionRepository = Self.makeSessionRepository()
     let store = SessionStore(repository: sessionRepository)
-    let selectionStore = TaskSelectionStore()
-    let registry = ProviderRegistry()
+    let selectionStore = TaskSelectionStore(store: settingsStore)
+    let registry = ProviderRegistry(store: settingsStore)
     let notifications = NotificationService(settings: settings)
-    let obsidianProvider = ObsidianProvider()
+    let obsidianProvider = ObsidianProvider(store: settingsStore)
     let localProvider = LocalProvider()
-    let remindersProvider = RemindersProvider()
+    let remindersProvider = RemindersProvider(
+      store: LiveRemindersEventStore(), settings: settingsStore)
     let statsViewModel = StatsViewModel(
       repository: sessionRepository,
       providerLabel: { [registry] providerID in
@@ -59,9 +61,10 @@ struct AppComposition {
       [obsidianProvider, localProvider, remindersProvider], into: registry,
       fallback: localProvider)
     let queryService = TaskQueryService(registry: registry, sorter: TaskSorter())
-    let sidebarSelection = SelectionStore(registry: registry)
+    let sidebarSelection = SelectionStore(registry: registry, store: settingsStore)
     let nav = MainNavigation(
-      settings: settings, selectionStore: sidebarSelection, statsViewModel: statsViewModel)
+      settings: settings, selectionStore: sidebarSelection, statsViewModel: statsViewModel,
+      store: settingsStore)
     registry.onProviderStateChanged = { [weak sidebarSelection, weak nav] in
       sidebarSelection?.validateSelection()
       nav?.reconcileTaskScope()

--- a/app/Taskmato/Services/AppSettings.swift
+++ b/app/Taskmato/Services/AppSettings.swift
@@ -15,53 +15,53 @@ final class AppSettings {
 
   /// Length of a focus interval, in minutes.
   var focusMinutes: Int {
-    didSet { defaults.set(focusMinutes, forKey: Keys.focusMinutes) }
+    didSet { store[SettingsStore.Keys.focusMinutes] = focusMinutes }
   }
 
   /// Length of a short break, in minutes.
   var shortBreakMinutes: Int {
-    didSet { defaults.set(shortBreakMinutes, forKey: Keys.shortBreakMinutes) }
+    didSet { store[SettingsStore.Keys.shortBreakMinutes] = shortBreakMinutes }
   }
 
   /// Length of a long break, in minutes.
   var longBreakMinutes: Int {
-    didSet { defaults.set(longBreakMinutes, forKey: Keys.longBreakMinutes) }
+    didSet { store[SettingsStore.Keys.longBreakMinutes] = longBreakMinutes }
   }
 
   /// Number of completed focus sessions before a long break is taken.
   var longBreakAfterSessions: Int {
-    didSet { defaults.set(longBreakAfterSessions, forKey: Keys.longBreakAfterSessions) }
+    didSet { store[SettingsStore.Keys.longBreakAfterSessions] = longBreakAfterSessions }
   }
 
   /// Whether a sound is played when a phase completes naturally.
   var soundEnabled: Bool {
-    didSet { defaults.set(soundEnabled, forKey: Keys.soundEnabled) }
+    didSet { store[SettingsStore.Keys.soundEnabled] = soundEnabled }
   }
 
   /// The name of the system sound file (without `.aiff` extension) played on phase completion.
   ///
   /// Defaults to `"Hero"`. Built-in values: `Hero`, `Glass`, `Tink`, `Sosumi`, `Ping`.
   var soundName: String {
-    didSet { defaults.set(soundName, forKey: Keys.soundName) }
+    didSet { store[SettingsStore.Keys.soundName] = soundName }
   }
 
   /// Whether phase-end alerts (banner and sound) are delivered.
   ///
   /// Acts as the master toggle — when `false`, no cues fire regardless of sub-toggle values.
   var notificationsEnabled: Bool {
-    didSet { defaults.set(notificationsEnabled, forKey: Keys.notificationsEnabled) }
+    didSet { store[SettingsStore.Keys.notificationsEnabled] = notificationsEnabled }
   }
 
   /// Whether the next phase starts automatically on natural completion, or waits for the user to press Start.
   var autoStartNextPhase: Bool {
-    didSet { defaults.set(autoStartNextPhase, forKey: Keys.autoStartNextPhase) }
+    didSet { store[SettingsStore.Keys.autoStartNextPhase] = autoStartNextPhase }
   }
 
   /// The display mode for the task picker (list rows or card grid).
   ///
   /// Defaults to `.grid`.
   var taskPickerLayout: TaskPickerLayout {
-    didSet { defaults.set(taskPickerLayout.rawValue, forKey: Keys.taskPickerLayout) }
+    didSet { store[SettingsStore.Keys.taskPickerLayout] = taskPickerLayout }
   }
 
   /// Whether the provider/list sidebar column is visible in the window-first shell.
@@ -69,23 +69,23 @@ final class AppSettings {
   /// Defaults to `true` — the sidebar is the app's primary navigation (design doc 0008, D9;
   /// reverses design doc 0003 decision 4, whose tab-layout rationale no longer applies).
   var sidebarVisible: Bool {
-    didSet { defaults.set(sidebarVisible, forKey: Keys.sidebarVisible) }
+    didSet { store[SettingsStore.Keys.sidebarVisible] = sidebarVisible }
   }
 
   /// The field used to sort tasks in all views. Defaults to `.dueDate`.
   var taskSortField: TaskSortField {
-    didSet { defaults.set(taskSortField.rawValue, forKey: Keys.taskSortField) }
+    didSet { store[SettingsStore.Keys.taskSortField] = taskSortField }
   }
 
   /// The sort direction applied to `taskSortField`. Defaults to `.ascending`.
   var taskSortDirection: TaskSortDirection {
-    didSet { defaults.set(taskSortDirection.rawValue, forKey: Keys.taskSortDirection) }
+    didSet { store[SettingsStore.Keys.taskSortDirection] = taskSortDirection }
   }
 
   /// The provider ID of the preferred writable provider for new ad-hoc tasks and the
   /// Add Task sheet, or `nil` to automatically select the first enabled writable provider.
   var defaultWritableProviderID: String? {
-    didSet { defaults.set(defaultWritableProviderID, forKey: Keys.defaultWritableProviderID) }
+    didSet { store[SettingsStore.Keys.defaultWritableProviderID] = defaultWritableProviderID }
   }
 
   /// Sidebar section IDs (a provider `id`, or `"stats"`) the user has collapsed.
@@ -93,9 +93,7 @@ final class AppSettings {
   /// Empty by default, so every section starts expanded. Enabling or configuring a provider,
   /// and programmatic list selection, re-expands a section by removing its ID from this set.
   var collapsedSidebarSections: Set<String> {
-    didSet {
-      defaults.set(Array(collapsedSidebarSections), forKey: Keys.collapsedSidebarSections)
-    }
+    didSet { store[SettingsStore.Keys.collapsedSidebarSections] = collapsedSidebarSections }
   }
 
   /// `focusMinutes` expressed as a `TimeInterval` in seconds.
@@ -107,55 +105,29 @@ final class AppSettings {
   /// `longBreakMinutes` expressed as a `TimeInterval` in seconds.
   var longBreakDuration: TimeInterval { TimeInterval(longBreakMinutes * 60) }
 
-  private let defaults: UserDefaults
+  private let store: SettingsStore
 
   /// Creates settings backed by the standard `UserDefaults` suite.
   convenience init() {
-    self.init(defaults: .standard)
+    self.init(store: SettingsStore())
   }
 
-  /// Creates settings backed by the provided `UserDefaults` instance. Pass a temporary suite in tests.
-  init(defaults: UserDefaults) {
-    self.defaults = defaults
-    focusMinutes = defaults.integer(forKey: Keys.focusMinutes).nonZero ?? 25
-    shortBreakMinutes = defaults.integer(forKey: Keys.shortBreakMinutes).nonZero ?? 5
-    longBreakMinutes = defaults.integer(forKey: Keys.longBreakMinutes).nonZero ?? 15
-    longBreakAfterSessions = defaults.integer(forKey: Keys.longBreakAfterSessions).nonZero ?? 4
-    soundEnabled = defaults.object(forKey: Keys.soundEnabled) as? Bool ?? true
-    soundName = defaults.string(forKey: Keys.soundName) ?? "Hero"
-    notificationsEnabled = defaults.object(forKey: Keys.notificationsEnabled) as? Bool ?? true
-    autoStartNextPhase = defaults.object(forKey: Keys.autoStartNextPhase) as? Bool ?? false
-    let rawLayout = defaults.string(forKey: Keys.taskPickerLayout)
-    taskPickerLayout = rawLayout.flatMap(TaskPickerLayout.init) ?? .grid
-    sidebarVisible = defaults.object(forKey: Keys.sidebarVisible) as? Bool ?? true
-    taskSortField =
-      defaults.string(forKey: Keys.taskSortField).flatMap(TaskSortField.init) ?? .dueDate
-    taskSortDirection =
-      defaults.string(forKey: Keys.taskSortDirection).flatMap(TaskSortDirection.init) ?? .ascending
-    defaultWritableProviderID = defaults.string(forKey: Keys.defaultWritableProviderID)
-    collapsedSidebarSections = Set(
-      defaults.stringArray(forKey: Keys.collapsedSidebarSections) ?? [])
+  /// Creates settings backed by the provided ``SettingsStore``. Pass a store over a temporary suite in tests.
+  init(store: SettingsStore) {
+    self.store = store
+    focusMinutes = store[SettingsStore.Keys.focusMinutes]
+    shortBreakMinutes = store[SettingsStore.Keys.shortBreakMinutes]
+    longBreakMinutes = store[SettingsStore.Keys.longBreakMinutes]
+    longBreakAfterSessions = store[SettingsStore.Keys.longBreakAfterSessions]
+    soundEnabled = store[SettingsStore.Keys.soundEnabled]
+    soundName = store[SettingsStore.Keys.soundName]
+    notificationsEnabled = store[SettingsStore.Keys.notificationsEnabled]
+    autoStartNextPhase = store[SettingsStore.Keys.autoStartNextPhase]
+    taskPickerLayout = store[SettingsStore.Keys.taskPickerLayout]
+    sidebarVisible = store[SettingsStore.Keys.sidebarVisible]
+    taskSortField = store[SettingsStore.Keys.taskSortField]
+    taskSortDirection = store[SettingsStore.Keys.taskSortDirection]
+    defaultWritableProviderID = store[SettingsStore.Keys.defaultWritableProviderID]
+    collapsedSidebarSections = store[SettingsStore.Keys.collapsedSidebarSections]
   }
-
-  private enum Keys {
-    static let focusMinutes = "focusMinutes"
-    static let shortBreakMinutes = "shortBreakMinutes"
-    static let longBreakMinutes = "longBreakMinutes"
-    static let longBreakAfterSessions = "longBreakAfterSessions"
-    static let soundEnabled = "soundEnabled"
-    static let soundName = "soundName"
-    static let notificationsEnabled = "notificationsEnabled"
-    static let autoStartNextPhase = "autoStartNextPhase"
-    static let taskPickerLayout = "taskPickerLayout"
-    static let sidebarVisible = "taskRegistry.sidebarVisible"
-    static let taskSortField = "taskSort.field"
-    static let taskSortDirection = "taskSort.direction"
-    static let defaultWritableProviderID = "tasks.defaultWritableProviderID"
-    static let collapsedSidebarSections = "sidebar.collapsedSections"
-  }
-}
-
-extension Int {
-  /// Returns `self` if greater than zero, otherwise `nil`.
-  fileprivate var nonZero: Int? { self > 0 ? self : nil }
 }

--- a/app/Taskmato/Services/SettingsStore.swift
+++ b/app/Taskmato/Services/SettingsStore.swift
@@ -1,0 +1,189 @@
+//
+//  SettingsStore.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A typed, defaulted key into ``SettingsStore``.
+///
+/// Pairs a persisted `UserDefaults` key name with the value returned when the key is absent.
+struct SettingsKey<Value> {
+
+  /// The `UserDefaults` key string, preserved verbatim across releases to avoid data migration.
+  let name: String
+
+  /// The value returned when no stored value exists for ``name``.
+  let defaultValue: Value
+
+  /// - Parameters:
+  ///   - name: The `UserDefaults` key string.
+  ///   - defaultValue: The value returned when the key is absent.
+  init(_ name: String, default defaultValue: Value) {
+    self.name = name
+    self.defaultValue = defaultValue
+  }
+}
+
+/// The single typed gateway to `UserDefaults` — the one place the app reads and writes settings.
+///
+/// Every persisted key is enumerated in ``Keys``. Scalar and enum values use typed ``SettingsKey``
+/// subscripts; `Codable` values round-trip through ``value(forKey:as:)`` / ``setValue(_:forKey:)``
+/// and raw `Data` (e.g. a security-scoped bookmark) through ``data(forKey:)`` / ``setData(_:forKey:)``.
+/// Key strings and value encodings match the pre-consolidation layout, so existing user settings
+/// survive an upgrade.
+final class SettingsStore {
+
+  private let defaults: UserDefaults
+
+  /// - Parameter defaults: Backing store. Pass a temporary suite in tests.
+  init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  // MARK: - Scalar & enum keys
+
+  /// Reads or writes an integer setting, returning the key's default when absent.
+  subscript(key: SettingsKey<Int>) -> Int {
+    get { (defaults.object(forKey: key.name) as? Int) ?? key.defaultValue }
+    set { defaults.set(newValue, forKey: key.name) }
+  }
+
+  /// Reads or writes a boolean setting, returning the key's default when absent.
+  subscript(key: SettingsKey<Bool>) -> Bool {
+    get { (defaults.object(forKey: key.name) as? Bool) ?? key.defaultValue }
+    set { defaults.set(newValue, forKey: key.name) }
+  }
+
+  /// Reads or writes a string setting, returning the key's default when absent.
+  subscript(key: SettingsKey<String>) -> String {
+    get { defaults.string(forKey: key.name) ?? key.defaultValue }
+    set { defaults.set(newValue, forKey: key.name) }
+  }
+
+  /// Reads or writes an optional string setting, removing the key when set to `nil`.
+  subscript(key: SettingsKey<String?>) -> String? {
+    get { defaults.string(forKey: key.name) ?? key.defaultValue }
+    set {
+      if let newValue {
+        defaults.set(newValue, forKey: key.name)
+      } else {
+        defaults.removeObject(forKey: key.name)
+      }
+    }
+  }
+
+  /// Reads or writes a string-array setting, returning the key's default when absent.
+  subscript(key: SettingsKey<[String]>) -> [String] {
+    get { defaults.stringArray(forKey: key.name) ?? key.defaultValue }
+    set { defaults.set(newValue, forKey: key.name) }
+  }
+
+  /// Reads or writes a string set stored as an array, returning the key's default when absent.
+  subscript(key: SettingsKey<Set<String>>) -> Set<String> {
+    get {
+      guard let stored = defaults.stringArray(forKey: key.name) else { return key.defaultValue }
+      return Set(stored)
+    }
+    set { defaults.set(Array(newValue), forKey: key.name) }
+  }
+
+  /// Reads or writes a `String`-backed `RawRepresentable` (e.g. an enum), stored as its raw value.
+  subscript<Value: RawRepresentable>(key: SettingsKey<Value>) -> Value
+  where Value.RawValue == String {
+    get { defaults.string(forKey: key.name).flatMap(Value.init(rawValue:)) ?? key.defaultValue }
+    set { defaults.set(newValue.rawValue, forKey: key.name) }
+  }
+
+  // MARK: - Codable & Data values
+
+  /// Decodes a JSON-encoded `Codable` value for `key`, or `nil` when absent or undecodable.
+  /// - Parameters:
+  ///   - key: The persisted key string, from ``Keys``.
+  ///   - type: The value type to decode.
+  func value<Value: Decodable>(forKey key: String, as type: Value.Type = Value.self) -> Value? {
+    guard let data = defaults.data(forKey: key) else { return nil }
+    return try? JSONDecoder().decode(Value.self, from: data)
+  }
+
+  /// JSON-encodes and stores `value` for `key`, removing the key when `value` is `nil` or fails to encode.
+  func setValue<Value: Encodable>(_ value: Value?, forKey key: String) {
+    guard let value, let data = try? JSONEncoder().encode(value) else {
+      defaults.removeObject(forKey: key)
+      return
+    }
+    defaults.set(data, forKey: key)
+  }
+
+  /// Reads raw `Data` for `key` (e.g. a security-scoped bookmark), or `nil` when absent.
+  func data(forKey key: String) -> Data? {
+    defaults.data(forKey: key)
+  }
+
+  /// Writes raw `Data` for `key`, removing the key when `data` is `nil`.
+  func setData(_ data: Data?, forKey key: String) {
+    if let data {
+      defaults.set(data, forKey: key)
+    } else {
+      defaults.removeObject(forKey: key)
+    }
+  }
+}
+
+extension SettingsStore {
+
+  /// Every persisted `UserDefaults` key the app uses, named in one place.
+  ///
+  /// Scalar and enum keys are typed ``SettingsKey`` values carrying their default; `Codable`
+  /// and `Data` keys are plain strings used with ``SettingsStore/value(forKey:as:)`` and
+  /// ``SettingsStore/data(forKey:)``.
+  enum Keys {
+
+    // MARK: Timer durations & session cadence
+
+    static let focusMinutes = SettingsKey("focusMinutes", default: 25)
+    static let shortBreakMinutes = SettingsKey("shortBreakMinutes", default: 5)
+    static let longBreakMinutes = SettingsKey("longBreakMinutes", default: 15)
+    static let longBreakAfterSessions = SettingsKey("longBreakAfterSessions", default: 4)
+
+    // MARK: Alerts
+
+    static let soundEnabled = SettingsKey("soundEnabled", default: true)
+    static let soundName = SettingsKey("soundName", default: "Hero")
+    static let notificationsEnabled = SettingsKey("notificationsEnabled", default: true)
+    static let autoStartNextPhase = SettingsKey("autoStartNextPhase", default: false)
+
+    // MARK: Task views & sidebar
+
+    static let taskPickerLayout = SettingsKey("taskPickerLayout", default: TaskPickerLayout.grid)
+    static let sidebarVisible = SettingsKey("taskRegistry.sidebarVisible", default: true)
+    static let taskSortField = SettingsKey("taskSort.field", default: TaskSortField.dueDate)
+    static let taskSortDirection = SettingsKey(
+      "taskSort.direction", default: TaskSortDirection.ascending)
+    static let defaultWritableProviderID = SettingsKey<String?>(
+      "tasks.defaultWritableProviderID", default: nil)
+    static let collapsedSidebarSections = SettingsKey(
+      "sidebar.collapsedSections", default: Set<String>())
+
+    // MARK: Provider registry
+
+    static let enabledProviderIDs = SettingsKey(
+      "taskRegistry.enabledProviderIDs", default: Set<String>())
+
+    // MARK: Obsidian provider
+
+    static let obsidianFilePatterns = SettingsKey("obsidian.filePatterns", default: ["**/*.md"])
+    static let obsidianVaultBookmark = "obsidian.vaultBookmark"
+
+    // MARK: Reminders provider
+
+    static let remindersListPatterns = SettingsKey("reminders.listPatterns", default: [String]())
+
+    // MARK: Codable navigation & selection blobs
+
+    static let sidebarSelection = "taskRegistry.selection"
+    static let activeTask = "taskSelection.activeTask"
+    static let recentsByProvider = "taskSelection.recentsByProvider"
+    static let shellDestination = "shell.destination"
+  }
+}

--- a/app/Taskmato/Services/TaskSelectionStore.swift
+++ b/app/Taskmato/Services/TaskSelectionStore.swift
@@ -21,14 +21,12 @@ final class TaskSelectionStore {
   /// Recent tasks keyed by provider ID, each capped at `recentsLimit` entries.
   private(set) var recentsByProvider: [String: [TaskItem]] = [:]
 
-  private let defaults: UserDefaults
-  private static let activeTaskKey = "taskSelection.activeTask"
-  private static let recentsKey = "taskSelection.recentsByProvider"
+  private let store: SettingsStore
   static let recentsLimit = 10
 
-  /// - Parameter defaults: `UserDefaults` store for persistence. Override in tests.
-  init(defaults: UserDefaults = .standard) {
-    self.defaults = defaults
+  /// - Parameter store: The settings store for persistence. Override in tests.
+  init(store: SettingsStore = SettingsStore()) {
+    self.store = store
     load()
   }
 
@@ -71,24 +69,14 @@ final class TaskSelectionStore {
   }
 
   private func persist() {
-    let encoder = JSONEncoder()
-    if let activeTask, let data = try? encoder.encode(activeTask) {
-      defaults.set(data, forKey: Self.activeTaskKey)
-    } else {
-      defaults.removeObject(forKey: Self.activeTaskKey)
-    }
-    if let data = try? encoder.encode(recentsByProvider) {
-      defaults.set(data, forKey: Self.recentsKey)
-    }
+    store.setValue(activeTask, forKey: SettingsStore.Keys.activeTask)
+    store.setValue(recentsByProvider, forKey: SettingsStore.Keys.recentsByProvider)
   }
 
   private func load() {
-    let decoder = JSONDecoder()
-    if let data = defaults.data(forKey: Self.activeTaskKey) {
-      activeTask = try? decoder.decode(TaskItem.self, from: data)
-    }
-    if let data = defaults.data(forKey: Self.recentsKey) {
-      recentsByProvider = (try? decoder.decode([String: [TaskItem]].self, from: data)) ?? [:]
-    }
+    activeTask = store.value(forKey: SettingsStore.Keys.activeTask, as: TaskItem.self)
+    recentsByProvider =
+      store.value(forKey: SettingsStore.Keys.recentsByProvider, as: [String: [TaskItem]].self)
+      ?? [:]
   }
 }

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -222,7 +222,13 @@ final class ObsidianProvider: ClosableTaskProvider {
 
   // MARK: - Private helpers
 
-  private nonisolated func restoreVaultBookmark() {
+  /// Resolves the persisted security-scoped bookmark into ``vaultURL``, refreshing the stored
+  /// bookmark when the system reports it stale.
+  ///
+  /// Runs synchronously from `init` so ``vaultURL`` is set before the sidebar's first `lists()`
+  /// load. A deferred assignment races that load and leaves the vault appearing unconfigured after
+  /// a cold launch, even though the bookmark persisted correctly.
+  private func restoreVaultBookmark() {
     guard let data = store.data(forKey: SettingsStore.Keys.obsidianVaultBookmark) else { return }
     var isStale = false
     guard
@@ -233,12 +239,8 @@ final class ObsidianProvider: ClosableTaskProvider {
         bookmarkDataIsStale: &isStale
       )
     else { return }
-    // vaultURL assignment and stale-refresh must happen on MainActor
-    Task { @MainActor [weak self] in
-      guard let self else { return }
-      if isStale { try? self.saveVaultBookmark(for: url) }
-      self.vaultURL = url
-    }
+    vaultURL = url
+    if isStale { try? saveVaultBookmark(for: url) }
   }
 
   /// Wraps `perform` with security-scoped resource access for `url`.

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -43,30 +43,27 @@ final class ObsidianProvider: ClosableTaskProvider {
   /// Whether the user has selected a vault directory.
   var isConfigured: Bool { vaultURL != nil }
 
-  private let defaults: UserDefaults
+  private let store: SettingsStore
   private let parser = ObsidianTaskParser()
   private var streamContinuation: AsyncStream<[TaskItem]>.Continuation?
   private var fsEventStream: FSEventStreamRef?
   private let debouncer = Debouncer()
 
-  private static let bookmarkKey = "obsidian.vaultBookmark"
-  private static let patternsKey = "obsidian.filePatterns"
   private static let defaultPatterns = ["**/*.md"]
 
-  init(defaults: UserDefaults = .standard) {
-    self.defaults = defaults
-    self.filePatterns =
-      defaults.array(forKey: Self.patternsKey) as? [String] ?? Self.defaultPatterns
+  init(store: SettingsStore = SettingsStore()) {
+    self.store = store
+    self.filePatterns = store[SettingsStore.Keys.obsidianFilePatterns]
     restoreVaultBookmark()
   }
 
-  /// Creates a pre-configured provider for unit tests, bypassing the UserDefaults bookmark lookup.
+  /// Creates a pre-configured provider for unit tests, bypassing the settings-store bookmark lookup.
   init(
-    defaults: UserDefaults,
+    store: SettingsStore,
     vaultURL: URL?,
     filePatterns: [String] = ObsidianProvider.defaultPatterns
   ) {
-    self.defaults = defaults
+    self.store = store
     self.filePatterns = filePatterns
     self.vaultURL = vaultURL
   }
@@ -206,27 +203,27 @@ final class ObsidianProvider: ClosableTaskProvider {
       includingResourceValuesForKeys: nil,
       relativeTo: nil
     )
-    defaults.set(bookmark, forKey: Self.bookmarkKey)
+    store.setData(bookmark, forKey: SettingsStore.Keys.obsidianVaultBookmark)
     vaultURL = url
   }
 
   /// Clears the stored vault bookmark and stops any active file-system watcher.
   func clearVault() {
-    defaults.removeObject(forKey: Self.bookmarkKey)
+    store.setData(nil, forKey: SettingsStore.Keys.obsidianVaultBookmark)
     vaultURL = nil
     stopWatching()
   }
 
-  /// Replaces the current file pattern list and persists it to `UserDefaults`.
+  /// Replaces the current file pattern list and persists it through the settings store.
   func setFilePatterns(_ patterns: [String]) {
     filePatterns = patterns.isEmpty ? Self.defaultPatterns : patterns
-    defaults.set(filePatterns, forKey: Self.patternsKey)
+    store[SettingsStore.Keys.obsidianFilePatterns] = filePatterns
   }
 
   // MARK: - Private helpers
 
   private nonisolated func restoreVaultBookmark() {
-    guard let data = defaults.data(forKey: Self.bookmarkKey) else { return }
+    guard let data = store.data(forKey: SettingsStore.Keys.obsidianVaultBookmark) else { return }
     var isStale = false
     guard
       let url = try? URL(

--- a/app/Taskmato/Tasks/Registry/ProviderRegistry.swift
+++ b/app/Taskmato/Tasks/Registry/ProviderRegistry.swift
@@ -38,14 +38,12 @@ final class ProviderRegistry {
   @ObservationIgnored
   var onProviderStateChanged: (() -> Void)?
 
-  private let defaults: UserDefaults
-  private static let enabledKey = "taskRegistry.enabledProviderIDs"
+  private let store: SettingsStore
 
-  /// - Parameter defaults: `UserDefaults` store for persistence. Override in tests.
-  init(defaults: UserDefaults = .standard) {
-    self.defaults = defaults
-    let stored = defaults.stringArray(forKey: Self.enabledKey) ?? []
-    self.enabledIDs = Set(stored)
+  /// - Parameter store: The settings store for persistence. Override in tests.
+  init(store: SettingsStore = SettingsStore()) {
+    self.store = store
+    self.enabledIDs = store[SettingsStore.Keys.enabledProviderIDs]
   }
 
   // MARK: - Registration
@@ -163,7 +161,7 @@ final class ProviderRegistry {
   // MARK: - Persistence
 
   private func persist() {
-    defaults.set(Array(enabledIDs), forKey: Self.enabledKey)
+    store[SettingsStore.Keys.enabledProviderIDs] = enabledIDs
   }
 }
 

--- a/app/Taskmato/Tasks/Registry/SelectionStore.swift
+++ b/app/Taskmato/Tasks/Registry/SelectionStore.swift
@@ -34,19 +34,16 @@ final class SelectionStore {
   // store weakly (via `onProviderStateChanged`), so there is no retain cycle. A strong
   // reference keeps the cascade safe even if no other owner outlives this store.
   @ObservationIgnored private let registry: ProviderRegistry
-  @ObservationIgnored private let defaults: UserDefaults
-  private static let selectionKey = "taskRegistry.selection"
+  @ObservationIgnored private let store: SettingsStore
 
   /// - Parameters:
   ///   - registry: The registry supplying providers, enabled state, and the list cache.
-  ///   - defaults: `UserDefaults` store for persistence. Override in tests.
-  init(registry: ProviderRegistry, defaults: UserDefaults = .standard) {
+  ///   - store: The settings store for persistence. Override in tests.
+  init(registry: ProviderRegistry, store: SettingsStore = SettingsStore()) {
     self.registry = registry
-    self.defaults = defaults
+    self.store = store
     self.selection =
-      defaults.data(forKey: Self.selectionKey).flatMap {
-        try? JSONDecoder().decode(SidebarSelection.self, from: $0)
-      } ?? .today
+      store.value(forKey: SettingsStore.Keys.sidebarSelection, as: SidebarSelection.self) ?? .today
   }
 
   /// Sets the active sidebar selection. Persistence happens automatically via `selection`'s `didSet`.
@@ -99,12 +96,6 @@ final class SelectionStore {
   }
 
   private func persistSelection() {
-    guard let selection,
-      let data = try? JSONEncoder().encode(selection)
-    else {
-      defaults.removeObject(forKey: Self.selectionKey)
-      return
-    }
-    defaults.set(data, forKey: Self.selectionKey)
+    store.setValue(selection, forKey: SettingsStore.Keys.sidebarSelection)
   }
 }

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -32,22 +32,21 @@ final class RemindersProvider: ClosableTaskProvider {
   private(set) var listPatterns: [String]
 
   private let store: any RemindersEventStore
-  private let defaults: UserDefaults
-  private static let patternsKey = "reminders.listPatterns"
+  private let settings: SettingsStore
   private var streamContinuation: AsyncStream<[TaskItem]>.Continuation?
   private var observer: NSObjectProtocol?
   private let debouncer = Debouncer()
 
   /// Production initializer using live EventKit.
   convenience init() {
-    self.init(store: LiveRemindersEventStore(), defaults: .standard)
+    self.init(store: LiveRemindersEventStore(), settings: SettingsStore())
   }
 
   /// Test-friendly initializer accepting any ``RemindersEventStore`` conformer.
-  init(store: any RemindersEventStore, defaults: UserDefaults = .standard) {
+  init(store: any RemindersEventStore, settings: SettingsStore = SettingsStore()) {
     self.store = store
-    self.defaults = defaults
-    self.listPatterns = defaults.array(forKey: Self.patternsKey) as? [String] ?? []
+    self.settings = settings
+    self.listPatterns = settings[SettingsStore.Keys.remindersListPatterns]
     isAuthorized = store.authorizationStatus() == .fullAccess
   }
 
@@ -82,7 +81,7 @@ final class RemindersProvider: ClosableTaskProvider {
   /// Replaces the stored list-pattern array and persists it to UserDefaults.
   func setListPatterns(_ patterns: [String]) {
     listPatterns = patterns
-    defaults.set(listPatterns, forKey: Self.patternsKey)
+    settings[SettingsStore.Keys.remindersListPatterns] = listPatterns
   }
 
   /// Returns titles of all Reminders calendars without applying ``listPatterns``.

--- a/app/Taskmato/Views/App/MainNavigation.swift
+++ b/app/Taskmato/Views/App/MainNavigation.swift
@@ -44,25 +44,25 @@ final class MainNavigation {
   @ObservationIgnored private let settings: AppSettings
   @ObservationIgnored private let selectionStore: SelectionStore
   @ObservationIgnored private let statsViewModel: StatsViewModel
-  @ObservationIgnored private let defaults: UserDefaults
+  @ObservationIgnored private let store: SettingsStore
   @ObservationIgnored private var openMainWindowAction: (() -> Void)?
 
   /// - Parameters:
   ///   - settings: App settings that persist `sidebarVisible`.
   ///   - selectionStore: The task-scope selection sink that task destinations forward into.
   ///   - statsViewModel: The stats view model whose scope stats destinations forward into.
-  ///   - defaults: `UserDefaults` store for the persisted destination. Override in tests.
+  ///   - store: The settings store for the persisted destination. Override in tests.
   init(
     settings: AppSettings, selectionStore: SelectionStore, statsViewModel: StatsViewModel,
-    defaults: UserDefaults = .standard
+    store: SettingsStore = SettingsStore()
   ) {
     self.settings = settings
     self.selectionStore = selectionStore
     self.statsViewModel = statsViewModel
-    self.defaults = defaults
+    self.store = store
     // Restore the last surface (design doc 0008, D9). `didSet` does not fire during `init`, so
     // the Stats scope is forwarded explicitly; the task scope is owned by `SelectionStore`.
-    switch Self.decodePersistedDestination(from: defaults) {
+    switch Self.decodePersistedDestination(from: store) {
     case .timer:
       self.destination = .timer
     case .stats(let scope):
@@ -107,14 +107,10 @@ final class MainNavigation {
     case stats(StatScope)
   }
 
-  private static let destinationKey = "shell.destination"
-
   private static func decodePersistedDestination(
-    from defaults: UserDefaults
+    from store: SettingsStore
   ) -> PersistedDestination? {
-    defaults.data(forKey: destinationKey).flatMap {
-      try? JSONDecoder().decode(PersistedDestination.self, from: $0)
-    }
+    store.value(forKey: SettingsStore.Keys.shellDestination, as: PersistedDestination.self)
   }
 
   private func persistDestination() {
@@ -124,8 +120,7 @@ final class MainNavigation {
     case .today, .list: persisted = .tasks
     case .stats(let scope): persisted = .stats(scope)
     }
-    guard let data = try? JSONEncoder().encode(persisted) else { return }
-    defaults.set(data, forKey: Self.destinationKey)
+    store.setValue(persisted, forKey: SettingsStore.Keys.shellDestination)
   }
 
   // MARK: - Window binding

--- a/app/TaskmatoTests/AppSettingsTests.swift
+++ b/app/TaskmatoTests/AppSettingsTests.swift
@@ -12,7 +12,7 @@ struct AppSettingsTests {
 
   /// Returns settings backed by an isolated, temporary UserDefaults suite.
   private func makeSettings() -> AppSettings {
-    AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    AppSettings(store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
   }
 
   // MARK: - Duration conversions
@@ -90,10 +90,10 @@ struct AppSettingsTests {
 
   @Test func sortSettingsPersistAcrossInstances() {
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let writer = AppSettings(defaults: defaults)
+    let writer = AppSettings(store: SettingsStore(defaults: defaults))
     writer.taskSortField = .title
     writer.taskSortDirection = .descending
-    let reader = AppSettings(defaults: defaults)
+    let reader = AppSettings(store: SettingsStore(defaults: defaults))
     #expect(reader.taskSortField == .title)
     #expect(reader.taskSortDirection == .descending)
   }
@@ -108,8 +108,8 @@ struct AppSettingsTests {
 
   @Test func soundNamePersistsAcrossInstances() {
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    AppSettings(defaults: defaults).soundName = "Glass"
-    #expect(AppSettings(defaults: defaults).soundName == "Glass")
+    AppSettings(store: SettingsStore(defaults: defaults)).soundName = "Glass"
+    #expect(AppSettings(store: SettingsStore(defaults: defaults)).soundName == "Glass")
   }
 
   // MARK: - Persistence
@@ -117,12 +117,12 @@ struct AppSettingsTests {
   @Test func settingPersistsAcrossInstances() {
     let suite = UUID().uuidString
     let defaults = UserDefaults(suiteName: suite)!
-    let writer = AppSettings(defaults: defaults)
+    let writer = AppSettings(store: SettingsStore(defaults: defaults))
     writer.focusMinutes = 42
     writer.soundEnabled = false
     writer.autoStartNextPhase = true
 
-    let reader = AppSettings(defaults: defaults)
+    let reader = AppSettings(store: SettingsStore(defaults: defaults))
     #expect(reader.focusMinutes == 42)
     #expect(reader.soundEnabled == false)
     #expect(reader.autoStartNextPhase == true)

--- a/app/TaskmatoTests/MainNavigationTests.swift
+++ b/app/TaskmatoTests/MainNavigationTests.swift
@@ -44,12 +44,13 @@ struct MainNavigationTests {
   /// Builds a navigation model and its selection store over shared `defaults`, wiring
   /// `onProviderStateChanged` exactly as the composition root does (validate, then reconcile).
   private func makeNav(defaults: UserDefaults) -> NavContext {
-    let registry = ProviderRegistry(defaults: defaults)
-    let store = SelectionStore(registry: registry, defaults: defaults)
+    let settings = SettingsStore(defaults: defaults)
+    let registry = ProviderRegistry(store: settings)
+    let store = SelectionStore(registry: registry, store: settings)
     let statsViewModel = StatsViewModel.preview
     let nav = MainNavigation(
-      settings: AppSettings(defaults: defaults), selectionStore: store,
-      statsViewModel: statsViewModel, defaults: defaults)
+      settings: AppSettings(store: settings), selectionStore: store,
+      statsViewModel: statsViewModel, store: settings)
     registry.onProviderStateChanged = { [weak store, weak nav] in
       store?.validateSelection()
       nav?.reconcileTaskScope()

--- a/app/TaskmatoTests/NotificationServiceTests.swift
+++ b/app/TaskmatoTests/NotificationServiceTests.swift
@@ -45,7 +45,8 @@ private struct ServiceContext {
 @MainActor
 private func makeContext(status: UNAuthorizationStatus = .notDetermined) -> ServiceContext {
   let center = FakeNotificationCenter(status: status)
-  let settings = AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+  let settings = AppSettings(
+    store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
   let service = NotificationService(settings: settings, center: center)
   return ServiceContext(service: service, center: center, settings: settings)
 }

--- a/app/TaskmatoTests/ObsidianProviderTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderTests.swift
@@ -207,3 +207,35 @@ struct ObsidianProviderTokenExpansionTests {
     #expect(tasks[0].title == "Weekly task")
   }
 }
+
+// MARK: - Vault bookmark restore
+
+@Suite("ObsidianProvider — vault bookmark restore")
+@MainActor
+struct ObsidianProviderBookmarkRestoreTests {
+
+  /// A provider constructed over a store that already holds a vault bookmark must expose
+  /// `vaultURL` synchronously from `init` — before any list load — so the sidebar's first
+  /// `lists()` call after a cold launch sees a configured vault. A deferred assignment races
+  /// that load and leaves the vault appearing unconfigured.
+  @Test func restoresVaultSynchronouslyFromPersistedBookmark() throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+
+    let settings = SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    try ObsidianProvider(store: settings).saveVaultBookmark(for: vault)
+
+    // A fresh provider over the same store resolves the bookmark during init — no await.
+    let restored = ObsidianProvider(store: settings)
+    #expect(restored.isConfigured)
+    #expect(restored.vaultURL?.standardizedFileURL == vault.standardizedFileURL)
+  }
+
+  /// An empty store leaves the provider unconfigured rather than resolving a phantom vault.
+  @Test func staysUnconfiguredWithoutPersistedBookmark() {
+    let settings = SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    let provider = ObsidianProvider(store: settings)
+    #expect(!provider.isConfigured)
+    #expect(provider.vaultURL == nil)
+  }
+}

--- a/app/TaskmatoTests/ObsidianProviderTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderTests.swift
@@ -29,7 +29,7 @@ private func write(_ content: String, at relativePath: String, in vault: URL) th
 @MainActor
 private func makeProvider(vaultURL: URL?) -> ObsidianProvider {
   ObsidianProvider(
-    defaults: UserDefaults(suiteName: UUID().uuidString)!,
+    store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!),
     vaultURL: vaultURL
   )
 }
@@ -134,7 +134,8 @@ struct ObsidianProviderCompletedTasksTests {
 struct ObsidianProviderTokenExpansionTests {
 
   private func makeProvider() -> ObsidianProvider {
-    ObsidianProvider(defaults: UserDefaults(suiteName: UUID().uuidString)!, vaultURL: nil)
+    ObsidianProvider(
+      store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!), vaultURL: nil)
   }
 
   private func date(year: Int, month: Int, day: Int) -> Date {
@@ -197,7 +198,7 @@ struct ObsidianProviderTokenExpansionTests {
     let filename = String(format: "%04d-W%02d.md", year, week)
     try write("- [ ] Weekly task", at: "Weekly/\(filename)", in: vault)
     let provider = ObsidianProvider(
-      defaults: UserDefaults(suiteName: UUID().uuidString)!,
+      store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!),
       vaultURL: vault,
       filePatterns: ["**/Weekly/{YYYY}-W{ww}.md"]
     )

--- a/app/TaskmatoTests/ProviderRegistryTests.swift
+++ b/app/TaskmatoTests/ProviderRegistryTests.swift
@@ -122,7 +122,7 @@ private final class StubClosableProvider: ClosableTaskProvider {
 struct ProviderRegistryTests {
 
   private func makeRegistry() -> ProviderRegistry {
-    ProviderRegistry(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    ProviderRegistry(store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
   }
 
   // MARK: Registration

--- a/app/TaskmatoTests/RemindersProviderTests.swift
+++ b/app/TaskmatoTests/RemindersProviderTests.swift
@@ -58,7 +58,7 @@ struct RemindersProviderAuthorizationTests {
     store.status = status
     store.grantAccess = grantAccess
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     return (provider, store)
   }
 
@@ -148,7 +148,7 @@ struct RemindersProviderListTests {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     try await provider.authorize()
     return (provider, store)
   }
@@ -204,7 +204,7 @@ struct RemindersProviderListPatternTests {
     store.status = .fullAccess
     store.stubbedCalendars = calendarTitles.map { store.makeCalendar(title: $0) }
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     try await provider.authorize()
     if !patterns.isEmpty { provider.setListPatterns(patterns) }
     return provider
@@ -253,7 +253,7 @@ struct RemindersProviderTaskTests {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     try await provider.authorize()
     return (provider, store)
   }
@@ -406,7 +406,7 @@ struct RemindersProviderMutationTests {
     let store = FakeRemindersEventStore()
     store.status = .fullAccess
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     try await provider.authorize()
     return (provider, store)
   }
@@ -509,7 +509,7 @@ struct RemindersProviderCompletedTasksTests {
     let store = FakeRemindersEventStore()
     store.grantAccess = true
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     try await provider.authorize()
     return (provider, store)
   }
@@ -543,7 +543,7 @@ struct RemindersProviderCompletedTasksTests {
       store.makeReminder(title: "Done", isCompleted: true)
     ]
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let provider = RemindersProvider(store: store, defaults: defaults)
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
     let tasks = try await provider.completedTasks()
     #expect(tasks.isEmpty)
   }

--- a/app/TaskmatoTests/SelectionStoreTests.swift
+++ b/app/TaskmatoTests/SelectionStoreTests.swift
@@ -75,8 +75,9 @@ struct SelectionStoreTests {
     registry: ProviderRegistry, store: SelectionStore
   ) {
     let defaults = defaults ?? UserDefaults(suiteName: UUID().uuidString)!
-    let registry = ProviderRegistry(defaults: defaults)
-    let store = SelectionStore(registry: registry, defaults: defaults)
+    let settings = SettingsStore(defaults: defaults)
+    let registry = ProviderRegistry(store: settings)
+    let store = SelectionStore(registry: registry, store: settings)
     registry.onProviderStateChanged = { [weak store] in store?.validateSelection() }
     return (registry, store)
   }

--- a/app/TaskmatoTests/SessionEngineTests.swift
+++ b/app/TaskmatoTests/SessionEngineTests.swift
@@ -64,7 +64,8 @@ struct SessionEngineTests {
 
   @Test func applyDurationsCopiesSettingsIntoEngine() {
     let engine = SessionEngine(focusDuration: 1, shortBreakDuration: 1, longBreakDuration: 1)
-    let settings = AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    let settings = AppSettings(
+      store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
     settings.focusMinutes = 25
     settings.shortBreakMinutes = 5
     settings.longBreakMinutes = 15

--- a/app/TaskmatoTests/TaskPickerLayoutTests.swift
+++ b/app/TaskmatoTests/TaskPickerLayoutTests.swift
@@ -11,7 +11,7 @@ import Testing
 struct TaskPickerLayoutTests {
 
   private func makeSettings() -> AppSettings {
-    AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    AppSettings(store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
   }
 
   @Test func defaultLayoutIsGrid() {
@@ -21,10 +21,10 @@ struct TaskPickerLayoutTests {
   @Test func layoutPersistsAcrossInstances() {
     let suite = UUID().uuidString
     let defaults = UserDefaults(suiteName: suite)!
-    let writer = AppSettings(defaults: defaults)
+    let writer = AppSettings(store: SettingsStore(defaults: defaults))
     writer.taskPickerLayout = .list
 
-    let reader = AppSettings(defaults: defaults)
+    let reader = AppSettings(store: SettingsStore(defaults: defaults))
     #expect(reader.taskPickerLayout == .list)
   }
 

--- a/app/TaskmatoTests/TaskQueryServiceTests.swift
+++ b/app/TaskmatoTests/TaskQueryServiceTests.swift
@@ -97,7 +97,7 @@ private func queryItem(
 struct TaskQueryServiceTests {
 
   private func makeRegistry() -> ProviderRegistry {
-    ProviderRegistry(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    ProviderRegistry(store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
   }
 
   private func makeService(_ registry: ProviderRegistry) -> TaskQueryService {

--- a/app/TaskmatoTests/TaskSelectionStoreTests.swift
+++ b/app/TaskmatoTests/TaskSelectionStoreTests.swift
@@ -29,7 +29,7 @@ private func makeItem(providerID: String, nativeID: String, title: String) -> Ta
 struct TaskSelectionStoreTests {
 
   private func makeStore() -> TaskSelectionStore {
-    TaskSelectionStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    TaskSelectionStore(store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
   }
 
   // MARK: - Active task
@@ -129,10 +129,10 @@ struct TaskSelectionStoreTests {
     let defaults = UserDefaults(suiteName: suiteName)!
     let task = makeItem(providerID: "alpha", nativeID: "1", title: "Persisted task")
 
-    let store = TaskSelectionStore(defaults: defaults)
+    let store = TaskSelectionStore(store: SettingsStore(defaults: defaults))
     store.select(task)
 
-    let reloaded = TaskSelectionStore(defaults: defaults)
+    let reloaded = TaskSelectionStore(store: SettingsStore(defaults: defaults))
     #expect(reloaded.activeTask == task)
   }
 
@@ -141,10 +141,10 @@ struct TaskSelectionStoreTests {
     let defaults = UserDefaults(suiteName: suiteName)!
     let task = makeItem(providerID: "alpha", nativeID: "1", title: "Persisted task")
 
-    let store = TaskSelectionStore(defaults: defaults)
+    let store = TaskSelectionStore(store: SettingsStore(defaults: defaults))
     store.select(task)
 
-    let reloaded = TaskSelectionStore(defaults: defaults)
+    let reloaded = TaskSelectionStore(store: SettingsStore(defaults: defaults))
     #expect(reloaded.recents(for: "alpha") == [task])
   }
 
@@ -153,11 +153,11 @@ struct TaskSelectionStoreTests {
     let defaults = UserDefaults(suiteName: suiteName)!
     let task = makeItem(providerID: "alpha", nativeID: "1", title: "Temp task")
 
-    let store = TaskSelectionStore(defaults: defaults)
+    let store = TaskSelectionStore(store: SettingsStore(defaults: defaults))
     store.select(task)
     store.clearActiveTask()
 
-    let reloaded = TaskSelectionStore(defaults: defaults)
+    let reloaded = TaskSelectionStore(store: SettingsStore(defaults: defaults))
     #expect(reloaded.activeTask == nil)
   }
 }

--- a/app/TaskmatoTests/TimerPresenterTests.swift
+++ b/app/TaskmatoTests/TimerPresenterTests.swift
@@ -13,7 +13,8 @@ struct TimerPresenterTests {
 
   /// Builds isolated settings with the given phase lengths (in minutes).
   private func makeSettings(focus: Int = 25, short: Int = 5, long: Int = 15) -> AppSettings {
-    let settings = AppSettings(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+    let settings = AppSettings(
+      store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
     settings.focusMinutes = focus
     settings.shortBreakMinutes = short
     settings.longBreakMinutes = long

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -106,11 +106,12 @@ struct URLSchemeHandlerTests {
     defaultWritableProviderID: String? = nil
   ) -> HandlerContext {
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
-    let selectionStore = TaskSelectionStore(defaults: defaults)
+    let settingsStore = SettingsStore(defaults: defaults)
+    let selectionStore = TaskSelectionStore(store: settingsStore)
     let engine = SessionEngine()
-    let registry = ProviderRegistry(defaults: defaults)
+    let registry = ProviderRegistry(store: settingsStore)
     let localProvider = LocalProvider(fileURL: makeTempURL())
-    let settings = AppSettings(defaults: defaults)
+    let settings = AppSettings(store: settingsStore)
     settings.defaultWritableProviderID = defaultWritableProviderID
 
     registry.register(localProvider)
@@ -133,7 +134,7 @@ struct URLSchemeHandlerTests {
       settings: settings,
       nav: MainNavigation(
         settings: settings,
-        selectionStore: SelectionStore(registry: registry, defaults: defaults),
+        selectionStore: SelectionStore(registry: registry, store: settingsStore),
         statsViewModel: .preview),
       errorPresenter: errorPresenter
     )


### PR DESCRIPTION
## Summary

Consolidate every direct `UserDefaults` client behind a single typed `SettingsStore` (roadmap PR 38, Finding E), and fix a pre-existing Obsidian cold-launch bug surfaced while verifying it.

## Linked issue

Closes #409

## Motivation

Five+ types wrote to `UserDefaults` with ad-hoc key namespaces — no inventory of what the app persists, no schema, no single place to change a key. Centralising through one typed store makes the persisted surface auditable and future key changes a one-file edit.

## Changes

- **New `Services/SettingsStore.swift`** — one typed gateway over `UserDefaults`. Scalars/enums use typed `SettingsKey` subscripts; `Codable` blobs and the Obsidian `Data` bookmark round-trip through dedicated methods. Every persisted key is enumerated once in `SettingsStore.Keys`.
- **Migrated clients**: `AppSettings`, `ProviderRegistry`, `SelectionStore`, `TaskSelectionStore`, `MainNavigation`, `ObsidianProvider`, `RemindersProvider`. `AppComposition` builds one shared store and injects it into all (single-writer).
- **No data migration**: key strings and value encodings preserved verbatim — existing settings survive an upgrade. Verified against the live defaults domain.
- **Obsidian cold-launch fix** (separate commit): `restoreVaultBookmark()` assigned `vaultURL` on a deferred `Task { @MainActor }`, racing the sidebar's one-shot list load, so a persisted vault appeared unconfigured after restart (reconfiguring worked because it set `vaultURL` synchronously). The provider is already `@MainActor`, so the hop is unnecessary — now resolves synchronously in `init`. Adds a regression test.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Two logical commits, independently reviewable: (1) the `SettingsStore` refactor (#409), (2) the Obsidian cold-launch fix (pre-existing bug, not caused by the refactor — the `git diff` shows #409 only swapped persistence calls). The `#409` issue header speculated a `SelectionStore`/`destination` reshaping from #445 that didn't land that way; this PR consolidates the actual current key set rather than re-architecting the selection/navigation split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
