### PR TITLE
refactor(tasks): introduce ProviderID newtype

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -51,10 +51,10 @@ struct AppComposition {
     let statsViewModel = StatsViewModel(
       store: store,
       providerLabel: { [registry] providerID in
-        registry.providers.first { $0.id == providerID }?.displayName ?? providerID
+        registry.providers.first { $0.id.rawValue == providerID }?.displayName ?? providerID
       },
       providerTint: { [registry] providerID in
-        registry.providers.first { $0.id == providerID }?.tint ?? .gray
+        registry.providers.first { $0.id.rawValue == providerID }?.tint ?? .gray
       })
     Self.configureNotifications(notifications)
     Self.registerProviders(

--- a/app/Taskmato/Services/AppSettings.swift
+++ b/app/Taskmato/Services/AppSettings.swift
@@ -84,7 +84,7 @@ final class AppSettings {
 
   /// The provider ID of the preferred writable provider for new ad-hoc tasks and the
   /// Add Task sheet, or `nil` to automatically select the first enabled writable provider.
-  var defaultWritableProviderID: String? {
+  var defaultWritableProviderID: ProviderID? {
     didSet { store[SettingsStore.Keys.defaultWritableProviderID] = defaultWritableProviderID }
   }
 

--- a/app/Taskmato/Services/SettingsStore.swift
+++ b/app/Taskmato/Services/SettingsStore.swift
@@ -95,6 +95,29 @@ final class SettingsStore {
     set { defaults.set(newValue.rawValue, forKey: key.name) }
   }
 
+  /// Reads or writes an optional `String`-backed `RawRepresentable`, removing the key when `nil`.
+  subscript<Value: RawRepresentable>(key: SettingsKey<Value?>) -> Value?
+  where Value.RawValue == String {
+    get { defaults.string(forKey: key.name).flatMap { Value(rawValue: $0) } ?? key.defaultValue }
+    set {
+      if let newValue {
+        defaults.set(newValue.rawValue, forKey: key.name)
+      } else {
+        defaults.removeObject(forKey: key.name)
+      }
+    }
+  }
+
+  /// Reads or writes a set of `String`-backed `RawRepresentable` values, stored as a string array.
+  subscript<Value: RawRepresentable>(key: SettingsKey<Set<Value>>) -> Set<Value>
+  where Value.RawValue == String {
+    get {
+      guard let stored = defaults.stringArray(forKey: key.name) else { return key.defaultValue }
+      return Set(stored.compactMap(Value.init(rawValue:)))
+    }
+    set { defaults.set(newValue.map(\.rawValue), forKey: key.name) }
+  }
+
   // MARK: - Codable & Data values
 
   /// Decodes a JSON-encoded `Codable` value for `key`, or `nil` when absent or undecodable.
@@ -160,7 +183,7 @@ extension SettingsStore {
     static let taskSortField = SettingsKey("taskSort.field", default: TaskSortField.dueDate)
     static let taskSortDirection = SettingsKey(
       "taskSort.direction", default: TaskSortDirection.ascending)
-    static let defaultWritableProviderID = SettingsKey<String?>(
+    static let defaultWritableProviderID = SettingsKey<ProviderID?>(
       "tasks.defaultWritableProviderID", default: nil)
     static let collapsedSidebarSections = SettingsKey(
       "sidebar.collapsedSections", default: Set<String>())
@@ -168,7 +191,7 @@ extension SettingsStore {
     // MARK: Provider registry
 
     static let enabledProviderIDs = SettingsKey(
-      "taskRegistry.enabledProviderIDs", default: Set<String>())
+      "taskRegistry.enabledProviderIDs", default: Set<ProviderID>())
 
     // MARK: Obsidian provider
 

--- a/app/Taskmato/Services/TaskSelectionStore.swift
+++ b/app/Taskmato/Services/TaskSelectionStore.swift
@@ -52,20 +52,21 @@ final class TaskSelectionStore {
 
   /// Returns recent tasks for the given provider, newest first.
   /// - Parameter providerID: The provider whose recents to return.
-  func recents(for providerID: String) -> [TaskItem] {
-    recentsByProvider[providerID] ?? []
+  func recents(for providerID: ProviderID) -> [TaskItem] {
+    recentsByProvider[providerID.rawValue] ?? []
   }
 
   // MARK: - Private
 
   private func addToRecents(_ task: TaskItem) {
-    var list = recentsByProvider[task.id.providerID] ?? []
+    let key = task.id.providerID.rawValue
+    var list = recentsByProvider[key] ?? []
     list.removeAll { $0.id == task.id }
     list.insert(task, at: 0)
     if list.count > Self.recentsLimit {
       list = Array(list.prefix(Self.recentsLimit))
     }
-    recentsByProvider[task.id.providerID] = list
+    recentsByProvider[key] = list
   }
 
   private func persist() {

--- a/app/Taskmato/Session/SessionSummary.swift
+++ b/app/Taskmato/Session/SessionSummary.swift
@@ -77,7 +77,7 @@ struct SessionSummary {
       let key: String
       let label: String
       if let ref = session.taskRef {
-        key = "\(ref.providerID):\(ref.nativeID)"
+        key = "\(ref.providerID.rawValue):\(ref.nativeID)"
         label = session.taskTitle ?? "Unknown Task"
       } else {
         key = "__untracked__"

--- a/app/Taskmato/Session/Storage/SessionEntity.swift
+++ b/app/Taskmato/Session/Storage/SessionEntity.swift
@@ -60,7 +60,7 @@ extension SessionEntity {
     self.init(
       id: session.id, phase: session.phase, startedAt: session.startedAt,
       endedAt: session.endedAt, wasCompleted: session.wasCompleted,
-      taskProviderID: session.taskRef?.providerID,
+      taskProviderID: session.taskRef?.providerID.rawValue,
       taskNativeID: session.taskRef?.nativeID,
       taskTitle: session.taskTitle)
   }
@@ -72,7 +72,7 @@ extension Session {
   nonisolated init(entity: SessionEntity) {
     let taskRef: TaskRef?
     if let providerID = entity.taskProviderID, let nativeID = entity.taskNativeID {
-      taskRef = TaskRef(providerID: providerID, nativeID: nativeID)
+      taskRef = TaskRef(providerID: ProviderID(providerID), nativeID: nativeID)
     } else {
       taskRef = nil
     }

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -18,9 +18,9 @@ import os
 final class LocalProvider: WritableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
-  static let providerID = "local"
+  static let providerID: ProviderID = "local"
 
-  let id: String = LocalProvider.providerID
+  let id: ProviderID = LocalProvider.providerID
   let displayName: String = "Local"
   let displayOrder: Int = 0
   let icon: String = "tray"

--- a/app/Taskmato/Tasks/Models/ProviderID.swift
+++ b/app/Taskmato/Tasks/Models/ProviderID.swift
@@ -1,0 +1,51 @@
+//
+//  ProviderID.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A type-safe identifier for a ``TaskProvider``, wrapping the underlying string.
+///
+/// Using a newtype instead of a raw `String` catches every site where a non-provider
+/// string could leak into provider comparisons, and produces clearer call sites
+/// (`ref.providerID == LocalProvider.providerID` rather than `ref.providerID == "local"`).
+///
+/// `Codable` encodes as a bare string via a single-value container, so JSON and SwiftData
+/// records stay byte-for-byte compatible with the previous `String`-typed representation.
+/// `ExpressibleByStringLiteral` lets providers declare `static let providerID: ProviderID = "local"`.
+nonisolated struct ProviderID: Hashable, Sendable, RawRepresentable, ExpressibleByStringLiteral {
+
+  /// The underlying provider identifier string (e.g. `"local"`, `"obsidian"`, `"reminders"`).
+  let rawValue: String
+
+  /// Wraps an existing raw identifier string.
+  init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Wraps a raw identifier string.
+  init(_ rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates an identifier from a string literal, enabling `let id: ProviderID = "local"`.
+  init(stringLiteral value: String) {
+    self.rawValue = value
+  }
+}
+
+extension ProviderID: Codable {
+
+  /// Decodes from a bare string value, preserving compatibility with `String`-typed records.
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self.rawValue = try container.decode(String.self)
+  }
+
+  /// Encodes as a bare string value, preserving compatibility with `String`-typed records.
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+}

--- a/app/Taskmato/Tasks/Models/SelectedList.swift
+++ b/app/Taskmato/Tasks/Models/SelectedList.swift
@@ -9,7 +9,7 @@ import Foundation
 struct SelectedList: Hashable, Codable, Sendable {
 
   /// The provider that owns this list.
-  let providerID: String
+  let providerID: ProviderID
 
   /// The list's stable identifier within its provider.
   let listID: String

--- a/app/Taskmato/Tasks/Models/TaskList.swift
+++ b/app/Taskmato/Tasks/Models/TaskList.swift
@@ -12,7 +12,7 @@ nonisolated struct TaskList: Identifiable, Hashable, Codable, Sendable {
   let id: String
 
   /// The identifier of the provider that owns this list.
-  let providerID: String
+  let providerID: ProviderID
 
   /// Human-readable name shown in the picker.
   let name: String

--- a/app/Taskmato/Tasks/Models/TaskRef.swift
+++ b/app/Taskmato/Tasks/Models/TaskRef.swift
@@ -11,8 +11,8 @@ import Foundation
 /// concurrent providers to coexist without collisions.
 nonisolated struct TaskRef: Hashable, Codable, Sendable {
 
-  /// The identifier of the provider that owns this task (e.g. `"reminders"`, `"obsidian"`, `"cli"`).
-  let providerID: String
+  /// The identifier of the provider that owns this task (e.g. `"reminders"`, `"obsidian"`, `"local"`).
+  let providerID: ProviderID
 
   /// The provider-local identifier for the task (e.g. an EventKit calendar item ID or a file-path hash).
   let nativeID: String

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -22,9 +22,9 @@ import Observation
 final class ObsidianProvider: ClosableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
-  nonisolated static let providerID = "obsidian"
+  nonisolated static let providerID: ProviderID = "obsidian"
 
-  let id: String = ObsidianProvider.providerID
+  let id: ProviderID = ObsidianProvider.providerID
   let displayName: String = "Obsidian"
   let icon: String = "book.closed"
   let tint: ProviderTint = .purple

--- a/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
@@ -41,7 +41,7 @@ nonisolated struct ObsidianTaskParser: Sendable {
   /// - Returns: Parsed tasks and the optional H1-derived list name.
   func parse(
     content: String,
-    providerID: String,
+    providerID: ProviderID,
     fileRelativePath: String,
     vaultName: String,
     list: TaskList
@@ -72,7 +72,7 @@ nonisolated struct ObsidianTaskParser: Sendable {
   /// when present, or `nil` when the date is absent.
   func parseCompleted(
     content: String,
-    providerID: String,
+    providerID: ProviderID,
     fileRelativePath: String,
     vaultName: String,
     list: TaskList
@@ -236,7 +236,7 @@ nonisolated struct ObsidianTaskParser: Sendable {
 
   /// File-level context shared across all tasks parsed from a single file.
   nonisolated private struct FileContext {
-    let providerID: String
+    let providerID: ProviderID
     let fileRelativePath: String
     let vaultName: String
     let list: TaskList

--- a/app/Taskmato/Tasks/Registry/ProviderRegistry.swift
+++ b/app/Taskmato/Tasks/Registry/ProviderRegistry.swift
@@ -21,14 +21,14 @@ final class ProviderRegistry {
   private(set) var providers: [any TaskProvider] = []
 
   /// IDs of providers currently enabled by the user.
-  private(set) var enabledIDs: Set<String>
+  private(set) var enabledIDs: Set<ProviderID>
 
   /// Lists loaded for each provider, keyed by provider ID.
   ///
   /// Populated by ``setLists(_:forProviderID:)``, which the sidebar calls after every
   /// `provider.lists()` load. Cleared for a provider when it is disabled. Views can
   /// observe this property to react when list data becomes available.
-  private(set) var providerLists: [String: [TaskList]] = [:]
+  private(set) var providerLists: [ProviderID: [TaskList]] = [:]
 
   /// Invoked after the enabled set or list cache changes, so the selection can be re-validated.
   ///
@@ -77,7 +77,7 @@ final class ProviderRegistry {
   ///
   /// Also clears the provider's list cache so downstream observers react immediately.
   /// - Parameter providerID: The `id` of the provider to disable.
-  func disable(providerID: String) {
+  func disable(providerID: ProviderID) {
     enabledIDs.remove(providerID)
     providerLists.removeValue(forKey: providerID)
     persist()
@@ -86,7 +86,7 @@ final class ProviderRegistry {
 
   /// Returns `true` if the provider with the given ID is currently enabled.
   /// - Parameter providerID: The provider ID to check.
-  func isEnabled(_ providerID: String) -> Bool {
+  func isEnabled(_ providerID: ProviderID) -> Bool {
     enabledIDs.contains(providerID)
   }
 
@@ -95,7 +95,7 @@ final class ProviderRegistry {
   /// Updates the list cache for `providerID` and re-validates the current selection.
   ///
   /// Call this after every `provider.lists()` load — on appear, after add, delete, or rename.
-  func setLists(_ lists: [TaskList], forProviderID providerID: String) {
+  func setLists(_ lists: [TaskList], forProviderID providerID: ProviderID) {
     providerLists[providerID] = lists
     onProviderStateChanged?()
   }
@@ -128,7 +128,7 @@ final class ProviderRegistry {
 
   /// Returns the enabled writable provider with the given ID, or `nil`.
   /// - Parameter id: The provider ID to resolve exactly.
-  func enabledWritableProvider(id: String) -> (any WritableTaskProvider)? {
+  func enabledWritableProvider(id: ProviderID) -> (any WritableTaskProvider)? {
     providers.first { $0.id == id && isEnabled($0.id) }
       as? (any WritableTaskProvider)
   }
@@ -144,7 +144,7 @@ final class ProviderRegistry {
   /// Returns `nil` when no enabled writable provider is registered.
   /// - Parameter preferredID: A provider ID to try first, typically from ``AppSettings``
   ///   user preference. Pass `nil` to skip directly to the fallback.
-  func resolveDefaultWritableProvider(preferredID: String?) -> (any WritableTaskProvider)? {
+  func resolveDefaultWritableProvider(preferredID: ProviderID?) -> (any WritableTaskProvider)? {
     if let preferredID, let writable = enabledWritableProvider(id: preferredID) {
       return writable
     }

--- a/app/Taskmato/Tasks/Registry/TaskQueryService.swift
+++ b/app/Taskmato/Tasks/Registry/TaskQueryService.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// A per-provider error returned alongside tasks when a provider fetch fails.
-typealias ProviderFetchError = (providerID: String, error: any Error)
+typealias ProviderFetchError = (providerID: ProviderID, error: any Error)
 
 /// Fans out task queries across the enabled providers in a ``ProviderRegistry`` and orders the result.
 ///

--- a/app/Taskmato/Tasks/Registry/TaskSorter.swift
+++ b/app/Taskmato/Tasks/Registry/TaskSorter.swift
@@ -101,6 +101,6 @@ struct TaskSorter: Sendable {
 
   /// Deterministic tiebreaker using the lexicographic order of `providerID/nativeID`.
   private func compareRefs(_ lhs: TaskRef, _ rhs: TaskRef) -> Bool {
-    "\(lhs.providerID)/\(lhs.nativeID)" < "\(rhs.providerID)/\(rhs.nativeID)"
+    "\(lhs.providerID.rawValue)/\(lhs.nativeID)" < "\(rhs.providerID.rawValue)/\(rhs.nativeID)"
   }
 }

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -16,9 +16,9 @@ import Foundation
 final class RemindersProvider: ClosableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
-  static let providerID = "reminders"
+  static let providerID: ProviderID = "reminders"
 
-  let id: String = RemindersProvider.providerID
+  let id: ProviderID = RemindersProvider.providerID
   let displayName: String = "Apple Reminders"
   let icon: String = "checklist"
   let tint: ProviderTint = .orange

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -12,7 +12,7 @@ import Foundation
 protocol TaskProvider: AnyObject, Sendable {
 
   /// Stable identifier used as `TaskRef.providerID` and for persisting enabled state.
-  var id: String { get }
+  var id: ProviderID { get }
 
   /// Human-readable name shown in the Providers settings panel.
   var displayName: String { get }

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -126,7 +126,9 @@ final class URLSchemeHandler {
   /// provider is available or the write fails; the caller then starts no session.
   func makeAdHocTask(from adHocParams: AdHocTaskParams) async -> TaskItem? {
     // Level 1: URL param targets a specific provider (strict — no implicit fallback within level).
-    let urlTargeted = adHocParams.providerID.flatMap(registry.enabledWritableProvider(id:))
+    let urlTargeted = adHocParams.providerID
+      .map(ProviderID.init(_:))
+      .flatMap(registry.enabledWritableProvider(id:))
     // Level 2 & 3: settings default, then first enabled writable provider.
     let writable =
       urlTargeted
@@ -172,7 +174,7 @@ final class URLSchemeHandler {
 
     // 1. Exact lookup by stable ID within a named provider
     if let providerID, let nativeID {
-      if let task = await lookupByID(nativeID: nativeID, providerID: providerID) {
+      if let task = await lookupByID(nativeID: nativeID, providerID: ProviderID(providerID)) {
         return task
       }
     }
@@ -186,7 +188,7 @@ final class URLSchemeHandler {
 
     // 3. Title match within a named provider
     if let providerID, let title {
-      if let task = await lookupByTitle(title, providerID: providerID) {
+      if let task = await lookupByTitle(title, providerID: ProviderID(providerID)) {
         return task
       }
     }
@@ -210,7 +212,7 @@ final class URLSchemeHandler {
     return nil
   }
 
-  private func lookupByID(nativeID: String, providerID: String) async -> TaskItem? {
+  private func lookupByID(nativeID: String, providerID: ProviderID) async -> TaskItem? {
     guard let provider = registry.providers.first(where: { $0.id == providerID }),
       registry.isEnabled(provider.id)
     else { return nil }
@@ -228,7 +230,7 @@ final class URLSchemeHandler {
     return nil
   }
 
-  private func lookupByTitle(_ title: String, providerID: String) async -> TaskItem? {
+  private func lookupByTitle(_ title: String, providerID: ProviderID) async -> TaskItem? {
     guard let provider = registry.providers.first(where: { $0.id == providerID }),
       registry.isEnabled(provider.id)
     else { return nil }

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -24,7 +24,7 @@ struct AppSidebarView: View {
   var onTaskAdded: (() -> Void)?
 
   /// Inline new-list name buffer keyed by provider ID.
-  @State private var newListName: [String: String] = [:]
+  @State private var newListName: [ProviderID: String] = [:]
 
   /// The list ID currently being renamed inline, or `nil` when no rename is in progress.
   @State private var renamingListID: String?
@@ -131,7 +131,7 @@ struct AppSidebarView: View {
 
   @ViewBuilder
   private func providerSection(_ provider: any TaskProvider) -> some View {
-    Section(isExpanded: expansionBinding(for: provider.id)) {
+    Section(isExpanded: expansionBinding(for: provider.id.rawValue)) {
       ForEach(lists(for: provider)) { list in
         listRow(list, provider: provider)
           .tag(AppDestination.list(SelectedList(providerID: provider.id, listID: list.id)))
@@ -330,7 +330,7 @@ struct AppSidebarView: View {
   // MARK: - New list row
 
   @ViewBuilder
-  private func newListRow(providerID: String) -> some View {
+  private func newListRow(providerID: ProviderID) -> some View {
     let nameBinding = Binding(
       get: { newListName[providerID] ?? "" },
       set: { newListName[providerID] = $0 }
@@ -393,11 +393,11 @@ struct AppSidebarView: View {
   /// Reacts to providers becoming enabled from any source: re-expands each section, opens the
   /// configuration sheet for a configurable provider that is not yet authorized (so lists can
   /// load), and refreshes its list cache.
-  private func handleNewlyEnabled(_ addedIDs: Set<String>) {
+  private func handleNewlyEnabled(_ addedIDs: Set<ProviderID>) {
     guard !addedIDs.isEmpty else { return }
     let added = registry.providers.filter { addedIDs.contains($0.id) }
     for provider in added {
-      settings.collapsedSidebarSections.remove(provider.id)
+      settings.collapsedSidebarSections.remove(provider.id.rawValue)
       if let configurable = provider as? (any ConfigurableTaskProvider), !provider.isAuthorized {
         configuringProvider = configurable
       }

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -93,16 +93,10 @@ struct SettingsView: View {
       }
 
       Section("Tasks") {
-        Picker(
-          "Default writable provider",
-          selection: Binding(
-            get: { settings.defaultWritableProviderID ?? "" },
-            set: { settings.defaultWritableProviderID = $0.isEmpty ? nil : $0 }
-          )
-        ) {
-          Text("Automatic").tag("")
+        Picker("Default writable provider", selection: $settings.defaultWritableProviderID) {
+          Text("Automatic").tag(ProviderID?.none)
           ForEach(writableProviderEntries) { entry in
-            Label(entry.displayName, systemImage: entry.icon).tag(entry.id)
+            Label(entry.displayName, systemImage: entry.icon).tag(ProviderID?.some(entry.id))
           }
         }
         Text(
@@ -158,7 +152,7 @@ private struct SystemSound: Identifiable {
 
 /// A lightweight display model for a writable provider in the settings picker.
 private struct ProviderEntry: Identifiable {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String
 }

--- a/app/Taskmato/Views/Stats/StatsViewModel.swift
+++ b/app/Taskmato/Views/Stats/StatsViewModel.swift
@@ -84,7 +84,7 @@ final class StatsViewModel {
 
     for session in completedFocus(in: scopedInterval) {
       let day = calendar.startOfDay(for: session.startedAt)
-      let providerID = session.taskRef?.providerID ?? Self.untrackedKey
+      let providerID = session.taskRef?.providerID.rawValue ?? Self.untrackedKey
       let key = "\(day.timeIntervalSinceReferenceDate):\(providerID)"
       if accumulated[key] == nil {
         order.append(key)
@@ -110,7 +110,7 @@ final class StatsViewModel {
     var accumulated: [String: TimeInterval] = [:]
 
     for session in completedFocus(in: scopedInterval) {
-      let providerID = session.taskRef?.providerID ?? Self.untrackedKey
+      let providerID = session.taskRef?.providerID.rawValue ?? Self.untrackedKey
       if accumulated[providerID] == nil { order.append(providerID) }
       accumulated[providerID, default: 0] += session.duration
     }
@@ -135,7 +135,7 @@ final class StatsViewModel {
     for session in sessions where session.phase == .focus && session.wasCompleted {
       let key: String
       if let ref = session.taskRef {
-        key = "\(ref.providerID):\(ref.nativeID)"
+        key = "\(ref.providerID.rawValue):\(ref.nativeID)"
       } else {
         key = Self.untrackedKey
       }
@@ -153,7 +153,7 @@ final class StatsViewModel {
       order
       .compactMap { key -> AllTimeTaskRow? in
         guard let entry = accumulated[key] else { return nil }
-        let resolvedLabel = entry.taskRef.map { providerLabel($0.providerID) } ?? "—"
+        let resolvedLabel = entry.taskRef.map { providerLabel($0.providerID.rawValue) } ?? "—"
         return AllTimeTaskRow(
           taskRef: entry.taskRef, title: entry.title, providerLabel: resolvedLabel,
           totalMinutes: Int(entry.seconds / 60), lastSessionDate: entry.last)
@@ -299,7 +299,7 @@ final class StatsViewModel {
         for slot in 0...(dayOffset % 3) {
           let provider = providers[(dayOffset + slot) % providers.count]
           let start = day.addingTimeInterval(TimeInterval((9 + slot) * 3_600))
-          let ref = provider.map { TaskRef(providerID: $0, nativeID: "task-\(slot)") }
+          let ref = provider.map { TaskRef(providerID: ProviderID($0), nativeID: "task-\(slot)") }
           sessions.append(
             Session(
               id: UUID(), phase: .focus, startedAt: start,

--- a/app/TaskmatoTests/MainNavigationTests.swift
+++ b/app/TaskmatoTests/MainNavigationTests.swift
@@ -11,14 +11,14 @@ import Testing
 // MARK: - Fakes
 
 private final class NavStubProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
 
-  init(id: String) {
+  init(id: ProviderID) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
   }
 
   func authorize() async throws {}

--- a/app/TaskmatoTests/ObsidianTaskParserOrderedListTests.swift
+++ b/app/TaskmatoTests/ObsidianTaskParserOrderedListTests.swift
@@ -12,7 +12,7 @@ import Testing
 struct ObsidianTaskParserOrderedListTests {
 
   private let parser = ObsidianTaskParser()
-  private let providerID = "obsidian"
+  private let providerID: ProviderID = "obsidian"
   private let dummyList = TaskList(id: "tasks.md", providerID: "obsidian", name: "tasks")
 
   private func parse(_ content: String) -> [TaskItem] {

--- a/app/TaskmatoTests/ObsidianTaskParserTests.swift
+++ b/app/TaskmatoTests/ObsidianTaskParserTests.swift
@@ -12,7 +12,7 @@ import Testing
 struct ObsidianTaskParserTests {
 
   private let parser = ObsidianTaskParser()
-  private let providerID = "obsidian"
+  private let providerID: ProviderID = "obsidian"
   private let dummyList = TaskList(id: "tasks.md", providerID: "obsidian", name: "tasks")
 
   private func parse(_ content: String, relativePath: String = "tasks.md") -> [TaskItem] {
@@ -356,7 +356,7 @@ struct ObsidianTaskParserTests {
 struct ObsidianTaskParserCompletedTests {
 
   private let parser = ObsidianTaskParser()
-  private let providerID = "obsidian"
+  private let providerID: ProviderID = "obsidian"
   private let dummyList = TaskList(id: "tasks.md", providerID: "obsidian", name: "tasks")
 
   private func parseCompleted(

--- a/app/TaskmatoTests/ProviderRegistryTests.swift
+++ b/app/TaskmatoTests/ProviderRegistryTests.swift
@@ -13,16 +13,16 @@ import Testing
 private struct StubError: Error, Equatable {}
 
 private final class StubProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let stubbedTasks: [TaskItem]
   let shouldThrow: Bool
 
-  init(id: String, tasks: [TaskItem] = [], shouldThrow: Bool = false) {
+  init(id: ProviderID, tasks: [TaskItem] = [], shouldThrow: Bool = false) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.stubbedTasks = tasks
     self.shouldThrow = shouldThrow
   }
@@ -37,15 +37,15 @@ private final class StubProvider: TaskProvider {
 }
 
 private final class StubWritableProvider: WritableTaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private(set) var defaultListID: String?
 
-  init(id: String) {
+  init(id: ProviderID) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
   }
 
   func authorize() async throws {}
@@ -76,15 +76,15 @@ private final class StubWritableProvider: WritableTaskProvider {
 }
 
 private final class StubUnauthorizedProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let isAuthorized = false
 
-  init(id: String) {
+  init(id: ProviderID) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
   }
 
   func authorize() async throws {}
@@ -94,16 +94,16 @@ private final class StubUnauthorizedProvider: TaskProvider {
 }
 
 private final class StubClosableProvider: ClosableTaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let stubbedTasks: [TaskItem]
   private(set) var completedRefs: [TaskRef] = []
 
-  init(id: String, tasks: [TaskItem] = []) {
+  init(id: ProviderID, tasks: [TaskItem] = []) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.stubbedTasks = tasks
   }
 

--- a/app/TaskmatoTests/SelectionStoreTests.swift
+++ b/app/TaskmatoTests/SelectionStoreTests.swift
@@ -11,16 +11,16 @@ import Testing
 // MARK: - Fakes
 
 private final class SelectionStubProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private let stubbedTasks: [TaskItem]
   private let stubbedLists: [TaskList]
 
-  init(id: String, tasks: [TaskItem] = [], lists: [TaskList] = []) {
+  init(id: ProviderID, tasks: [TaskItem] = [], lists: [TaskList] = []) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.stubbedTasks = tasks
     self.stubbedLists = lists
   }
@@ -32,15 +32,15 @@ private final class SelectionStubProvider: TaskProvider {
 }
 
 private final class SelectionWritableProvider: WritableTaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let defaultListID: String?
 
-  init(id: String, defaultListID: String? = nil) {
+  init(id: ProviderID, defaultListID: String? = nil) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.defaultListID = defaultListID
   }
 

--- a/app/TaskmatoTests/StatsViewModelTests.swift
+++ b/app/TaskmatoTests/StatsViewModelTests.swift
@@ -28,7 +28,7 @@ struct StatsViewModelTests {
 
   private func focus(
     start: Date, minutes: Int = 25, completed: Bool = true,
-    provider: String? = nil, nativeID: String = "t1", title: String? = nil
+    provider: ProviderID? = nil, nativeID: String = "t1", title: String? = nil
   ) -> Session {
     let ref = provider.map { TaskRef(providerID: $0, nativeID: nativeID) }
     return Session(

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -12,7 +12,7 @@ import Testing
 // MARK: - Fakes
 
 private final class FakeWritableProvider: WritableTaskProvider {
-  let id = "fake-writable"
+  let id: ProviderID = "fake-writable"
   let displayName = "Fake Writable"
   let icon = "square"
   let entitlement: ProviderEntitlement = .free
@@ -71,7 +71,7 @@ private final class FakeWritableProvider: WritableTaskProvider {
 }
 
 private final class FakeReadOnlyProvider: TaskProvider {
-  let id = "fake-readonly"
+  let id: ProviderID = "fake-readonly"
   let displayName = "Fake Read-Only"
   let icon = "square"
   let entitlement: ProviderEntitlement = .free
@@ -83,7 +83,7 @@ private final class FakeReadOnlyProvider: TaskProvider {
 }
 
 private final class FakeUnauthorizedProvider: TaskProvider {
-  let id = "fake-unauthorized"
+  let id: ProviderID = "fake-unauthorized"
   let displayName = "Fake Unauthorized"
   let icon = "square"
   let entitlement: ProviderEntitlement = .free
@@ -96,7 +96,7 @@ private final class FakeUnauthorizedProvider: TaskProvider {
 }
 
 private final class FakeConfigurableProvider: TaskProvider, ConfigurableTaskProvider {
-  let id = "fake-configurable"
+  let id: ProviderID = "fake-configurable"
   let displayName = "Fake Configurable"
   let icon = "square"
   let entitlement: ProviderEntitlement = .free
@@ -111,7 +111,7 @@ private final class FakeConfigurableProvider: TaskProvider, ConfigurableTaskProv
 }
 
 private final class FakeClosableProvider: ClosableTaskProvider {
-  let id = "fake-closable"
+  let id: ProviderID = "fake-closable"
   let displayName = "Fake Closable"
   let icon = "square"
   let entitlement: ProviderEntitlement = .paid(productID: "com.taskmato.provider.fake")

--- a/app/TaskmatoTests/TaskQueryServiceTests.swift
+++ b/app/TaskmatoTests/TaskQueryServiceTests.swift
@@ -14,7 +14,7 @@ private struct QueryStubError: Error, Equatable {}
 
 /// Returns a fixed task set from `tasks(in:)` regardless of the requested list.
 private final class QueryStubProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
@@ -22,9 +22,9 @@ private final class QueryStubProvider: TaskProvider {
   private let stubbedLists: [TaskList]
   private let shouldThrow: Bool
 
-  init(id: String, tasks: [TaskItem] = [], lists: [TaskList] = [], shouldThrow: Bool = false) {
+  init(id: ProviderID, tasks: [TaskItem] = [], lists: [TaskList] = [], shouldThrow: Bool = false) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.stubbedTasks = tasks
     self.stubbedLists = lists
     self.shouldThrow = shouldThrow
@@ -41,16 +41,16 @@ private final class QueryStubProvider: TaskProvider {
 
 /// Scopes returned tasks to the requested list, so single-list queries can be exercised.
 private final class QueryScopedProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private let stubbedLists: [TaskList]
   private let tasksByListID: [String: [TaskItem]]
 
-  init(id: String, listTasks: [(TaskList, [TaskItem])]) {
+  init(id: ProviderID, listTasks: [(TaskList, [TaskItem])]) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.stubbedLists = listTasks.map(\.0)
     self.tasksByListID = Dictionary(uniqueKeysWithValues: listTasks.map { ($0.0.id, $0.1) })
   }
@@ -65,7 +65,7 @@ private final class QueryScopedProvider: TaskProvider {
 }
 
 private func queryItem(
-  providerID: String = "p",
+  providerID: ProviderID = "p",
   nativeID: String = UUID().uuidString,
   title: String,
   priority: TaskPriority = .none,

--- a/app/TaskmatoTests/TaskSelectionStoreTests.swift
+++ b/app/TaskmatoTests/TaskSelectionStoreTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 @testable import Taskmato
 
-private func makeItem(providerID: String, nativeID: String, title: String) -> TaskItem {
+private func makeItem(providerID: ProviderID, nativeID: String, title: String) -> TaskItem {
   TaskItem(
     id: TaskRef(providerID: providerID, nativeID: nativeID),
     title: title,

--- a/app/TaskmatoTests/TaskSorterTests.swift
+++ b/app/TaskmatoTests/TaskSorterTests.swift
@@ -11,7 +11,7 @@ import Testing
 // MARK: - Factory
 
 private func makeSortItem(
-  providerID: String = "p",
+  providerID: ProviderID = "p",
   nativeID: String,
   title: String,
   priority: TaskPriority = .none,

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -22,15 +22,15 @@ private struct HandlerContext {
 // MARK: - Fakes
 
 private final class StubTaskProvider: TaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private let stubbedTasks: [TaskItem]
 
-  init(id: String, tasks: [TaskItem] = []) {
+  init(id: ProviderID, tasks: [TaskItem] = []) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
     self.stubbedTasks = tasks
   }
 
@@ -41,15 +41,15 @@ private final class StubTaskProvider: TaskProvider {
 }
 
 private final class StubWritableProvider: WritableTaskProvider {
-  let id: String
+  let id: ProviderID
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let defaultListID: String? = nil
 
-  init(id: String) {
+  init(id: ProviderID) {
     self.id = id
-    self.displayName = id
+    self.displayName = id.rawValue
   }
 
   nonisolated func authorize() async throws {}
@@ -103,7 +103,7 @@ struct URLSchemeHandlerTests {
   private func makeHandler(
     stubProviderTasks: [TaskItem] = [],
     enableLocalProvider: Bool = true,
-    defaultWritableProviderID: String? = nil
+    defaultWritableProviderID: ProviderID? = nil
   ) -> HandlerContext {
     let defaults = UserDefaults(suiteName: UUID().uuidString)!
     let settingsStore = SettingsStore(defaults: defaults)
@@ -148,7 +148,7 @@ struct URLSchemeHandlerTests {
     )
   }
 
-  private func makeTask(title: String, providerID: String = "stub") -> TaskItem {
+  private func makeTask(title: String, providerID: ProviderID = "stub") -> TaskItem {
     TaskItem(
       id: TaskRef(providerID: providerID, nativeID: UUID().uuidString),
       title: title,


### PR DESCRIPTION
## Summary

Introduce a `ProviderID` value type and migrate the domain models and provider registry off raw `String` provider identifiers.

## Linked issue

Closes #403

## Motivation

`TaskRef.providerID: String` was type-safe only by convention — provider IDs were compared against string literals (`"local"`, `"obsidian"`, …) and static constants interchangeably. A newtype catches every site where a non-provider string could leak in and produces clearer call sites (`ref.providerID == LocalProvider.providerID` rather than `== "local"`). Doing this before 1.0 avoids a breaking change to stored task data later. Roadmap PR 26 / Finding S in design doc [`0005-pre-1.0-architecture-pass.md`](docs/architecture/design/0005-pre-1.0-architecture-pass.md).

## Changes

- **New `ProviderID`** (`Tasks/Models/ProviderID.swift`): `Hashable, Codable, Sendable, RawRepresentable, ExpressibleByStringLiteral`. Custom `Codable` uses a single-value string container, so JSON/SwiftData records stay byte-for-byte compatible with the previous `String` form; string literals (`static let providerID: ProviderID = "local"`) keep working.
- **Migrated to `ProviderID`:** `TaskRef`, `TaskList`, `SelectedList`, `TaskProvider.id` + the three provider constants, `ObsidianTaskParser`, `TaskQueryService.ProviderFetchError`, `ProviderRegistry` (`enabledIDs`, `providerLists` keys, ID-taking methods), and `AppSettings.defaultWritableProviderID`. Added optional and set `RawRepresentable` subscripts to `SettingsStore`.
- **Boundaries kept as `String`** (converted via `.rawValue`): SwiftData columns in `SessionEntity`; the stats aggregation layer (`StatsViewModel`, `StatTypes`, `SessionSummary`) whose grouping keys intermix the `__untracked__` sentinel; and raw `taskmato://` URL params, converted to `ProviderID` at the point of use.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

`make build` succeeds, `make test` passes (488 test cases, 0 failures), `make lint` reports 0 violations, `make format-check` is clean.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

Persistence stays string-compatible on disk, so no data migration is needed.

## Reviewer notes

The key enabler is `ExpressibleByStringLiteral` + single-value `Codable`, which let most `TaskRef(providerID: "reminders", …)` construction and `== "reminders"` comparison sites compile unchanged. The interesting review surface is the deliberate `String` boundaries listed under Changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)