### PR TITLE
feat(ui): timer strip, task source, and Browse Tasks refinements

### DIFF
--- a/app/Taskmato/Views/App/MainNavigation.swift
+++ b/app/Taskmato/Views/App/MainNavigation.swift
@@ -158,6 +158,12 @@ final class MainNavigation {
     destination = .timer
   }
 
+  /// Opens the main window and switches to the last task-scope destination, falling back to Today.
+  func showTasksInMainWindow() {
+    openMainWindowAction?()
+    showTasks()
+  }
+
   /// Opens the main window and switches to the Stats destination at the current scope.
   func showStatsInMainWindow() {
     openMainWindowAction?()

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -50,9 +50,7 @@ struct MenuBarPopoverView: View {
         .padding(.horizontal, .sectionGap)
         .padding(.vertical, .contentGap)
       } else {
-        Text(AppLabels.Tooltip.selectTaskFirst)
-          .font(.caption)
-          .foregroundStyle(.secondary)
+        BrowseTasksButton { dismissPopover { nav.showTasksInMainWindow() } }
           .frame(maxWidth: .infinity, alignment: .leading)
           .padding(.horizontal, .sectionGap)
           .padding(.vertical, .contentGap)

--- a/app/Taskmato/Views/Tasks/Components/TaskCompletionButton.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskCompletionButton.swift
@@ -8,10 +8,12 @@ import SwiftUI
 /// The hover-toggling completion control shared by the task picker's rows/cards and the
 /// active-task surfaces.
 ///
-/// Renders an accent-tinted outline circle that previews a checkmark on hover and invokes
-/// ``action`` when clicked. Callers own the completion behavior (in-place completion for the
-/// picker, confirm-then-stop for a live session) and the tooltip text; this view owns only the
-/// glyph, hover, and accessibility so every surface's completion affordance looks identical.
+/// Renders a secondary grey outline circle at rest that greens into a checkmark preview on
+/// hover, and invokes ``action`` when clicked. Resting grey keeps the completion radio from
+/// competing with the accent-tinted timer ring beside it and matches the idiom used by most
+/// task apps. Callers own the completion behavior (in-place completion for the picker,
+/// confirm-then-stop for a live session) and the tooltip text; this view owns only the glyph,
+/// hover, and accessibility so every surface's completion affordance looks identical.
 struct TaskCompletionButton: View {
 
   /// Invoked when the user clicks to complete the task.
@@ -27,7 +29,7 @@ struct TaskCompletionButton: View {
     Button(action: action) {
       Image(systemName: isHovered ? "checkmark.circle" : "circle")
         .font(font)
-        .foregroundStyle(Color.accentColor)
+        .foregroundStyle(isHovered ? Color.statusSuccess : Color.secondary)
     }
     .buttonStyle(.plain)
     .onHover { isHovered = $0 }

--- a/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
@@ -83,7 +83,7 @@ enum AppLabels {
     /// The sort toolbar menu.
     static let sort = AppLabel("Sort", systemImage: "arrow.up.arrow.down")
     /// Opens the task browser from the timer views.
-    static let browseTask = AppLabel("Browse Tasks…", systemImage: "checklist")
+    static let browseTask = AppLabel("Browse Tasks…", systemImage: "list.bullet")
     /// Shows the provider sidebar column.
     static let showSidebar = AppLabel("Show Sidebar", systemImage: "sidebar.left")
     /// Hides the provider sidebar column.

--- a/app/Taskmato/Views/Tasks/Components/TaskSourceBadge.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskSourceBadge.swift
@@ -1,0 +1,57 @@
+//
+//  TaskSourceBadge.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A compact, tappable source tag linking a task back to the app it came from.
+///
+/// Renders the provider's glyph, its name, and a trailing "opens away" arrow as a subtle
+/// rounded chip wrapping a ``Link`` to the task's source URL. Shown only for tasks that carry a
+/// `sourceURL` (Obsidian, Apple Reminders); ad-hoc and Local tasks omit it. The label reads as
+/// provenance ("Obsidian ↗") rather than a command; the full "Open in …" phrasing lives in the
+/// tooltip and VoiceOver label.
+struct TaskSourceBadge: View {
+
+  /// The provider deep link the badge opens.
+  let url: URL
+  /// The provider's display name shown in the chip.
+  let name: String
+  /// The provider's SF Symbol icon.
+  let icon: String
+
+  /// Tracks pointer hover so the chip can brighten as it's targeted.
+  @State private var isHovered = false
+
+  var body: some View {
+    Link(destination: url) {
+      HStack(spacing: .stackTight) {
+        Image(systemName: icon)
+        Text(name)
+        Image(systemName: "arrow.up.forward")
+          .foregroundStyle(.tertiary)
+      }
+      .font(.taskMetadata)
+      .foregroundStyle(isHovered ? .primary : .secondary)
+      .padding(.horizontal, .iconLabel)
+      .padding(.vertical, .stackTight)
+      .background(Color.secondary.opacity(.subtle), in: RoundedRectangle.card)
+    }
+    .buttonStyle(.plain)
+    .onHover { isHovered = $0 }
+    .help("Open in \(name)")
+    .accessibilityLabel("Open in \(name)")
+  }
+}
+
+#Preview {
+  VStack(alignment: .leading, spacing: .sectionGap) {
+    TaskSourceBadge(
+      url: URL(string: "obsidian://open")!, name: "Obsidian", icon: "book.closed")
+    TaskSourceBadge(
+      url: URL(string: "x-apple-reminderkit://")!, name: "Apple Reminders", icon: "checklist")
+  }
+  .padding()
+  .frame(width: 360, alignment: .leading)
+}

--- a/app/Taskmato/Views/Timer/ActiveTaskView.swift
+++ b/app/Taskmato/Views/Timer/ActiveTaskView.swift
@@ -98,7 +98,7 @@ struct ActiveTaskView: View {
 
   /// The title portion of the row: a hanging priority glyph beside a single-line, content-width
   /// title for ``ActiveTaskStyle/compact`` (so the strip's inline countdown can sit snug beside
-  /// it), or the same glyph plus a filling title with notes and source link for
+  /// it), or the same glyph plus a filling title with notes and a ``TaskSourceBadge`` for
   /// ``ActiveTaskStyle/detail``, matching ``TaskRowView``.
   @ViewBuilder
   private func titleBlock(for task: TaskItem) -> some View {
@@ -126,10 +126,8 @@ struct ActiveTaskView: View {
             TaskNoteView(notes: notes, format: task.format)
           }
 
-          if let url = task.sourceURL, let name = registry.provider(for: task.id)?.displayName {
-            Link("Open in \(name)", destination: url)
-              .font(.caption2)
-              .foregroundStyle(.secondary)
+          if let url = task.sourceURL, let provider = registry.provider(for: task.id) {
+            TaskSourceBadge(url: url, name: provider.displayName, icon: provider.icon)
           }
         }
       }

--- a/app/Taskmato/Views/Timer/Components/BrowseTasksButton.swift
+++ b/app/Taskmato/Views/Timer/Components/BrowseTasksButton.swift
@@ -1,0 +1,34 @@
+//
+//  BrowseTasksButton.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A borderless "Browse Tasks…" affordance shown on the timer surfaces when no task is active.
+///
+/// Rendered in place of the active-task row on both the Timer destination and the companion
+/// popover, so the two surfaces stay visually consistent and the dividers bracketing the row
+/// keep a constant position whether or not a task is selected.
+struct BrowseTasksButton: View {
+
+  /// Invoked when the user clicks the button; routes to the task browser.
+  var action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Label(
+        AppLabels.View.browseTask.title,
+        systemImage: AppLabels.View.browseTask.systemImage
+      )
+      .contentShape(.rect)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(.secondary)
+  }
+}
+
+#Preview {
+  BrowseTasksButton {}
+    .padding()
+}

--- a/app/Taskmato/Views/Timer/TimerStripView.swift
+++ b/app/Taskmato/Views/Timer/TimerStripView.swift
@@ -7,14 +7,17 @@ import SwiftUI
 
 /// A compact session bar pinned below the detail column while a session is non-idle.
 ///
-/// Keeps the countdown and core controls visible from any non-Timer destination: a mini
-/// progress ring, the active task, the phase and countdown, and the shared pause/resume ·
-/// skip · stop controls. When a task is active, the phase + countdown sits inline just after
-/// the task title on a single line (`.secondary`); with no active task it stands alone as a
-/// `.primary` line. Clicking the ring, the countdown, or the task title jumps to the Timer
-/// destination; the active task's radio stays a sibling control so completing or clearing
-/// mid-session never navigates. The window gates visibility via ``SessionIndicators``; this
-/// view assumes it is only shown when non-idle, so its controls never surface Start.
+/// Keeps the countdown and core controls visible from any non-Timer destination: the active
+/// task, a mini progress ring, the phase and countdown, and the shared pause/resume · skip ·
+/// stop controls. When a task is active its title leads the strip on the left; a flexible
+/// spacer pushes the timer machinery — a hairline divider walling it off, the ring, and the
+/// phase + countdown session-state cluster (`.secondary`) — into a right rail flush against
+/// the controls. With no active task the ring and countdown stand alone (`.primary`),
+/// right-aligned beside the controls with the divider omitted. Clicking the ring, the
+/// countdown, or the task title jumps to the Timer destination; the active task's radio stays
+/// a sibling control so completing or clearing mid-session never navigates. The window gates
+/// visibility via ``SessionIndicators``; this view assumes it is only shown when non-idle, so
+/// its controls never surface Start.
 struct TimerStripView: View {
 
   /// The presenter supplying timer display values and receiving control intents.
@@ -34,6 +37,21 @@ struct TimerStripView: View {
 
   var body: some View {
     HStack(spacing: .contentGap) {
+      if selectionStore.activeTask != nil {
+        ActiveTaskView(
+          engine: engine, selectionStore: selectionStore, registry: registry, nav: nav,
+          errorPresenter: errorPresenter, style: .compact, onSelect: onSelectTimer
+        )
+      }
+
+      Spacer()
+
+      if selectionStore.activeTask != nil {
+        Divider()
+          .frame(height: 22)
+          .padding(.horizontal, .contentGap)
+      }
+
       Button(action: onSelectTimer) {
         TimerRing(progress: presenter.progress, diameter: 22, strokeWidth: 3)
       }
@@ -41,17 +59,7 @@ struct TimerStripView: View {
       .help(AppLabels.Tab.timer.title)
       .accessibilityLabel(AppLabels.Tab.timer.title)
 
-      if selectionStore.activeTask == nil {
-        countdown(secondary: false)
-      } else {
-        ActiveTaskView(
-          engine: engine, selectionStore: selectionStore, registry: registry, nav: nav,
-          errorPresenter: errorPresenter, style: .compact, onSelect: onSelectTimer
-        )
-        countdown(secondary: true)
-      }
-
-      Spacer()
+      countdown(secondary: selectionStore.activeTask != nil)
 
       TimerControlsView(presenter: presenter, size: .compact)
     }

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -48,16 +48,10 @@ struct TimerTabView: View {
         .padding(.horizontal, .sectionGap)
         .padding(.vertical, .contentGap)
       } else {
-        Button {
-          nav.showTasks()
-        } label: {
-          Label(AppLabels.View.browseTask.title, systemImage: AppLabels.View.browseTask.systemImage)
-            .font(.caption)
-        }
-        .buttonStyle(.plain)
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, .screenPadding)
-        .padding(.vertical, .iconLabel)
+        BrowseTasksButton { nav.showTasks() }
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.horizontal, .sectionGap)
+          .padding(.vertical, .contentGap)
       }
 
       Divider()


### PR DESCRIPTION
## Summary

A set of small UI refinements to the Timer surfaces and task rows:

- **Session strip separation** — pull the timer ring apart from the active task's completion radio so the two circles stop reading as one cluster. The completion radio quiets to a grey outline at rest (greening on hover/complete), and the ring + phase/countdown move into a right rail beside the transport controls, walled off from the task by a hairline divider.
- **Task source badge** — replace the plain `Open in <provider>` caption link with a tappable source chip (provider glyph + name + ↗) that reads as provenance rather than a command.
- **Browse Tasks affordance** — unify the Browse Tasks control across the Timer and companion surfaces (commit `628fbe3`, already on the branch).

## Linked issue

None — standalone UI refinements, no tracking issue.

## Approach

- **Completion radio** (`TaskCompletionButton`): renders `.secondary` grey at rest and `Color.statusSuccess` green on hover/complete instead of always `Color.accentColor`, so it no longer competes with the accent-tinted timer ring beside it — and matches the grey-at-rest idiom most task apps use. Shared control, so the treatment lands on every completion affordance.
- **Strip layout** (`TimerStripView`): the active task title leads on the left; a `Spacer` pushes a fixed-height `Divider`, the ring, and the phase·countdown session-state cluster into a right rail flush against `TimerControlsView`. With no active task the ring + countdown stand alone, right-aligned, and the divider is omitted.
- **Source badge** (new `TaskSourceBadge`): a reusable rounded chip wrapping a `Link` to the task's `sourceURL`, built from the existing design tokens and mirroring the `TaskLineageRow` provenance idiom. `ActiveTaskView`'s detail block renders it with the provider's real `displayName`/`icon`; the full "Open in …" phrasing moves to the tooltip/VoiceOver label.

Design alternatives for the source affordance were explored as prototypes; the implemented direction is the badge-with-arrow on its own line.

## Out of scope

- The source badge appears only in the Timer **detail** active task, not the task-picker rows (`TaskRowView`). Factoring it into a shared row component is a follow-up.
- No changes to the timer state machine, persistence, providers, or entitlements.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated tests covering the new behavior
- [ ] Manually verified the new behavior
- [x] Documentation updated where appropriate

Ran `make sync-version`, `make lint` (0 violations), `make format-check` (clean), `xcodebuild ... build` (**BUILD SUCCEEDED**), and `make test` — the full Swift Testing suite **passed** with 0 failures. Swift doc comments on the changed/new types were updated.

**No new tests added, by design.** All three changes are pure SwiftUI view structure/layout/modifiers, which the [testing charter](docs/explanation/testing.md) explicitly exempts, and none touch a required-coverage area (task providers, session engine, URL-scheme handler, Obsidian parser, session store). `TaskSourceBadge`'s only branch is trivial view gating on `task.sourceURL`; `registry.provider(for:)` is existing, already-covered infrastructure. The app was not launched; the changes are visual-only and best confirmed by eye.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- Verification was build + lint + format-check only — best confirmed visually by running the Timer surfaces (strip + detail active task) with an Obsidian/Apple Reminders task selected.
- `buildServer.json` is a local, untracked file and is intentionally not part of this PR.
