### PR TITLE
refactor(tasks): rename NoteFormat to ContentFormat

### DIFF
--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -24,7 +24,7 @@ struct LocalTask: Codable, Identifiable {
   ///
   /// Defaults to `.markdown` for all new tasks. Existing JSON records without this
   /// field also decode as `.markdown` via ``init(from:)``.
-  var format: NoteFormat
+  var format: ContentFormat
 
   /// Priority level, used for sorting and badging in the picker.
   var priority: TaskPriority
@@ -100,7 +100,7 @@ extension LocalTask {
     id = try container.decode(UUID.self, forKey: .id)
     title = try container.decode(String.self, forKey: .title)
     notes = try container.decodeIfPresent(String.self, forKey: .notes)
-    format = try container.decodeIfPresent(NoteFormat.self, forKey: .format) ?? .markdown
+    format = try container.decodeIfPresent(ContentFormat.self, forKey: .format) ?? .markdown
     priority = try container.decode(TaskPriority.self, forKey: .priority)
     dueDate = try container.decodeIfPresent(Date.self, forKey: .dueDate)
     scheduledDate = try container.decodeIfPresent(Date.self, forKey: .scheduledDate)

--- a/app/Taskmato/Tasks/Models/ContentFormat.swift
+++ b/app/Taskmato/Tasks/Models/ContentFormat.swift
@@ -1,12 +1,12 @@
 //
-//  NoteFormat.swift
+//  ContentFormat.swift
 //  Taskmato
 //
 
 import Foundation
 
-/// Declares how a task's `notes` string should be interpreted for display.
-nonisolated enum NoteFormat: Codable, Sendable {
+/// Declares how a task's `title` and `notes` strings should be interpreted for display.
+nonisolated enum ContentFormat: Codable, Sendable {
 
   /// Plain text — rendered verbatim, no markdown interpretation.
   case plainText

--- a/app/Taskmato/Tasks/Models/TaskItem.swift
+++ b/app/Taskmato/Tasks/Models/TaskItem.swift
@@ -22,7 +22,7 @@ nonisolated struct TaskItem: Identifiable, Hashable, Codable, Sendable {
   var notes: String?
 
   /// How `title` and `notes` should be rendered — plain text or markdown.
-  var format: NoteFormat
+  var format: ContentFormat
 
   /// Priority level, used for sorting and badging in the picker.
   var priority: TaskPriority

--- a/app/Taskmato/Views/Tasks/Components/TaskNoteView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskNoteView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 struct TaskNoteView: View {
 
   let notes: String
-  let format: NoteFormat
+  let format: ContentFormat
 
   var body: some View {
     Group {

--- a/app/TaskmatoTests/RemindersProviderTests.swift
+++ b/app/TaskmatoTests/RemindersProviderTests.swift
@@ -284,7 +284,7 @@ struct RemindersProviderTaskTests {
     #expect(tasks.first?.notes == "Some notes")
   }
 
-  @Test func tasksNoteFormatIsPlainText() async throws {
+  @Test func tasksContentFormatIsPlainText() async throws {
     let (provider, store) = try await makeAuthorizedProvider()
     let cal = store.makeCalendar(title: "Work")
     store.stubbedCalendars = [cal]

--- a/app/TaskmatoTests/TaskItemTests.swift
+++ b/app/TaskmatoTests/TaskItemTests.swift
@@ -117,10 +117,10 @@ struct TaskItemTests {
     #expect(decoded.title == "Legacy task")
   }
 
-  @Test func taskItemNoteFormatCodableRoundTrip() throws {
-    for format in [NoteFormat.plainText, NoteFormat.markdown] {
+  @Test func taskItemContentFormatCodableRoundTrip() throws {
+    for format in [ContentFormat.plainText, ContentFormat.markdown] {
       let data = try JSONEncoder().encode(format)
-      let decoded = try JSONDecoder().decode(NoteFormat.self, from: data)
+      let decoded = try JSONDecoder().decode(ContentFormat.self, from: data)
       #expect(decoded == format)
     }
   }


### PR DESCRIPTION
## Summary

Rename the `NoteFormat` type to `ContentFormat` to match its actual scope. It now governs how both a task's `title` and `notes` are rendered, not just notes.

## Linked issue

Closes #419

## Motivation

After the #395 DRY pass added `TaskItem.markdownTitle`, the `format` value drives title rendering as well as notes. The name `NoteFormat` and its doc comment ("how a task's `notes` string should be interpreted") no longer matched, and the mismatch would grow as more consumers read `format` for the title. Renaming now — before 1.0 — avoids a breaking change to stored task data later.

## Changes

- Renamed `NoteFormat.swift` → `ContentFormat.swift` and the `enum NoteFormat` → `ContentFormat`; the cases (`.plainText`, `.markdown`) are unchanged.
- Updated the doc comment to describe both `title` and `notes` rendering.
- Updated `format` property types on `TaskItem` and `LocalTask`, the `TaskNoteView` parameter, and the `decodeIfPresent` call in `LocalTask.init(from:)`.
- Renamed the referencing test names/usages in `TaskItemTests` and `RemindersProviderTests`.

No behavior change — the JSON encoding of the enum is unchanged, so existing stored task records decode identically.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

`make lint` (0 violations), `make format-check` (clean), and `make test` (`** TEST SUCCEEDED **`) all pass.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The enum's `Codable` representation is unchanged, so this is a pure source-level rename with no migration needed. The Xcode project uses synced groups, so no `.pbxproj` change was required for the file rename.
