### PR TITLE
fix(commands): gate task View menu items off-tab and restore sidebar toggle

### DIFF
--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -120,7 +120,7 @@ struct TaskmatoApp: App {
 /// Menu commands and keyboard shortcuts for the main application window.
 struct TaskmatoCommands: Commands {
 
-  @FocusedValue(\.destination) private var destination
+  @FocusedValue(\.taskViewActive) private var taskViewActive
   @FocusedValue(\.focusSearch) private var focusSearch
   @FocusedValue(\.addTask) private var addTask
   @FocusedValue(\.toggleCompleted) private var toggleCompleted
@@ -138,14 +138,19 @@ struct TaskmatoCommands: Commands {
   /// The provider registry used to populate the File → Add Provider submenu.
   var registry: ProviderRegistry
 
-  /// Whether the focused window is showing a task-scope destination (Today or a list).
+  /// Whether the task surface currently owns the focused scene.
   ///
-  /// Read from the focused value so task-scope commands gate on what the window shows,
-  /// which absorbs the #426 pattern where Layout/Sort stayed enabled off the task surface.
+  /// Gates task-scope View menu commands (Layout, Sort By) on the presence of the
+  /// ``FocusedValues/taskViewActive`` marker published by ``TaskDetailView``. Presence-based
+  /// gating — the same mechanism Show/Hide Completed uses — grays these out reliably when the
+  /// task surface leaves the scene, resolving #426 where value-comparison gating went stale.
   private var isTaskScope: Bool {
-    if case .today = destination { return true }
-    if case .list = destination { return true }
-    return false
+    taskViewActive == true
+  }
+
+  /// The sidebar toggle's title, reflecting the current column visibility.
+  private var sidebarToggleTitle: String {
+    nav.sidebarVisible ? AppLabels.View.hideSidebar.title : AppLabels.View.showSidebar.title
   }
 
   /// Whether the current navigation destination is any Stats scope.
@@ -188,9 +193,11 @@ struct TaskmatoCommands: Commands {
         .keyboardShortcut("f")
         .disabled(focusSearch == nil)
     }
-    // View → destination navigation (⌘1/2/3), layout, completed toggle (⌘⇧C), Sort By.
-    // The system Show/Hide Sidebar command (⌃⌘S) is restored automatically now that a
-    // single NavigationSplitView sits at the window root, so no custom toggle is needed.
+    // View → destination navigation (⌘1/2/3), layout, completed toggle (⌘⇧C), Sort By, and
+    // the sidebar toggle (⌃⌘S) last so it sits just above the system Enter Full Screen item.
+    // The main window drives column visibility with its own `nav.sidebarVisible` binding
+    // (persisted to `UserDefaults`), which suppresses SwiftUI's automatic sidebar command, so
+    // the toggle is provided explicitly here against that state.
     CommandGroup(after: .sidebar) {
       Divider()
       Button {
@@ -212,13 +219,27 @@ struct TaskmatoCommands: Commands {
       }
       .keyboardShortcut("3")
       Divider()
-      Picker("Layout", selection: $settings.taskPickerLayout) {
+      // Layout uses Toggles, not a Picker: a Toggle is an action item, so AppKit re-validates
+      // it on every menu open and `.disabled` greys it live off the task surface (a `Picker`
+      // container froze its state at build time — the root cause of #426). The Toggle also
+      // renders the on-state checkmark alongside the label glyph, matching the Reminders app.
+      Toggle(
+        isOn: Binding(
+          get: { settings.taskPickerLayout == .list },
+          set: { if $0 { settings.taskPickerLayout = .list } }
+        )
+      ) {
         Label(AppLabels.View.listLayout.title, systemImage: AppLabels.View.listLayout.systemImage)
-          .tag(TaskPickerLayout.list)
-        Label(AppLabels.View.gridLayout.title, systemImage: AppLabels.View.gridLayout.systemImage)
-          .tag(TaskPickerLayout.grid)
       }
-      .pickerStyle(.inline)
+      .disabled(!isTaskScope)
+      Toggle(
+        isOn: Binding(
+          get: { settings.taskPickerLayout == .grid },
+          set: { if $0 { settings.taskPickerLayout = .grid } }
+        )
+      ) {
+        Label(AppLabels.View.gridLayout.title, systemImage: AppLabels.View.gridLayout.systemImage)
+      }
       .disabled(!isTaskScope)
       Divider()
       Button {
@@ -232,6 +253,9 @@ struct TaskmatoCommands: Commands {
       .keyboardShortcut("c", modifiers: [.command, .shift])
       .disabled(toggleCompleted == nil)
       Divider()
+      // Each sort option is disabled individually: as action items they re-validate on menu
+      // open and grey live off the task surface, whereas `.disabled` on the parent `Menu`
+      // container alone did not update (see the Layout note above, #426).
       Menu {
         ForEach(TaskSortField.allCases, id: \.self) { field in
           Button {
@@ -242,6 +266,7 @@ struct TaskmatoCommands: Commands {
               field.displayName,
               systemImage: settings.taskSortField == field ? "checkmark" : "")
           }
+          .disabled(!isTaskScope)
         }
         Divider()
         Button {
@@ -251,6 +276,7 @@ struct TaskmatoCommands: Commands {
             settings.taskSortField.ascendingLabel,
             systemImage: settings.taskSortDirection == .ascending ? "checkmark" : "")
         }
+        .disabled(!isTaskScope)
         Button {
           settings.taskSortDirection = .descending
         } label: {
@@ -258,10 +284,18 @@ struct TaskmatoCommands: Commands {
             settings.taskSortField.descendingLabel,
             systemImage: settings.taskSortDirection == .descending ? "checkmark" : "")
         }
+        .disabled(!isTaskScope)
       } label: {
         Label(AppLabels.View.sort.title, systemImage: AppLabels.View.sort.systemImage)
       }
       .disabled(!isTaskScope)
+      Divider()
+      Button {
+        nav.sidebarVisible.toggle()
+      } label: {
+        Label(sidebarToggleTitle, systemImage: AppLabels.View.showSidebar.systemImage)
+      }
+      .keyboardShortcut("s", modifiers: [.control, .command])
     }
     // Timer menu — Start/Pause/Resume (⌘⏎), Skip Phase (⌘K), Stop (⌘.).
     CommandMenu("Timer") {

--- a/app/Taskmato/Views/App/AppFocusedValues.swift
+++ b/app/Taskmato/Views/App/AppFocusedValues.swift
@@ -43,8 +43,8 @@ private struct TimerStopKey: FocusedValueKey {
   typealias Value = () -> Void
 }
 
-private struct DestinationKey: FocusedValueKey {
-  typealias Value = AppDestination
+private struct TaskViewActiveKey: FocusedValueKey {
+  typealias Value = Bool
 }
 
 // MARK: - FocusedValues extensions
@@ -105,9 +105,13 @@ extension FocusedValues {
     set { self[TimerStopKey.self] = newValue }
   }
 
-  /// The currently selected destination in the main window. Published by ``MainWindowView``.
-  var destination: AppDestination? {
-    get { self[DestinationKey.self] }
-    set { self[DestinationKey.self] = newValue }
+  /// Marks that the task surface is the focused scene. Published by ``TaskDetailView``.
+  ///
+  /// Present (`true`) only while the Tasks destination is shown, so task-scope View menu
+  /// commands (Layout, Sort By) gate on its presence the same way Show/Hide Completed gates
+  /// on ``toggleCompleted`` — the value disappears when the task surface leaves the scene.
+  var taskViewActive: Bool? {
+    get { self[TaskViewActiveKey.self] }
+    set { self[TaskViewActiveKey.self] = newValue }
   }
 }

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -68,7 +68,6 @@ struct MainWindowView: View {
       .animation(.default, value: errorPresenter.current)
     }
     .frame(minWidth: 640, minHeight: 400)
-    .focusedSceneValue(\.destination, nav.destination)
     .focusedSceneValue(\.timerToggle, timerToggleAction)
     .focusedSceneValue(\.timerToggleTitle, timerToggleTitleValue)
     .focusedSceneValue(\.timerSkip, { presenter.skip() })

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -137,6 +137,7 @@ struct TaskDetailView: View {
           sortMenu
         }
       }
+      .focusedSceneValue(\.taskViewActive, true)
       .focusedSceneValue(\.focusSearch, { isSearchFocused = true })
       .focusedSceneValue(\.addTask, writableProvider != nil ? { isAddingTask = true } : nil)
       .focusedSceneValue(


### PR DESCRIPTION
## Summary

Layout and Sort By in the View menu stayed fully enabled on the Timer and Stats tabs, letting the user change settings that have no visible effect off the Tasks surface. They now grey out whenever the Tasks tab is not active, matching Show/Hide Completed. Along the way this also restores the Show/Hide Sidebar command, which had gone missing, and gives the Layout items the Reminders-style checkmark + glyph.

## Linked issue

Closes #426

## Root cause

`Layout` was a `Picker` and `Sort By` a submenu `Menu`. macOS re-runs menu-item validation on every menu open only for **action items** (Buttons/Toggles); container items like `Picker`/`Menu` capture their `.disabled(...)` state at build time and are never re-validated, so they stayed frozen enabled. (The gate value was also read from a `\.destination` focused value that didn't drive re-evaluation.)

Separately, the main window drives `NavigationSplitView` column visibility with its own `nav.sidebarVisible` binding (persisted to `UserDefaults`), which suppresses SwiftUI's automatic Show/Hide Sidebar command — so that command had disappeared from the View menu.

## Fix

- Publish a `taskViewActive` focused value from `TaskDetailView` (present only while the Tasks surface is shown) and gate task-scope commands on it, replacing the `\.destination` value comparison.
- Express Layout as two `Toggle`s and gate each Sort By option `Button` individually, so they are action items that AppKit re-validates on open and grey out reliably off-tab. Toggles also render the on-state checkmark alongside the layout glyph.
- Re-add an explicit Show/Hide Sidebar command (⌃⌘S) bound to `nav.sidebarVisible`, placed just above the system Enter Full Screen item, with the sidebar glyph.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- No automated regression test: these are menu-bar `Commands` whose disabled state depends on AppKit menu-open validation, which isn't exercisable from Swift Testing. Verified manually in a running build (Layout/Sort grey out on Timer/Stats; sidebar toggle works and persists).
- Full-screen support was explored (the window's `Window`+`MenuBarExtra` combo leaves Enter Full Screen disabled) but inserting `.fullScreenPrimary` into the window `collectionBehavior` did not enable it, so that work was dropped from this PR; it would need a deeper change (e.g. `WindowGroup`).
