### PR TITLE
refactor(session): move phase-end cascade to PhaseOrchestrator over AsyncStream

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -12,8 +12,7 @@ import Foundation
 /// them as immutable properties for injection into the scene hierarchy.
 ///
 /// `TaskmatoApp` holds one `@State` instance and passes slices to each scene.
-/// The `engine.onPhaseEnded` side-effect cascade is wired here; it will move
-/// to `PhaseOrchestrator` at 0.9.0.
+/// The `engine.phaseEvents` side-effect cascade is wired here, consumed by `PhaseOrchestrator`.
 @MainActor
 struct AppComposition {
 
@@ -33,8 +32,9 @@ struct AppComposition {
   let urlHandler: URLSchemeHandler
   let nav: MainNavigation
   let errorPresenter: ErrorPresenter
+  let phaseOrchestrator: PhaseOrchestrator
 
-  /// Constructs every service, registers providers, and wires the phase-ended callback.
+  /// Constructs every service, registers providers, and launches the phase-end orchestrator.
   init() {
     let engine = SessionEngine()
     let settingsStore = SettingsStore()
@@ -49,7 +49,7 @@ struct AppComposition {
     let remindersProvider = RemindersProvider(
       store: LiveRemindersEventStore(), settings: settingsStore)
     let statsViewModel = StatsViewModel(
-      repository: sessionRepository,
+      store: store,
       providerLabel: { [registry] providerID in
         registry.providers.first { $0.id == providerID }?.displayName ?? providerID
       },
@@ -77,6 +77,9 @@ struct AppComposition {
       engine: engine, settings: settings,
       nav: nav, errorPresenter: errorPresenter
     )
+    let phaseOrchestrator = Self.makePhaseOrchestrator(
+      engine: engine, store: store, settings: settings, selectionStore: selectionStore,
+      notifications: notifications)
     self.engine = engine
     self.settings = settings
     self.timerPresenter = TimerPresenter(engine: engine, settings: settings)
@@ -93,7 +96,7 @@ struct AppComposition {
     self.urlHandler = urlHandler
     self.nav = nav
     self.errorPresenter = errorPresenter
-    engine.onPhaseEnded = makePhaseEndedHandler()
+    self.phaseOrchestrator = phaseOrchestrator
   }
 
   /// Opens the SwiftData session store, trapping if it cannot be created.
@@ -118,41 +121,23 @@ struct AppComposition {
     ) { _ in Task { await notifications.refreshAuthStatus() } }
   }
 
+  /// Builds the phase-end orchestrator and launches it, fire-and-forget, for the app's lifetime.
+  private static func makePhaseOrchestrator(
+    engine: SessionEngine, store: SessionStore, settings: AppSettings,
+    selectionStore: TaskSelectionStore, notifications: NotificationService
+  ) -> PhaseOrchestrator {
+    let orchestrator = PhaseOrchestrator(
+      events: engine.phaseEvents, engine: engine, store: store, settings: settings,
+      selectionStore: selectionStore, notifications: notifications)
+    Task { await orchestrator.run() }
+    return orchestrator
+  }
+
   /// Registers each provider, enabling `fallback` on first launch when nothing is persisted.
   private static func registerProviders(
     _ providers: [any TaskProvider], into registry: ProviderRegistry, fallback: any TaskProvider
   ) {
     for provider in providers { registry.register(provider) }
     if registry.enabledIDs.isEmpty { registry.enable(fallback) }
-  }
-
-  /// Records the completed session, fires the phase notification, and advances the timer.
-  ///
-  /// The engine holds this callback; it moves to `PhaseOrchestrator` at 0.9.0.
-  private func makePhaseEndedHandler() -> (SessionPhase, Date, Date, Bool) -> Void {
-    { phase, startedAt, endedAt, wasCompleted in
-      let session = Session(
-        id: UUID(), phase: phase, startedAt: startedAt,
-        endedAt: endedAt, wasCompleted: wasCompleted,
-        taskRef: self.selectionStore.activeTask?.id,
-        taskTitle: self.selectionStore.activeTask?.title
-      )
-      self.store.append(session)
-      self.statsViewModel.recordAppended(session)
-      guard wasCompleted else { return }
-      self.notifications.send(phase: phase)
-      self.engine.applyDurations(from: self.settings)
-      let next: SessionPhase
-      switch phase {
-      case .focus:
-        next = self.engine.nextBreakPhase(longBreakAfter: self.settings.longBreakAfterSessions)
-      case .shortBreak, .longBreak: next = .focus
-      }
-      if self.settings.autoStartNextPhase {
-        self.engine.start(phase: next)
-      } else {
-        self.engine.enqueuePhase(next)
-      }
-    }
   }
 }

--- a/app/Taskmato/Session/PhaseEvent.swift
+++ b/app/Taskmato/Session/PhaseEvent.swift
@@ -1,0 +1,17 @@
+//
+//  PhaseEvent.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// An event emitted by ``SessionEngine`` when a phase ends.
+enum PhaseEvent: Sendable {
+  /// A phase ended, naturally or via manual stop.
+  /// - Parameters:
+  ///   - phase: The phase that ended.
+  ///   - startedAt: Virtual start time, reflecting actual accumulated focus time.
+  ///   - endedAt: The wall-clock time the phase ended.
+  ///   - wasCompleted: `true` if time ran out naturally; `false` if the user stopped manually.
+  case ended(phase: SessionPhase, startedAt: Date, endedAt: Date, wasCompleted: Bool)
+}

--- a/app/Taskmato/Session/PhaseOrchestrator.swift
+++ b/app/Taskmato/Session/PhaseOrchestrator.swift
@@ -1,0 +1,79 @@
+//
+//  PhaseOrchestrator.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Drives the phase-end side-effect cascade from a stream of ``PhaseEvent`` values.
+///
+/// Consumes ``SessionEngine/phaseEvents``: records the completed session, fires the phase
+/// notification, re-syncs engine durations from settings, and advances or queues the next
+/// phase. Isolating this cascade behind an injected stream makes it testable without a real
+/// clock or the live app services.
+@MainActor
+final class PhaseOrchestrator {
+
+  private let events: AsyncStream<PhaseEvent>
+  private let engine: SessionEngine
+  private let store: SessionStore
+  private let settings: AppSettings
+  private let selectionStore: TaskSelectionStore
+  private let notifications: NotificationService
+
+  /// - Parameters:
+  ///   - events: The phase-event stream to consume; production passes `engine.phaseEvents`.
+  ///   - engine: The session engine, used to re-sync durations and advance/queue the next phase.
+  ///   - store: Where completed sessions are recorded.
+  ///   - settings: User preferences consulted for durations and auto-start behavior.
+  ///   - selectionStore: Supplies the active task recorded alongside each session.
+  ///   - notifications: Delivers the phase-end banner and sound.
+  init(
+    events: AsyncStream<PhaseEvent>,
+    engine: SessionEngine,
+    store: SessionStore,
+    settings: AppSettings,
+    selectionStore: TaskSelectionStore,
+    notifications: NotificationService
+  ) {
+    self.events = events
+    self.engine = engine
+    self.store = store
+    self.settings = settings
+    self.selectionStore = selectionStore
+    self.notifications = notifications
+  }
+
+  /// Consumes `events` for the lifetime of the stream, applying the cascade to each one.
+  func run() async {
+    for await case .ended(let phase, let startedAt, let endedAt, let wasCompleted) in events {
+      apply(phase: phase, startedAt: startedAt, endedAt: endedAt, wasCompleted: wasCompleted)
+    }
+  }
+
+  /// Records the completed session, fires the phase notification, and advances the timer.
+  private func apply(phase: SessionPhase, startedAt: Date, endedAt: Date, wasCompleted: Bool) {
+    let session = Session(
+      id: UUID(), phase: phase, startedAt: startedAt,
+      endedAt: endedAt, wasCompleted: wasCompleted,
+      taskRef: selectionStore.activeTask?.id,
+      taskTitle: selectionStore.activeTask?.title
+    )
+    store.append(session)
+    guard wasCompleted else { return }
+    notifications.send(phase: phase)
+    engine.applyDurations(from: settings)
+    let next: SessionPhase
+    switch phase {
+    case .focus:
+      next = engine.nextBreakPhase(longBreakAfter: settings.longBreakAfterSessions)
+    case .shortBreak, .longBreak:
+      next = .focus
+    }
+    if settings.autoStartNextPhase {
+      engine.start(phase: next)
+    } else {
+      engine.enqueuePhase(next)
+    }
+  }
+}

--- a/app/Taskmato/Session/SessionEngine.swift
+++ b/app/Taskmato/Session/SessionEngine.swift
@@ -83,6 +83,7 @@ enum SessionState: Equatable {
 /// timer while a session is running. Time is always derived from wall-clock timestamps,
 /// so it stays accurate across sleep/wake cycles.
 @Observable
+@MainActor
 final class SessionEngine {
 
   /// The current state of the session.
@@ -111,14 +112,11 @@ final class SessionEngine {
   /// naturally. Manual stops and skips do not affect this counter.
   private(set) var completedFocusCount: Int = 0
 
-  /// Called whenever a phase ends — either naturally (time reaches zero) or via manual stop.
-  /// - Parameters:
-  ///   - phase: The phase that ended.
-  ///   - startedAt: Virtual start time, reflecting actual accumulated focus time.
-  ///   - endedAt: The wall-clock time the phase ended.
-  ///   - wasCompleted: `true` if time ran out naturally; `false` if the user stopped manually.
-  var onPhaseEnded: ((SessionPhase, Date, Date, Bool) -> Void)?
+  /// Emits an event whenever a phase ends — either naturally (time reaches zero) or via
+  /// manual stop. ``PhaseOrchestrator`` consumes this to drive the phase-end cascade.
+  let phaseEvents: AsyncStream<PhaseEvent>
 
+  private let phaseContinuation: AsyncStream<PhaseEvent>.Continuation
   private let now: () -> Date
   private var tickTimer: Timer?
 
@@ -138,6 +136,7 @@ final class SessionEngine {
     self.longBreakDuration = longBreakDuration
     self.now = now
     self.timeRemaining = focusDuration
+    (phaseEvents, phaseContinuation) = AsyncStream.makeStream(of: PhaseEvent.self)
   }
 
   /// `true` while a phase is actively counting down (not paused or idle).
@@ -185,11 +184,14 @@ final class SessionEngine {
     case .running(let phase, let startedAt, _):
       stopTicking()
       refreshTimeRemaining()
-      onPhaseEnded?(phase, startedAt, endedAt, false)
+      guard case .running = state else { break }  // completion may have fired during refresh
+      phaseContinuation.yield(
+        .ended(phase: phase, startedAt: startedAt, endedAt: endedAt, wasCompleted: false))
     case .paused(let phase, let remaining):
       let elapsed = duration(for: phase) - remaining
       let startedAt = endedAt.addingTimeInterval(-elapsed)
-      onPhaseEnded?(phase, startedAt, endedAt, false)
+      phaseContinuation.yield(
+        .ended(phase: phase, startedAt: startedAt, endedAt: endedAt, wasCompleted: false))
     case .idle:
       return
     }
@@ -276,7 +278,10 @@ final class SessionEngine {
       case .longBreak: completedFocusCount = 0
       case .shortBreak: break
       }
-      onPhaseEnded?(phase, startedAt, startedAt.addingTimeInterval(duration), true)
+      phaseContinuation.yield(
+        .ended(
+          phase: phase, startedAt: startedAt,
+          endedAt: startedAt.addingTimeInterval(duration), wasCompleted: true))
     }
   }
 

--- a/app/Taskmato/Session/SessionStore.swift
+++ b/app/Taskmato/Session/SessionStore.swift
@@ -39,12 +39,29 @@ final class SessionStore {
     SessionSummary(sessions: sessions, over: interval)
   }
 
-  // MARK: - Private
-
   /// Refreshes the observable mirror from the repository's full log.
-  private func reload() async {
+  func reload() async {
     let all = try? await repository.sessions(
       over: DateInterval(start: .distantPast, end: .distantFuture))
     sessions = all ?? []
   }
 }
+
+#if DEBUG
+  extension SessionStore {
+
+    /// A store backed by a fresh in-memory repository, synchronously seeded with `sessions`.
+    ///
+    /// For SwiftUI previews, where waiting on the async `reload()` would leave the preview
+    /// briefly empty.
+    /// - Parameter sessions: The sessions to seed the observable mirror with.
+    static func seeded(_ sessions: [Session]) -> SessionStore {
+      guard let repository = try? SwiftDataSessionRepository.makeInMemory() else {
+        fatalError("Failed to build in-memory preview repository")
+      }
+      let store = SessionStore(repository: repository)
+      store.sessions = sessions
+      return store
+    }
+  }
+#endif

--- a/app/Taskmato/Views/Stats/StatsViewModel.swift
+++ b/app/Taskmato/Views/Stats/StatsViewModel.swift
@@ -8,9 +8,9 @@ import Observation
 
 /// The single owner of stats scope state, period navigation, and all session aggregation.
 ///
-/// Loads the full session log from an injected ``SessionRepository`` into an in-memory cache
-/// and derives every value the stats UI and popover footer consume. All grouping, counting,
-/// and streak logic lives here — never in the repository (design doc 0006, decisions D1/D2).
+/// Projects every value the stats UI and popover footer consume over an injected
+/// ``SessionStore``'s observable session log. All grouping, counting, and streak logic lives
+/// here — never in the store (design doc 0006, decisions D1/D2).
 @Observable
 @MainActor
 final class StatsViewModel {
@@ -18,12 +18,12 @@ final class StatsViewModel {
   /// Grouping key used for focus time recorded without a selected task.
   private static let untrackedKey = "__untracked__"
 
-  private let repository: SessionRepository
+  private let store: SessionStore
   private let providerLabel: (String) -> String
   private let providerTint: (String) -> ProviderTint
 
   /// The full session log, oldest-first; the source for every derived value.
-  private var sessions: [Session] = []
+  private var sessions: [Session] { store.sessions }
 
   /// The time window the scope-dependent outputs are computed over.
   var scope: StatScope = .today {
@@ -33,38 +33,19 @@ final class StatsViewModel {
   /// Period offset: `0` is the current period, `-1` the previous, and so on.
   private(set) var offset = 0
 
-  /// Creates a view model backed by a repository.
+  /// Creates a view model that projects over a session store.
   /// - Parameters:
-  ///   - repository: The session log to aggregate.
+  ///   - store: The session log to aggregate.
   ///   - providerLabel: Resolves a `providerID` to a display name; defaults to the raw ID.
   ///   - providerTint: Resolves a `providerID` to a display color; defaults to ``ProviderTint/gray``.
   init(
-    repository: SessionRepository,
+    store: SessionStore,
     providerLabel: @escaping (String) -> String = { $0 },
     providerTint: @escaping (String) -> ProviderTint = { _ in .gray }
   ) {
-    self.repository = repository
+    self.store = store
     self.providerLabel = providerLabel
     self.providerTint = providerTint
-    Task { await refresh() }
-  }
-
-  // MARK: - Data lifecycle
-
-  /// Reloads the full session log from the repository.
-  func refresh() async {
-    let all = try? await repository.sessions(
-      over: DateInterval(start: .distantPast, end: .distantFuture))
-    sessions = all ?? []
-  }
-
-  /// Optimistically adds a just-recorded session to the cache for immediate UI updates.
-  ///
-  /// Persistence remains the repository's responsibility (via `SessionStore`); this only
-  /// keeps the in-memory cache current between reloads.
-  /// - Parameter session: The session that was appended.
-  func recordAppended(_ session: Session) {
-    sessions.append(session)
   }
 
   // MARK: - Navigation
@@ -331,16 +312,10 @@ final class StatsViewModel {
 
     /// Builds a preview view model seeded with `sessions`.
     private static func seeded(_ sessions: [Session]) -> StatsViewModel {
-      guard let repository = try? SwiftDataSessionRepository.makeInMemory() else {
-        fatalError("Failed to build in-memory preview repository")
-      }
-      let viewModel = StatsViewModel(
-        repository: repository,
+      StatsViewModel(
+        store: .seeded(sessions),
         providerLabel: { previewProviders[$0]?.label ?? $0 },
         providerTint: { previewProviders[$0]?.tint ?? .gray })
-      // Seed the cache synchronously so previews render without waiting on the async refresh.
-      viewModel.sessions = sessions
-      return viewModel
     }
   }
 #endif

--- a/app/TaskmatoTests/PhaseOrchestratorTests.swift
+++ b/app/TaskmatoTests/PhaseOrchestratorTests.swift
@@ -1,0 +1,144 @@
+//
+//  PhaseOrchestratorTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+import UserNotifications
+
+@testable import Taskmato
+
+// MARK: - Fakes
+
+/// A controllable stand-in for UNUserNotificationCenter (spy pattern from NotificationServiceTests).
+private final class FakeNotificationCenter: NotificationCenterAPI {
+  var stubbedStatus: UNAuthorizationStatus
+  private(set) var scheduledRequests: [UNNotificationRequest] = []
+
+  init(status: UNAuthorizationStatus = .authorized) {
+    self.stubbedStatus = status
+  }
+
+  func authorizationStatus() async -> UNAuthorizationStatus { stubbedStatus }
+
+  func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
+    stubbedStatus == .authorized
+  }
+
+  func scheduleNotification(_ request: UNNotificationRequest) {
+    scheduledRequests.append(request)
+  }
+
+  func setDelegate(_ delegate: (any UNUserNotificationCenterDelegate)?) {}
+}
+
+// MARK: - Helpers
+
+@MainActor
+private struct OrchestratorContext {
+  let orchestrator: PhaseOrchestrator
+  let continuation: AsyncStream<PhaseEvent>.Continuation
+  let engine: SessionEngine
+  let store: SessionStore
+  let settings: AppSettings
+  let selectionStore: TaskSelectionStore
+  let center: FakeNotificationCenter
+}
+
+@MainActor
+private func makeContext() async -> OrchestratorContext {
+  let (stream, continuation) = AsyncStream.makeStream(of: PhaseEvent.self)
+  let engine = SessionEngine()
+  let store = SessionStore(repository: FakeSessionRepository())
+  let settingsStore = SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!)
+  let settings = AppSettings(store: settingsStore)
+  let selectionStore = TaskSelectionStore(store: settingsStore)
+  let center = FakeNotificationCenter(status: .authorized)
+  let notifications = NotificationService(settings: settings, center: center)
+  await notifications.refreshAuthStatus()
+  let orchestrator = PhaseOrchestrator(
+    events: stream, engine: engine, store: store, settings: settings,
+    selectionStore: selectionStore, notifications: notifications)
+  return OrchestratorContext(
+    orchestrator: orchestrator, continuation: continuation, engine: engine, store: store,
+    settings: settings, selectionStore: selectionStore, center: center)
+}
+
+/// Yields the main-actor executor repeatedly, giving a concurrently running `Task` a chance to
+/// drain buffered `AsyncStream` values before assertions run.
+@MainActor
+private func drain() async {
+  for _ in 0..<20 { await Task.yield() }
+}
+
+// MARK: - Tests
+
+@MainActor
+struct PhaseOrchestratorTests {
+
+  @Test func completedFocusRecordsSessionNotifiesAndQueuesNextPhase() async {
+    let ctx = await makeContext()
+    #expect(ctx.center.stubbedStatus == .authorized)
+    let runTask = Task { await ctx.orchestrator.run() }
+
+    let startedAt = Date(timeIntervalSinceReferenceDate: 0)
+    let endedAt = startedAt.addingTimeInterval(1500)
+    ctx.continuation.yield(
+      .ended(phase: .focus, startedAt: startedAt, endedAt: endedAt, wasCompleted: true))
+    await drain()
+
+    #expect(ctx.store.sessions.count == 1)
+    #expect(ctx.store.sessions.first?.phase == .focus)
+    #expect(ctx.store.sessions.first?.wasCompleted == true)
+    #expect(ctx.center.scheduledRequests.count == 1)
+    // autoStartNextPhase defaults to false — the next phase is queued, not started.
+    #expect(ctx.engine.queuedPhase == .shortBreak)
+    #expect(ctx.engine.state == .idle)
+
+    ctx.continuation.finish()
+    await runTask.value
+  }
+
+  @Test func completedFocusAutoStartsNextPhaseWhenEnabled() async {
+    let ctx = await makeContext()
+    ctx.settings.autoStartNextPhase = true
+    let runTask = Task { await ctx.orchestrator.run() }
+
+    let startedAt = Date(timeIntervalSinceReferenceDate: 0)
+    let endedAt = startedAt.addingTimeInterval(1500)
+    ctx.continuation.yield(
+      .ended(phase: .focus, startedAt: startedAt, endedAt: endedAt, wasCompleted: true))
+    await drain()
+
+    guard case .running(let phase, _, _) = ctx.engine.state else {
+      Issue.record("Expected the engine to have auto-started the next phase")
+      ctx.continuation.finish()
+      return
+    }
+    #expect(phase == .shortBreak)
+
+    ctx.continuation.finish()
+    await runTask.value
+  }
+
+  @Test func manualStopRecordsSessionButDoesNotNotifyOrAdvance() async {
+    let ctx = await makeContext()
+    let runTask = Task { await ctx.orchestrator.run() }
+
+    let startedAt = Date(timeIntervalSinceReferenceDate: 0)
+    let endedAt = startedAt.addingTimeInterval(300)
+    ctx.continuation.yield(
+      .ended(phase: .focus, startedAt: startedAt, endedAt: endedAt, wasCompleted: false))
+    await drain()
+
+    #expect(ctx.store.sessions.count == 1)
+    #expect(ctx.store.sessions.first?.wasCompleted == false)
+    #expect(ctx.center.scheduledRequests.isEmpty)
+    #expect(ctx.engine.queuedPhase == nil)
+    #expect(ctx.engine.state == .idle)
+
+    ctx.continuation.finish()
+    await runTask.value
+  }
+}

--- a/app/TaskmatoTests/SessionEngineCompletionTests.swift
+++ b/app/TaskmatoTests/SessionEngineCompletionTests.swift
@@ -8,6 +8,7 @@ import Testing
 
 @testable import Taskmato
 
+@MainActor
 struct SessionEngineCompletionTests {
 
   // MARK: - Phase completion
@@ -30,79 +31,111 @@ struct SessionEngineCompletionTests {
     #expect(engine.timeRemaining == 60)
   }
 
-  @Test func phaseCompletionFiresCallback() {
+  @Test func phaseCompletionFiresEvent() async {
     var currentTime = Date(timeIntervalSinceReferenceDate: 0)
     let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-    var firedPhase: SessionPhase?
-    engine.onPhaseEnded = { phase, _, _, _ in firedPhase = phase }
     engine.start()
     currentTime = currentTime.addingTimeInterval(60)
     engine.pause()
-    #expect(firedPhase == .focus)
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(let phase, _, _, _) = await iterator.next() else {
+      Issue.record("Expected a phase-end event")
+      return
+    }
+    #expect(phase == .focus)
   }
 
-  @Test func phaseCompletionCallbackReceivesCorrectTimes() {
+  @Test func phaseCompletionEventCarriesCorrectTimes() async {
     let startTime = Date(timeIntervalSinceReferenceDate: 1000)
     var currentTime = startTime
     let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-    var capturedStart: Date?
-    var capturedEnd: Date?
-    engine.onPhaseEnded = { _, start, end, _ in
-      capturedStart = start
-      capturedEnd = end
-    }
     engine.start()
     currentTime = currentTime.addingTimeInterval(60)
     engine.pause()
-    #expect(capturedStart == startTime)
-    #expect(capturedEnd == startTime.addingTimeInterval(60))
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(_, let start, let end, _) = await iterator.next() else {
+      Issue.record("Expected a phase-end event")
+      return
+    }
+    #expect(start == startTime)
+    #expect(end == startTime.addingTimeInterval(60))
   }
 
-  @Test func naturalCompletionMarksWasCompletedTrue() {
+  @Test func naturalCompletionMarksWasCompletedTrue() async {
     var currentTime = Date(timeIntervalSinceReferenceDate: 0)
     let engine = SessionEngine(focusDuration: 60, now: { currentTime })
-    var wasCompleted: Bool?
-    engine.onPhaseEnded = { _, _, _, completed in wasCompleted = completed }
     engine.start()
     currentTime = currentTime.addingTimeInterval(60)
     engine.pause()
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(_, _, _, let wasCompleted) = await iterator.next() else {
+      Issue.record("Expected a phase-end event")
+      return
+    }
     #expect(wasCompleted == true)
   }
 
-  @Test func manualStopFiresCallbackWithWasCompletedFalse() {
+  @Test func manualStopFiresEventWithWasCompletedFalse() async {
     let engine = SessionEngine()
-    var wasCompleted: Bool?
-    engine.onPhaseEnded = { _, _, _, completed in wasCompleted = completed }
     engine.start()
     engine.stop()
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(_, _, _, let wasCompleted) = await iterator.next() else {
+      Issue.record("Expected a phase-end event")
+      return
+    }
     #expect(wasCompleted == false)
   }
 
-  @Test func manualStopFromPausedFiresCallback() {
+  @Test func manualStopFromPausedFiresEvent() async {
     let engine = SessionEngine()
-    var fired = false
-    engine.onPhaseEnded = { _, _, _, _ in fired = true }
     engine.start()
     engine.pause()
     engine.stop()
-    #expect(fired)
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    let event = await iterator.next()
+    #expect(event != nil)
   }
 
-  @Test func stopFromIdleDoesNotFireCallback() {
-    let engine = SessionEngine()
-    var fired = false
-    engine.onPhaseEnded = { _, _, _, _ in fired = true }
-    engine.stop()
-    #expect(!fired)
-  }
+  @Test func stopFromIdleDoesNotFireEvent() async {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(focusDuration: 60, now: { currentTime })
+    engine.stop()  // idle: must not buffer an event
 
-  @Test func skipDoesNotFireCallback() {
-    let engine = SessionEngine()
-    var fired = false
-    engine.onPhaseEnded = { _, _, _, _ in fired = true }
+    // Drive a real completion afterward as a sentinel: if the idle stop had wrongly
+    // buffered something, this would not be the first event received.
     engine.start()
-    engine.skip()
-    #expect(!fired)
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(let phase, _, _, let wasCompleted) = await iterator.next() else {
+      Issue.record("Expected exactly one phase-end event")
+      return
+    }
+    #expect(phase == .focus)
+    #expect(wasCompleted == true)
+  }
+
+  @Test func skipDoesNotFireEvent() async {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(
+      focusDuration: 60, shortBreakDuration: 60, now: { currentTime })
+    engine.start()
+    engine.skip()  // must not buffer an event
+
+    // Drive the (now short-break) phase to natural completion as a sentinel: if skip()
+    // had wrongly buffered a `.focus` event, this would not be the first event received.
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(let phase, _, _, let wasCompleted) = await iterator.next() else {
+      Issue.record("Expected exactly one phase-end event")
+      return
+    }
+    #expect(phase == .shortBreak)
+    #expect(wasCompleted == true)
   }
 
   @Test func skipUsesProvidedBreakPhase() {
@@ -114,6 +147,40 @@ struct SessionEngineCompletionTests {
       return
     }
     #expect(phase == .longBreak)
+  }
+
+  // MARK: - Stop-at-completion double-emit guard
+
+  @Test func stopExactlyAtCompletionEmitsSingleCompletedEvent() async {
+    var currentTime = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(
+      focusDuration: 60, shortBreakDuration: 60, now: { currentTime })
+    engine.start()
+    currentTime = currentTime.addingTimeInterval(60)  // lands exactly at completion
+    engine.stop()
+
+    // Without the guard, `stop()` would additionally yield a stale
+    // `.ended(phase: .focus, wasCompleted: false)` right after the natural completion.
+    // Drive a second, distinguishable completion as a sentinel: if the duplicate were
+    // present, it — not this sentinel — would be the second event received.
+    engine.start(phase: .shortBreak)
+    currentTime = currentTime.addingTimeInterval(60)
+    engine.pause()
+
+    var iterator = engine.phaseEvents.makeAsyncIterator()
+    guard case .ended(let firstPhase, _, _, let firstCompleted) = await iterator.next() else {
+      Issue.record("Expected the natural-completion event")
+      return
+    }
+    #expect(firstPhase == .focus)
+    #expect(firstCompleted == true)
+
+    guard case .ended(let secondPhase, _, _, let secondCompleted) = await iterator.next() else {
+      Issue.record("Expected the sentinel phase-end event")
+      return
+    }
+    #expect(secondPhase == .shortBreak)
+    #expect(secondCompleted == true)
   }
 
   // MARK: - enqueuePhase

--- a/app/TaskmatoTests/SessionEngineCycleTests.swift
+++ b/app/TaskmatoTests/SessionEngineCycleTests.swift
@@ -8,6 +8,7 @@ import Testing
 
 @testable import Taskmato
 
+@MainActor
 struct SessionEngineCycleTests {
 
   // MARK: - completedFocusCount initial state

--- a/app/TaskmatoTests/SessionEngineTests.swift
+++ b/app/TaskmatoTests/SessionEngineTests.swift
@@ -8,6 +8,7 @@ import Testing
 
 @testable import Taskmato
 
+@MainActor
 struct SessionEngineTests {
 
   @Test func startTransitionsToFocus() {

--- a/app/TaskmatoTests/StatsViewModelTests.swift
+++ b/app/TaskmatoTests/StatsViewModelTests.swift
@@ -41,11 +41,9 @@ struct StatsViewModelTests {
     _ sessions: [Session], providerLabel: @escaping (String) -> String = { $0 },
     providerTint: @escaping (String) -> ProviderTint = { _ in .gray }
   ) async -> StatsViewModel {
-    let viewModel = StatsViewModel(
-      repository: FakeSessionRepository(sessions: sessions), providerLabel: providerLabel,
-      providerTint: providerTint)
-    await viewModel.refresh()
-    return viewModel
+    let store = SessionStore(repository: FakeSessionRepository(sessions: sessions))
+    await store.reload()
+    return StatsViewModel(store: store, providerLabel: providerLabel, providerTint: providerTint)
   }
 
   // MARK: - Empty store
@@ -302,14 +300,16 @@ struct StatsViewModelTests {
     #expect(totals.first { $0.providerID == "__untracked__" }?.tint == .gray)
   }
 
-  // MARK: - Optimistic append
+  // MARK: - Live updates via the store
 
-  @Test func recordAppendedUpdatesTodayCounts() async {
-    let viewModel = await makeViewModel([])
+  @Test func storeAppendUpdatesTodayCounts() async {
+    let store = SessionStore(repository: FakeSessionRepository())
+    await store.reload()
+    let viewModel = StatsViewModel(store: store)
     #expect(viewModel.todayFocusCount == 0)
 
     let start = Self.dayStart(daysAgo: 0).addingTimeInterval(9 * 3_600)
-    viewModel.recordAppended(focus(start: start, minutes: 25, provider: "local"))
+    store.append(focus(start: start, minutes: 25, provider: "local"))
 
     #expect(viewModel.todayFocusCount == 1)
     #expect(viewModel.todayFocusMinutes == 25)

--- a/docs/architecture/design/0005-pre-1.0-architecture-pass.md
+++ b/docs/architecture/design/0005-pre-1.0-architecture-pass.md
@@ -63,6 +63,8 @@ Sequence: enable `SWIFT_STRICT_CONCURRENCY = complete` under Swift 5 first, fix 
 
 The engine is driven by a `Timer.scheduledTimer` on the main runloop and consumed exclusively from `@MainActor` views. Making the actor isolation explicit documents the contract and clears Swift 6 warnings for free. Concurrently, replace the `now: () -> Date` clock-injection closure with `ContinuousClock` for idiomatic test-time control.
 
+**Addendum (implementation, issue #407):** the `@MainActor` half landed as written. The `ContinuousClock` half did not: `SessionEngine` emits wall-clock `Date`s that become `Session.startedAt`/`endedAt`, persisted via SwiftData and grouped by calendar day in Stats. `ContinuousClock.Instant` is monotonic and cannot produce a wall-clock `Date`, and tests still need a `Date` source regardless — so `now: () -> Date` is kept.
+
 ### D9 — `SessionEngine.onPhaseEnded` callback becomes `AsyncStream<PhaseEvent>` + `PhaseOrchestrator`
 
 The 27-line side-effect cascade currently inside `TaskmatoApp.init` (append session → play sound → send notification → sync engine durations → auto-start or queue) moves into a `PhaseOrchestrator` that consumes a stream of `PhaseEvent` values from the engine. This makes the cascade unit-testable in isolation and removes the engine's tuple-callback surface.


### PR DESCRIPTION
## Summary

Replace `SessionEngine.onPhaseEnded` (tuple callback) with an `AsyncStream<PhaseEvent>`, and move the phase-end side-effect cascade (record session → notify/sound → sync durations → auto-start/queue) into a new `@MainActor PhaseOrchestrator` that consumes the stream. `SessionEngine` becomes `@MainActor`. This makes the cascade unit-testable in isolation.

## Linked issue

Closes #407

## Motivation

The cascade lived in a closure the engine held via `onPhaseEnded`, wired in `AppComposition`. It was untestable without the real clock and real stores. Promoting the engine to a stream-emitting `@MainActor` type with an explicit orchestrator turns the cascade into a plain unit test against a fake stream and fake stores (design doc 0005, D8/D9; findings J, V, residual C).

## Changes

- **`PhaseEvent`** — new `Sendable` enum (`.ended(phase:startedAt:endedAt:wasCompleted:)`).
- **`SessionEngine`** — now `@MainActor`; exposes `let phaseEvents: AsyncStream<PhaseEvent>` and yields through a private continuation instead of the callback. Also **guards the `stop()`-at-completion double-emit** (matching `pause()`), so a Stop landing exactly at natural completion records only the completion, not a duplicate partial.
- **`PhaseOrchestrator`** — new `@MainActor` type consuming an injected stream; `AppComposition` constructs it and launches `Task { await run() }` fire-and-forget, replacing the composition-root callback.
- **`StatsViewModel`** — decoupled to project over `SessionStore` (`sessions` is now a computed view of `store.sessions`); dropped its own cache, `refresh()`, `recordAppended()`, and `repository` dependency. The orchestrator no longer references the view model at all.
- **`SessionStore`** — `reload()` made internal (deterministic test await) + DEBUG `seeded(_:)` for previews.
- **Tests** — new `PhaseOrchestratorTests` (fake stream + `FakeSessionRepository`); `SessionEngineCompletionTests` rewritten to consume `phaseEvents` with a new stop-at-completion test; `@MainActor` added to the engine suites; `StatsViewModelTests` migrated to store-backed.

### Divergence from the issue: `ContinuousClock` intentionally **not** adopted

The issue also proposed replacing `now: () -> Date` with `ContinuousClock`. That is the wrong tool here and was dropped: `SessionEngine` emits **wall-clock `Date`s** that become `Session.startedAt`/`endedAt`, persisted and grouped by **calendar day** in Stats. `ContinuousClock.Instant` is monotonic and cannot produce a wall-clock `Date`, and tests would still need a `Date` source regardless. Only the `@MainActor` half of D8 is taken; the `Date` provider is retained. Recorded in design doc 0005 under D8.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

`make lint` → 0 violations · `make format-check` → clean · `make test` (full `xcodebuild`, app + unit + UI) → all passed.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- `AppComposition` wiring was extracted into a `makePhaseOrchestrator` helper to stay under SwiftLint's 60-line function-body limit.
- The no-emit tests (`stop` from idle, `skip`) use a sentinel-event technique rather than asserting stream emptiness (`AsyncStream` has no synchronous "empty" check) — same regression coverage, non-flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
