### PR TITLE
refactor(tasks): deduplicate row/card via TaskItemPresenter

### DIFF
--- a/app/Taskmato/Tasks/Models/TaskPriority.swift
+++ b/app/Taskmato/Tasks/Models/TaskPriority.swift
@@ -26,12 +26,18 @@ enum TaskPriority: Int, Codable, Comparable, CaseIterable, Sendable {
   }
 
   /// SF Symbol name for this priority level, or `nil` for `.none`.
+  ///
+  /// The five levels are glyph-distinct so priority reads without relying on color alone:
+  /// `highest` uses a filled triangle (mirroring the obsidian-tasks 🔺), the elevated band
+  /// steps `exclamationmark.3`/`.2`, and the low band shares `exclamationmark` (differentiated
+  /// by tint — see `accentColor`).
   var icon: String? {
     switch self {
     case .none: return nil
     case .lowest, .low: return "exclamationmark"
     case .medium: return "exclamationmark.2"
-    case .high, .highest: return "exclamationmark.3"
+    case .high: return "exclamationmark.3"
+    case .highest: return "exclamationmark.triangle.fill"
     }
   }
 }

--- a/app/Taskmato/Views/App/DesignTokens/Palette.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Palette.swift
@@ -10,7 +10,10 @@ extension Color {
   /// Due date that has reached or passed its urgency threshold.
   static let dueUrgent: Color = .red
 
-  /// Accent tint for elevated-priority tasks (medium and above).
+  /// Accent tint for the single highest-priority level, distinct from the elevated band.
+  static let priorityHighest: Color = .red
+
+  /// Accent tint for elevated-priority tasks (medium and high).
   static let priorityHigh: Color = .orange
 
   /// Default tint for tasks without elevated priority.

--- a/app/Taskmato/Views/Tasks/Components/PriorityGlyph.swift
+++ b/app/Taskmato/Views/Tasks/Components/PriorityGlyph.swift
@@ -1,0 +1,26 @@
+//
+//  PriorityGlyph.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The coloured priority indicator shared by every task-naming surface.
+///
+/// Renders the task priority's ``TaskPriority/icon`` tinted by its ``TaskPriority/accentColor``,
+/// or nothing for `.none`. `font` scales the glyph to match the host surface's title. Used both
+/// inline (``TaskTitleLabel``) and as a hanging leading marker beside a task's text block
+/// (``TaskRowView``, ``TaskCardView``), so priority reads identically everywhere.
+struct PriorityGlyph: View {
+
+  let priority: TaskPriority
+  var font: Font = .taskTitle
+
+  var body: some View {
+    if let icon = priority.icon {
+      Image(systemName: icon)
+        .foregroundStyle(priority.accentColor)
+        .font(font)
+    }
+  }
+}

--- a/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
@@ -8,7 +8,8 @@ import SwiftUI
 /// A card-style representation of a task for the grid layout in the task picker.
 ///
 /// Use ``TaskItemKind`` to distinguish active and completed tasks. Pass `lineage` when the
-/// picker is in cross-provider flat mode (Today or search) to show the task's origin.
+/// picker is in cross-provider flat mode (Today or search) to show the task's origin. All
+/// non-layout logic lives in ``TaskItemPresenter``; this view only arranges the slots.
 struct TaskCardView: View {
 
   let task: TaskItem
@@ -18,22 +19,30 @@ struct TaskCardView: View {
   @State private var isHovered = false
   @State private var showDeleteConfirmation = false
 
+  private var presenter: TaskItemPresenter {
+    TaskItemPresenter(task: task, kind: kind, lineage: lineage)
+  }
+
   var body: some View {
     HStack(alignment: .top, spacing: .iconLabel) {
-      leadingButton
-      VStack(alignment: .leading, spacing: .rowVertical) {
-        titleRow
-        if let notes = task.notes {
-          TaskNoteView(notes: notes, format: task.format)
-            .lineLimit(2)
+      TaskStateButtonView(presenter: presenter, isHovered: $isHovered)
+      HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
+        PriorityGlyph(priority: task.priority)
+        VStack(alignment: .leading, spacing: .rowVertical) {
+          TaskMarkdownTitle(task: task, isCompleted: presenter.isCompleted, lineLimit: 3)
+          if let notes = task.notes {
+            TaskNoteView(notes: notes, format: task.format)
+              .lineLimit(2)
+          }
+          metadata
+          if let lineage = presenter.displayLineage {
+            TaskLineageRow(lineage: lineage)
+          }
+          Spacer(minLength: 0)
         }
-        primaryMetadata
-        if let lin = lineage, !lin.isEmpty {
-          lineageRow(lin)
-        }
-        Spacer(minLength: 0)
       }
-      trailingButton
+      TaskDeleteButtonView(
+        presenter: presenter, isHovered: isHovered, showConfirmation: $showDeleteConfirmation)
     }
     .padding(.cardPadding)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -43,107 +52,29 @@ struct TaskCardView: View {
     )
     .contentShape(RoundedRectangle.card)
     .onHover { hover in
-      if case .completed = kind { isHovered = hover }
+      if presenter.isCompleted { isHovered = hover }
     }
     .confirmationDialog(
       "Delete this task permanently?", isPresented: $showDeleteConfirmation
     ) {
-      Button("Delete", role: .destructive) {
-        if case .completed(_, let onDelete) = kind { onDelete?() }
-      }
+      Button("Delete", role: .destructive) { presenter.onDelete?() }
       Button("Cancel", role: .cancel) {}
     }
   }
 
+  /// The due date (active tasks) or completed-relative subtitle (completed tasks). The card's
+  /// date format includes the year, distinguishing it from the row's compact form.
   @ViewBuilder
-  private var leadingButton: some View {
-    switch kind {
-    case .active(let onComplete):
-      if let complete = onComplete {
-        Button(action: complete) {
-          Image(systemName: isHovered ? "checkmark.circle" : "circle")
-            .foregroundStyle(Color.accentColor)
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .help(AppLabels.Tooltip.markAsCompleted)
-      }
-    case .completed(let onRestore, _):
-      Button(action: onRestore) {
-        Image(systemName: "checkmark.circle.fill")
-          .foregroundStyle(Color.accentColor)
-      }
-      .buttonStyle(.plain)
-      .help(AppLabels.Tooltip.restore)
-    }
-  }
-
-  private var titleRow: some View {
-    HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
-      if let icon = task.priority.icon {
-        Image(systemName: icon)
-          .foregroundStyle(task.priority.accentColor)
-          .font(.taskTitle)
-      }
-      TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: 3)
-    }
-  }
-
-  @ViewBuilder
-  private var primaryMetadata: some View {
-    switch kind {
-    case .active:
-      if let due = task.dueDate {
-        Text(due, format: .dateTime.month(.abbreviated).day().year())
-          .font(.taskMetadata)
-          .foregroundStyle(due.isUrgentDueDate ? Color.dueUrgent : Color.secondary)
-      }
-    case .completed:
-      Text(completedSubtitle)
+  private var metadata: some View {
+    if let due = presenter.dueDate {
+      Text(due, format: .dateTime.month(.abbreviated).day().year())
+        .font(.taskMetadata)
+        .foregroundStyle(presenter.dueIsUrgent ? Color.dueUrgent : Color.secondary)
+    } else if presenter.isCompleted {
+      Text(presenter.completedSubtitle)
         .font(.taskMetadata)
         .foregroundStyle(.tertiary)
     }
-  }
-
-  private func lineageRow(_ lin: TaskLineage) -> some View {
-    HStack(spacing: .iconLabel) {
-      if let icon = lin.providerIcon {
-        Image(systemName: icon)
-      }
-      if let ctx = lin.contextLabel {
-        if lin.providerIcon != nil {
-          Image(systemName: "chevron.right")
-        }
-        Text(ctx)
-      }
-    }
-    .font(.taskLineage)
-    .foregroundStyle(.tertiary)
-  }
-
-  @ViewBuilder
-  private var trailingButton: some View {
-    if case .completed(_, _?) = kind, isHovered {
-      Button {
-        showDeleteConfirmation = true
-      } label: {
-        Image(systemName: "trash")
-          .foregroundStyle(.secondary)
-      }
-      .buttonStyle(.plain)
-      .help(AppLabels.Tooltip.deletePermanently)
-    }
-  }
-
-  private var isCompleted: Bool {
-    if case .completed = kind { return true }
-    return false
-  }
-
-  private var completedSubtitle: String {
-    task.completedAt.map {
-      RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
-    } ?? "Unknown date"
   }
 }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskDeleteButtonView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskDeleteButtonView.swift
@@ -1,0 +1,37 @@
+//
+//  TaskDeleteButtonView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The trailing permanent-delete control shared by ``TaskRowView`` and ``TaskCardView``.
+///
+/// Renders for a completed task on a writable provider, revealing on hover; requesting deletion
+/// sets `showConfirmation`, which the host view surfaces via its confirmation dialog. Renders
+/// nothing for tasks that cannot be deleted.
+///
+/// When deletable, the slot keeps its layout footprint at all times and toggles only opacity and
+/// hit-testing on hover, so the surrounding title never reflows as the button appears.
+struct TaskDeleteButtonView: View {
+
+  let presenter: TaskItemPresenter
+  let isHovered: Bool
+  @Binding var showConfirmation: Bool
+
+  var body: some View {
+    if presenter.canDelete {
+      Button {
+        showConfirmation = true
+      } label: {
+        Image(systemName: "trash")
+          .foregroundStyle(.secondary)
+      }
+      .buttonStyle(.plain)
+      .help(AppLabels.Tooltip.deletePermanently)
+      .opacity(isHovered ? 1 : 0)
+      .allowsHitTesting(isHovered)
+      .accessibilityHidden(!isHovered)
+    }
+  }
+}

--- a/app/Taskmato/Views/Tasks/Components/TaskItemPresenter.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskItemPresenter.swift
@@ -1,0 +1,90 @@
+//
+//  TaskItemPresenter.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Derives the display values and action affordances shared by ``TaskRowView`` and
+/// ``TaskCardView`` from a task, its ``TaskItemKind``, and optional ``TaskLineage``.
+///
+/// The presenter holds the logic both views would otherwise duplicate — completed-state
+/// detection, due-date urgency, the completed subtitle, the lineage-visibility gate, and the
+/// kind-derived complete/restore/delete affordances — leaving the views as layout-only shells.
+/// It exposes plain values (no SwiftUI `View` types), so its rules are unit-testable directly.
+struct TaskItemPresenter {
+
+  /// The task being presented.
+  let task: TaskItem
+  /// Whether the task is active or completed, carrying the relevant action closures.
+  let kind: TaskItemKind
+  /// The task's provenance, shown only in cross-provider flat modes (Today, search).
+  let lineage: TaskLineage?
+
+  /// - Parameters:
+  ///   - task: The task being presented.
+  ///   - kind: The active/completed kind and its action closures.
+  ///   - lineage: The task's provenance, or `nil` when not in a flat cross-provider mode.
+  init(task: TaskItem, kind: TaskItemKind, lineage: TaskLineage? = nil) {
+    self.task = task
+    self.kind = kind
+    self.lineage = lineage
+  }
+
+  /// `true` when the task is completed.
+  var isCompleted: Bool {
+    if case .completed = kind { return true }
+    return false
+  }
+
+  // MARK: - Action affordances
+
+  /// The complete action, present only for an active task whose provider supports completion.
+  var onComplete: (() -> Void)? {
+    if case .active(let onComplete) = kind { return onComplete }
+    return nil
+  }
+
+  /// The restore action, present for any completed task.
+  var onRestore: (() -> Void)? {
+    if case .completed(let onRestore, _) = kind { return onRestore }
+    return nil
+  }
+
+  /// The permanent-delete action, present for a completed task on a writable provider.
+  var onDelete: (() -> Void)? {
+    if case .completed(_, let onDelete) = kind { return onDelete }
+    return nil
+  }
+
+  /// Whether the leading control is a hover-toggling completion circle (active + completable).
+  var showsCompletionToggle: Bool { onComplete != nil }
+
+  /// Whether the leading control is a filled restore circle (any completed task).
+  var showsRestore: Bool { isCompleted }
+
+  /// Whether a trailing permanent-delete control should be offered.
+  var canDelete: Bool { onDelete != nil }
+
+  // MARK: - Metadata
+
+  /// The due date to display, or `nil` — suppressed for completed tasks, which show the
+  /// completed subtitle instead.
+  var dueDate: Date? { isCompleted ? nil : task.dueDate }
+
+  /// `true` when the due date is today or already past.
+  var dueIsUrgent: Bool { task.dueDate?.isUrgentDueDate ?? false }
+
+  /// The lineage to display, or `nil` when there is nothing meaningful to show.
+  var displayLineage: TaskLineage? {
+    guard let lineage, !lineage.isEmpty else { return nil }
+    return lineage
+  }
+
+  /// A relative description of when the task was completed, e.g. "2 days ago".
+  var completedSubtitle: String {
+    task.completedAt.map {
+      RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
+    } ?? "Unknown date"
+  }
+}

--- a/app/Taskmato/Views/Tasks/Components/TaskLineageRow.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLineageRow.swift
@@ -1,0 +1,32 @@
+//
+//  TaskLineageRow.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The provenance breadcrumb shared by ``TaskRowView`` and ``TaskCardView``.
+///
+/// Shows the provider icon (when multiple providers are enabled) followed by the most specific
+/// context label, separated by a chevron. Host views gate visibility on
+/// ``TaskItemPresenter/displayLineage`` so this view always has something to show.
+struct TaskLineageRow: View {
+
+  let lineage: TaskLineage
+
+  var body: some View {
+    HStack(spacing: .iconLabel) {
+      if let icon = lineage.providerIcon {
+        Image(systemName: icon)
+      }
+      if let context = lineage.contextLabel {
+        if lineage.providerIcon != nil {
+          Image(systemName: "chevron.right")
+        }
+        Text(context)
+      }
+    }
+    .font(.taskLineage)
+    .foregroundStyle(.tertiary)
+  }
+}

--- a/app/Taskmato/Views/Tasks/Components/TaskMarkdownTitle.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskMarkdownTitle.swift
@@ -7,17 +7,19 @@ import SwiftUI
 
 /// Renders a task title with inline-only markdown when `format` is `.markdown`, or as plain text.
 ///
-/// Used in task rows and cards wherever the title appears. Pass `isCompleted` to switch to
-/// secondary foreground color; use `lineLimit` to cap truncation per layout context.
+/// Used wherever a task title appears — composed into ``TaskTitleLabel`` alongside the priority
+/// glyph. Pass `isCompleted` to switch to secondary foreground color, `lineLimit` to cap
+/// truncation, and `font` to match the surrounding surface (defaults to ``Font/taskTitle``).
 struct TaskMarkdownTitle: View {
 
   let task: TaskItem
   var isCompleted: Bool = false
   var lineLimit: Int = 2
+  var font: Font = .taskTitle
 
   var body: some View {
     Text(task.markdownTitle)
-      .font(.taskTitle)
+      .font(font)
       .foregroundStyle(isCompleted ? .secondary : .primary)
       .lineLimit(lineLimit)
       .frame(maxWidth: .infinity, alignment: .leading)

--- a/app/Taskmato/Views/Tasks/Components/TaskPriority+Styling.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskPriority+Styling.swift
@@ -8,10 +8,16 @@ import SwiftUI
 extension TaskPriority {
 
   /// The accent color used to tint priority icons in task views.
+  ///
+  /// Tint completes the glyph-distinct `icon` mapping: `highest` gets its own emphatic tint,
+  /// the elevated band shares `priorityHigh`, `low` is neutral, and `lowest` dims to
+  /// `.secondary` so it reads below `low` while still showing its shared glyph.
   var accentColor: Color {
     switch self {
-    case .highest, .high, .medium: return .priorityHigh
-    case .low, .lowest, .none: return .priorityNeutral
+    case .highest: return .priorityHighest
+    case .high, .medium: return .priorityHigh
+    case .low, .none: return .priorityNeutral
+    case .lowest: return .secondary
     }
   }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskRowView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskRowView.swift
@@ -9,7 +9,8 @@ import SwiftUI
 /// title, notes, primary metadata, and optional lineage indicator.
 ///
 /// Use ``TaskItemKind`` to distinguish active and completed tasks. Pass `lineage` when the
-/// picker is in cross-provider flat mode (Today or search) to show the task's origin.
+/// picker is in cross-provider flat mode (Today or search) to show the task's origin. All
+/// non-layout logic lives in ``TaskItemPresenter``; this view only arranges the slots.
 struct TaskRowView: View {
 
   let task: TaskItem
@@ -19,124 +20,53 @@ struct TaskRowView: View {
   @State private var isHovered = false
   @State private var showDeleteConfirmation = false
 
+  private var presenter: TaskItemPresenter {
+    TaskItemPresenter(task: task, kind: kind, lineage: lineage)
+  }
+
   var body: some View {
     HStack(alignment: .top, spacing: .contentGap) {
-      leadingButton
-      VStack(alignment: .leading, spacing: .stackTight) {
-        titleRow
-        if let notes = task.notes {
-          TaskNoteView(notes: notes, format: task.format)
-        }
-        primaryMetadata
-        if let lin = lineage, !lin.isEmpty {
-          lineageRow(lin)
+      TaskStateButtonView(presenter: presenter, isHovered: $isHovered)
+      HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
+        PriorityGlyph(priority: task.priority)
+        VStack(alignment: .leading, spacing: .stackTight) {
+          TaskMarkdownTitle(task: task, isCompleted: presenter.isCompleted, lineLimit: 2)
+          if let notes = task.notes {
+            TaskNoteView(notes: notes, format: task.format)
+          }
+          metadata
+          if let lineage = presenter.displayLineage {
+            TaskLineageRow(lineage: lineage)
+          }
         }
       }
-      trailingButton
+      TaskDeleteButtonView(
+        presenter: presenter, isHovered: isHovered, showConfirmation: $showDeleteConfirmation)
     }
     .padding(.vertical, .rowVertical)
     .contentShape(Rectangle())
     .onHover { hover in
-      if case .completed = kind { isHovered = hover }
+      if presenter.isCompleted { isHovered = hover }
     }
     .confirmationDialog(
       "Delete this task permanently?", isPresented: $showDeleteConfirmation
     ) {
-      Button("Delete", role: .destructive) {
-        if case .completed(_, let onDelete) = kind { onDelete?() }
-      }
+      Button("Delete", role: .destructive) { presenter.onDelete?() }
       Button("Cancel", role: .cancel) {}
     }
   }
 
+  /// The due date (active tasks) or completed-relative subtitle (completed tasks).
   @ViewBuilder
-  private var leadingButton: some View {
-    switch kind {
-    case .active(let onComplete):
-      if let complete = onComplete {
-        Button(action: complete) {
-          Image(systemName: isHovered ? "checkmark.circle" : "circle")
-            .foregroundStyle(Color.accentColor)
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .help(AppLabels.Tooltip.markAsCompleted)
-      }
-    case .completed(let onRestore, _):
-      Button(action: onRestore) {
-        Image(systemName: "checkmark.circle.fill")
-          .foregroundStyle(Color.accentColor)
-      }
-      .buttonStyle(.plain)
-      .help(AppLabels.Tooltip.restore)
-    }
-  }
-
-  private var titleRow: some View {
-    HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
-      if let icon = task.priority.icon {
-        Image(systemName: icon)
-          .foregroundStyle(task.priority.accentColor)
-          .font(.taskTitle)
-      }
-      TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: 2)
-    }
-  }
-
-  @ViewBuilder
-  private var primaryMetadata: some View {
-    switch kind {
-    case .active:
-      if let due = task.dueDate {
-        Text(due, format: .dateTime.month(.abbreviated).day())
-          .font(.taskMetadata)
-          .foregroundStyle(due.isUrgentDueDate ? Color.dueUrgent : Color.secondary)
-      }
-    case .completed:
-      Text(completedSubtitle)
+  private var metadata: some View {
+    if let due = presenter.dueDate {
+      Text(due, format: .dateTime.month(.abbreviated).day())
+        .font(.taskMetadata)
+        .foregroundStyle(presenter.dueIsUrgent ? Color.dueUrgent : Color.secondary)
+    } else if presenter.isCompleted {
+      Text(presenter.completedSubtitle)
         .font(.taskMetadata)
         .foregroundStyle(.tertiary)
     }
-  }
-
-  private func lineageRow(_ lin: TaskLineage) -> some View {
-    HStack(spacing: .iconLabel) {
-      if let icon = lin.providerIcon {
-        Image(systemName: icon)
-      }
-      if let ctx = lin.contextLabel {
-        if lin.providerIcon != nil {
-          Image(systemName: "chevron.right")
-        }
-        Text(ctx)
-      }
-    }
-    .font(.taskLineage)
-    .foregroundStyle(.tertiary)
-  }
-
-  @ViewBuilder
-  private var trailingButton: some View {
-    if case .completed(_, _?) = kind, isHovered {
-      Button {
-        showDeleteConfirmation = true
-      } label: {
-        Image(systemName: "trash")
-          .foregroundStyle(.secondary)
-      }
-      .buttonStyle(.plain)
-      .help(AppLabels.Tooltip.deletePermanently)
-    }
-  }
-
-  private var isCompleted: Bool {
-    if case .completed = kind { return true }
-    return false
-  }
-
-  private var completedSubtitle: String {
-    task.completedAt.map {
-      RelativeDateTimeFormatter().localizedString(for: $0, relativeTo: Date())
-    } ?? "Unknown date"
   }
 }

--- a/app/Taskmato/Views/Tasks/Components/TaskStateButtonView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskStateButtonView.swift
@@ -1,0 +1,36 @@
+//
+//  TaskStateButtonView.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The leading state control shared by ``TaskRowView`` and ``TaskCardView``.
+///
+/// Renders a filled restore circle for completed tasks, or a hover-toggling completion circle
+/// for active tasks whose provider supports completion. Renders nothing for a read-only active
+/// task. Binds `isHovered` so the active completion glyph reacts to pointer hover.
+struct TaskStateButtonView: View {
+
+  let presenter: TaskItemPresenter
+  @Binding var isHovered: Bool
+
+  var body: some View {
+    if presenter.showsRestore, let onRestore = presenter.onRestore {
+      Button(action: onRestore) {
+        Image(systemName: "checkmark.circle.fill")
+          .foregroundStyle(Color.accentColor)
+      }
+      .buttonStyle(.plain)
+      .help(AppLabels.Tooltip.restore)
+    } else if let onComplete = presenter.onComplete {
+      Button(action: onComplete) {
+        Image(systemName: isHovered ? "checkmark.circle" : "circle")
+          .foregroundStyle(Color.accentColor)
+      }
+      .buttonStyle(.plain)
+      .onHover { isHovered = $0 }
+      .help(AppLabels.Tooltip.markAsCompleted)
+    }
+  }
+}

--- a/app/Taskmato/Views/Tasks/Components/TaskTitleLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskTitleLabel.swift
@@ -1,0 +1,50 @@
+//
+//  TaskTitleLabel.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The canonical "priority glyph + title" rendering shared by every task-naming surface.
+///
+/// Prefixes the task's coloured priority ``TaskPriority/icon`` (omitted for `.none`) before its
+/// markdown title so priority reads identically in list rows, cards, the timer strip, the
+/// popover companion, and the active-task view. `font` scales both glyph and title to the host
+/// surface; `isCompleted` dims the title; `lineLimit` caps truncation.
+///
+/// This view is intentionally non-interactive — it carries no button or gesture — so surfaces
+/// that make the whole task line tappable (the timer strip, the popover) can wrap it in a
+/// `Button` without nested-control conflicts.
+struct TaskTitleLabel: View {
+
+  let task: TaskItem
+  var isCompleted: Bool = false
+  var lineLimit: Int = 2
+  var font: Font = .taskTitle
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: .iconLabel) {
+      PriorityGlyph(priority: task.priority, font: font)
+      TaskMarkdownTitle(task: task, isCompleted: isCompleted, lineLimit: lineLimit, font: font)
+    }
+  }
+}
+
+#Preview {
+  VStack(alignment: .leading, spacing: .contentGap) {
+    ForEach(TaskPriority.allCases.reversed(), id: \.self) { priority in
+      TaskTitleLabel(
+        task: TaskItem(
+          id: TaskRef(providerID: "local", nativeID: "\(priority.rawValue)"),
+          title: "Priority \(priority)",
+          notes: nil,
+          format: .plainText,
+          priority: priority,
+          dueDate: nil
+        )
+      )
+    }
+  }
+  .padding()
+  .frame(width: 240)
+}

--- a/app/TaskmatoTests/TaskItemPresenterTests.swift
+++ b/app/TaskmatoTests/TaskItemPresenterTests.swift
@@ -1,0 +1,172 @@
+//
+//  TaskItemPresenterTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+@Suite("TaskItemPresenter")
+struct TaskItemPresenterTests {
+
+  /// Builds a task with only the fields the presenter reads, defaulting the rest.
+  private func makeTask(
+    priority: TaskPriority = .none,
+    dueDate: Date? = nil,
+    completedAt: Date? = nil
+  ) -> TaskItem {
+    TaskItem(
+      id: TaskRef(providerID: "local", nativeID: "1"),
+      title: "Sample task",
+      notes: nil,
+      format: .plainText,
+      priority: priority,
+      dueDate: dueDate,
+      scheduledDate: nil,
+      startDate: nil,
+      list: nil,
+      section: nil,
+      sourceURL: nil,
+      completedAt: completedAt,
+      createdAt: nil
+    )
+  }
+
+  // MARK: - Kind
+
+  @Test func activeKindIsNotCompleted() {
+    let presenter = TaskItemPresenter(task: makeTask(), kind: .active(onComplete: {}))
+    #expect(!presenter.isCompleted)
+    #expect(!presenter.showsRestore)
+  }
+
+  @Test func completedKindIsCompleted() {
+    let presenter = TaskItemPresenter(
+      task: makeTask(), kind: .completed(onRestore: {}, onDelete: nil))
+    #expect(presenter.isCompleted)
+    #expect(presenter.showsRestore)
+  }
+
+  // MARK: - Action affordances
+
+  @Test func activeExposesCompletionToggleWhenCompletable() {
+    var completed = false
+    let presenter = TaskItemPresenter(
+      task: makeTask(), kind: .active(onComplete: { completed = true }))
+    #expect(presenter.showsCompletionToggle)
+    #expect(presenter.onRestore == nil)
+    #expect(presenter.onDelete == nil)
+    presenter.onComplete?()
+    #expect(completed)
+  }
+
+  @Test func readOnlyActiveHasNoCompletionToggle() {
+    let presenter = TaskItemPresenter(task: makeTask(), kind: .active(onComplete: nil))
+    #expect(!presenter.showsCompletionToggle)
+    #expect(presenter.onComplete == nil)
+  }
+
+  @Test func completedExposesRestoreAndDelete() {
+    var restored = false
+    var deleted = false
+    let presenter = TaskItemPresenter(
+      task: makeTask(),
+      kind: .completed(onRestore: { restored = true }, onDelete: { deleted = true }))
+    #expect(presenter.canDelete)
+    #expect(!presenter.showsCompletionToggle)
+    presenter.onRestore?()
+    presenter.onDelete?()
+    #expect(restored)
+    #expect(deleted)
+  }
+
+  @Test func completedWithoutDeleteHandlerCannotDelete() {
+    let presenter = TaskItemPresenter(
+      task: makeTask(), kind: .completed(onRestore: {}, onDelete: nil))
+    #expect(!presenter.canDelete)
+    #expect(presenter.onDelete == nil)
+  }
+
+  // MARK: - Due date
+
+  @Test func dueDateSuppressedWhenCompleted() {
+    let due = Date(timeIntervalSinceNow: 3600)
+    let presenter = TaskItemPresenter(
+      task: makeTask(dueDate: due, completedAt: Date()),
+      kind: .completed(onRestore: {}, onDelete: nil))
+    #expect(presenter.dueDate == nil)
+  }
+
+  @Test func dueDateShownWhenActive() {
+    let due = Date(timeIntervalSinceNow: 3600)
+    let presenter = TaskItemPresenter(
+      task: makeTask(dueDate: due), kind: .active(onComplete: {}))
+    #expect(presenter.dueDate == due)
+  }
+
+  @Test func urgencyReflectsTodayAndPast() {
+    let past = Date(timeIntervalSinceNow: -86_400)
+    let today = Date()
+    let future = Date(timeIntervalSinceNow: 7 * 86_400)
+
+    #expect(
+      TaskItemPresenter(task: makeTask(dueDate: past), kind: .active(onComplete: {})).dueIsUrgent)
+    #expect(
+      TaskItemPresenter(task: makeTask(dueDate: today), kind: .active(onComplete: {})).dueIsUrgent)
+    #expect(
+      !TaskItemPresenter(task: makeTask(dueDate: future), kind: .active(onComplete: {}))
+        .dueIsUrgent)
+    #expect(
+      !TaskItemPresenter(task: makeTask(dueDate: nil), kind: .active(onComplete: {})).dueIsUrgent)
+  }
+
+  // MARK: - Lineage
+
+  @Test func displayLineageNilWhenAbsent() {
+    let presenter = TaskItemPresenter(task: makeTask(), kind: .active(onComplete: {}))
+    #expect(presenter.displayLineage == nil)
+  }
+
+  @Test func displayLineageNilWhenEmpty() {
+    let empty = TaskLineage(providerIcon: nil, listName: nil, sectionName: nil)
+    let presenter = TaskItemPresenter(
+      task: makeTask(), kind: .active(onComplete: {}), lineage: empty)
+    #expect(presenter.displayLineage == nil)
+  }
+
+  @Test func displayLineagePassesThroughWhenPopulated() {
+    let lineage = TaskLineage(providerIcon: "tray", listName: "Work", sectionName: nil)
+    let presenter = TaskItemPresenter(
+      task: makeTask(), kind: .active(onComplete: {}), lineage: lineage)
+    #expect(presenter.displayLineage?.contextLabel == "Work")
+  }
+
+  // MARK: - Completed subtitle
+
+  @Test func completedSubtitleFallsBackWhenDateMissing() {
+    let presenter = TaskItemPresenter(
+      task: makeTask(completedAt: nil), kind: .completed(onRestore: {}, onDelete: nil))
+    #expect(presenter.completedSubtitle == "Unknown date")
+  }
+
+  @Test func completedSubtitleFormatsRelativeDate() {
+    let presenter = TaskItemPresenter(
+      task: makeTask(completedAt: Date(timeIntervalSinceNow: -2 * 86_400)),
+      kind: .completed(onRestore: {}, onDelete: nil))
+    #expect(presenter.completedSubtitle != "Unknown date")
+    #expect(!presenter.completedSubtitle.isEmpty)
+  }
+
+  // MARK: - Priority glyph mapping (canonical across every surface)
+
+  @Test func priorityIconIsGlyphDistinctAcrossLevels() {
+    #expect(TaskPriority.none.icon == nil)
+    #expect(TaskPriority.lowest.icon == "exclamationmark")
+    #expect(TaskPriority.low.icon == "exclamationmark")
+    #expect(TaskPriority.medium.icon == "exclamationmark.2")
+    #expect(TaskPriority.high.icon == "exclamationmark.3")
+    #expect(TaskPriority.highest.icon == "exclamationmark.triangle.fill")
+  }
+}

--- a/docs/reference/styling.md
+++ b/docs/reference/styling.md
@@ -32,8 +32,9 @@ are used directly — they are not re-exported as tokens.
 | Token | Value | Where it's appropriate |
 | --- | --- | --- |
 | `dueUrgent` | `.red` | Due date at or past its urgency threshold |
-| `priorityHigh` | `.orange` | Accent for elevated-priority tasks (medium and above) |
-| `priorityNeutral` | `.primary` | Default tint for tasks without elevated priority |
+| `priorityHighest` | `.red` | Accent for the single highest-priority level, distinct from the elevated band |
+| `priorityHigh` | `.orange` | Accent for elevated-priority tasks (medium and high) |
+| `priorityNeutral` | `.primary` | Default tint for tasks without elevated priority (low) |
 | `timerRingTrack` | `.secondary.opacity(.muted)` | Unfilled portion of the circular timer ring |
 | `cardSurface` | `.secondary.opacity(.subtle)` | Fill behind a card to lift it off the background |
 | `favoriteStar` | `.yellow` | Marker on a provider's default (favorite) list |
@@ -41,7 +42,8 @@ are used directly — they are not re-exported as tokens.
 | `statusSuccess` | `.green` | Success or authorized-state indicator |
 | `chartPalette` | `[.blue, .green, .orange, .purple, .red, .teal, .indigo, .pink]` | Ordered colors for chart slices/series |
 
-`statusError` shares the `.red` value with `dueUrgent` — same color, distinct semantics.
+`statusError`, `dueUrgent`, and `priorityHighest` share the `.red` value — same color, distinct
+semantics. They never collide spatially (error banner vs. due-date text vs. priority glyph).
 
 ## Spacing
 


### PR DESCRIPTION
## Summary

Deduplicate `TaskRowView` and `TaskCardView` behind a shared `TaskItemPresenter` and a canonical priority-title seam, then fold in two view-layer polish fixes surfaced while reviewing the result.

## Linked issue

Closes #406

## Motivation

`TaskRowView` and `TaskCardView` shared ~70% of their bodies (leading/trailing buttons, title row, metadata, lineage, completed-subtitle, and the delete confirmation state machine). Any change had to be made and tested in both. Separately, priority was rendered with two disagreeing encodings across surfaces (an SF Symbol `icon` in rows/cards vs. a text `mark` on the timer/active surfaces) — they even disagreed on the mapping (icon showed for low; the mark did not; the icon merged high+highest, the mark split them). This PR centralises the row/card logic and establishes the single canonical priority-title rendering the timer-surface reconciliation (#468) will adopt.

## Changes

- **`TaskItemPresenter`** (new) — holds the display logic both views duplicated (completed-state, due-date urgency, completed subtitle, lineage-visibility gate, kind-derived complete/restore/delete affordances). Plain values, no `View` types, so its rules are unit-tested directly.
- **`TaskTitleLabel` + `PriorityGlyph`** (new) — the canonical "priority glyph + markdown title" seam shared across task-naming surfaces; deliberately non-interactive so tappable surfaces (timer strip, popover) can wrap it in a `Button` without nested-control conflicts.
- **Refined 5-level priority mapping** — `TaskPriority.icon` is now glyph-distinct across all five levels (`highest` → `exclamationmark.triangle.fill`), with a new `priorityHighest` design token; `accentColor` gains `highest` and dims `lowest`. `docs/reference/styling.md` updated.
- **`TaskRowView` / `TaskCardView`** — reduced to layout-only shells over the presenter and shared slot views (`TaskStateButtonView`, `TaskDeleteButtonView`, `TaskLineageRow`). Public signatures unchanged, so `TaskDetailView` (the only consumer) is untouched.
- **Alignment polish** — the priority indicator now hangs as a leading marker so a task's title, wrapped lines, notes, and due date share one left edge (previously notes/due sat under the mark, misaligned with the title).
- **Hover-reflow fix** — the completed-task delete button reserves its layout slot and toggles only opacity/hit-testing (and drops from the a11y tree when hidden), so the title no longer rewraps when the trash icon appears on hover.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

`make sync-version && make lint && make format-check` clean; `make build` succeeds; new `TaskItemPresenterTests` (16 cases) pass. Row/card layout, the hanging-marker alignment, and the hover-reflow fix were manually verified in the running app.

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- `TaskPriority.mark` and `activeTaskDisplayTitle(_:)` intentionally remain — they are the losing text-mark idiom the follow-up #468 will delete when the timer/popover/active surfaces adopt `TaskTitleLabel`.
- One deliberate visible change to weigh: `highest` priority now tints `.red` (shared value with `dueUrgent`/`statusError`, distinct semantics, never colocated). Happy to drop it to bold-orange if preferred.
- Deletable completed rows/cards now carry a small permanently-reserved trailing inset (the trash gutter) — the standard trade to eliminate hover jitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)