### PR TITLE
fix(timer): disable Skip when idle with no break queued

### DIFF
--- a/app/Taskmato/Views/Timer/Components/TimerControlsView.swift
+++ b/app/Taskmato/Views/Timer/Components/TimerControlsView.swift
@@ -20,7 +20,18 @@ enum TimerControlsSize {
   var spacing: CGFloat { self == .compact ? .groupGap : .sectionGap }
 }
 
-/// The start/pause · skip · stop control row shared by every timer surface.
+/// The transport control row — primary (Start/Pause/Resume) · Skip · Stop — whose
+/// enablement derives from the session state in ``TimerPresenter``.
+///
+/// | Session state          | Primary | Skip | Stop |
+/// |------------------------|---------|------|------|
+/// | idle (nothing/focus queued) | Start   |  ✗   |  ✗   |
+/// | idle (break queued)    | Start   |  ✓*  |  ✗   |
+/// | running                | Pause   |  ✓   |  ✓   |
+/// | paused                 | Resume  |  ✓   |  ✓   |
+///
+/// *Skip while idle cycles a queued break back to focus. Start additionally requires a
+/// selected task, gated externally via `startDisabled`.
 ///
 /// All intents route through the injected ``TimerPresenter``; callers vary only the
 /// ``TimerControlsSize`` and whether Start is disabled (typically when no task is
@@ -45,6 +56,7 @@ struct TimerControlsView: View {
         icon: AppLabels.Timer.skip.systemImage,
         diameter: size.secondaryDiameter
       ) { presenter.skip() }
+      .disabled(!presenter.canSkip)
 
       ControlButton(
         label: AppLabels.Timer.stop.title,

--- a/app/Taskmato/Views/Timer/TimerPresenter.swift
+++ b/app/Taskmato/Views/Timer/TimerPresenter.swift
@@ -85,6 +85,14 @@ final class TimerPresenter {
   /// `true` when there is a session to stop (running or paused).
   var canStop: Bool { engine.state != .idle }
 
+  /// `true` when Skip has an effect: an active phase to advance, or a queued break to
+  /// cycle back to focus while idle.
+  var canSkip: Bool {
+    if engine.state != .idle { return true }
+    guard let queued = engine.queuedPhase else { return false }
+    return queued != .focus  // a break is queued; idle-skip cycles it to focus
+  }
+
   // MARK: - Intents
 
   /// Syncs the latest durations into the engine, then starts the queued (or focus) phase.

--- a/app/TaskmatoTests/TimerPresenterTests.swift
+++ b/app/TaskmatoTests/TimerPresenterTests.swift
@@ -100,4 +100,63 @@ struct TimerPresenterTests {
     #expect(presenter.isIdle)
     #expect(!presenter.canStop)
   }
+
+  // MARK: - Enablement
+
+  @Test func canSkipDisabledWhenIdleWithNothingQueued() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings())
+    #expect(presenter.isIdle)
+    #expect(!presenter.isRunning)
+    #expect(!presenter.isPaused)
+    #expect(!presenter.canStop)
+    #expect(!presenter.canSkip)
+  }
+
+  @Test func canSkipEnabledWhenIdleWithBreakQueued() {
+    let engine = SessionEngine()
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings())
+    engine.enqueuePhase(.shortBreak)
+    #expect(presenter.isIdle)
+    #expect(!presenter.canStop)
+    #expect(presenter.canSkip)
+  }
+
+  @Test func canSkipDisabledWhenIdleWithFocusQueued() {
+    let engine = SessionEngine()
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings())
+    engine.enqueuePhase(.focus)
+    #expect(presenter.isIdle)
+    #expect(!presenter.canStop)
+    #expect(!presenter.canSkip)
+  }
+
+  @Test func canSkipAndCanStopEnabledWhenRunning() {
+    let engine = SessionEngine()
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings())
+    presenter.start()
+    #expect(presenter.isRunning)
+    #expect(!presenter.isPaused)
+    #expect(presenter.canStop)
+    #expect(presenter.canSkip)
+  }
+
+  @Test func canSkipAndCanStopEnabledWhenPaused() {
+    let engine = SessionEngine()
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings())
+    presenter.start()
+    presenter.pause()
+    #expect(presenter.isPaused)
+    #expect(!presenter.isRunning)
+    #expect(presenter.canStop)
+    #expect(presenter.canSkip)
+  }
+
+  @Test func canSkipAndCanStopDisabledAfterStoppingBackToIdle() {
+    let engine = SessionEngine()
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings())
+    presenter.start()
+    presenter.stop()
+    #expect(!presenter.canStop)
+    #expect(!presenter.canSkip)
+  }
 }

--- a/docs/reference/timer-controls.md
+++ b/docs/reference/timer-controls.md
@@ -1,0 +1,44 @@
+# Timer Controls
+
+Reference for the timer transport controls (Start/Pause/Resume · Skip · Stop) and the
+active-task controls (Complete · Swap · Clear). Enablement and behavior derive from
+`SessionEngine.state` via `TimerPresenter`, and are shared identically across all three
+surfaces — the Timer tab, the menu-bar popover, and the in-window timer strip.
+
+## Surfaces
+
+| Surface | Transport size | Active-task style |
+| --- | --- | --- |
+| Timer tab (`TimerTabView`) | `.regular` | `.detail` (radio + swap + clear) |
+| Menu-bar popover (`MenuBarPopoverView`) | `.compact` | `.compact` (radio + title) |
+| In-window strip (`TimerStripView`) | `.compact` | `.compact` (radio + title) |
+
+All three bind the same `TimerPresenter` and `TimerControlsView`, so enablement can't
+drift between surfaces.
+
+## Transport controls
+
+| Session state | Primary | Skip | Stop |
+| --- | --- | --- | --- |
+| idle (nothing queued) | Start | ✗ | ✗ |
+| idle (focus queued) | Start | ✗ | ✗ |
+| idle (break queued) | Start | ✓ | ✗ |
+| running | Pause | ✓ | ✓ |
+| paused | Resume | ✓ | ✓ |
+
+Start is additionally gated by task selection
+(`startDisabled = selectionStore.activeTask == nil`), an external task-selection axis
+orthogonal to session state. The idle "break queued" row is only reachable mid-cycle
+after a phase completes with auto-start off — `PhaseOrchestrator` enqueues the next
+phase. Idle Skip cycles a queued break back to focus.
+
+## Active-task controls
+
+| Control | Idle | Active |
+| --- | --- | --- |
+| Complete radio (all surfaces, when provider closable) | Completes immediately + clears selection | Inline "Stop & complete?" confirm → stop + complete |
+| Swap (`.detail` only) | Not shown | Visible; pauses if running, opens task picker |
+| Clear ✕ (`.detail` only) | Clears immediately | Inline "Stop & clear?" confirm → stop + clear |
+
+These are behavior/visibility-driven, not enabled/disabled, and all read the single
+`engine.state` source, so there's no drift.


### PR DESCRIPTION
## Summary

The timer's **Skip** control had no session-state guard, so it stayed actionable while the session was idle even though there was no active phase to advance. This audit gives control enablement a single source of truth in the presenter and documents the full truth table.

## Linked issue

Closes #463

## Root cause

Control availability was derived ad hoc from a few presenter flags (`isRunning`, `isPaused`, `canStop`) plus a caller-supplied `startDisabled`. **Skip** was wired with no `.disabled(...)` modifier at all, so it never reflected session state — enabled while idle where `engine.skip()` has no phase to advance.

## Fix

Enablement now derives from session state in `TimerPresenter`, mirroring `canStop`:

- Added `TimerPresenter.canSkip` — enabled while running/paused, and while idle **only when a break is queued** (the one idle case where `engine.skip()` does something: it cycles the queued break back to focus, "skip the break, keep working"). Disabled when nothing or a focus is queued (e.g. fresh task selection).
- Gated the Skip button on `canSkip` in `TimerControlsView`. All three surfaces (Timer tab, menu-bar popover, in-window strip) share the same presenter + controls view, so enablement can't drift between them.
- Documented the control truth table on the `TimerControlsView` doc comment and in a new `docs/reference/timer-controls.md` (covers transport controls + the active-task complete/swap/clear controls, which were audited and confirmed correct — no change).

`Start`'s "no task selected" gating stays external (`startDisabled`) — it's a task-selection axis, orthogonal to session state.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

`make format-check` clean · `make lint` 0 violations · `make build` and `make test` succeed, including 6 new `canSkip*` enablement tests across idle (nothing/break/focus queued) / running / paused.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The idle "break queued" state is only reachable mid-cycle: after a focus phase completes with auto-start off, `PhaseOrchestrator` enqueues the next phase and Start reads "Start Short Break" — pressing Skip there flips the queue to focus. That affordance is preserved on purpose (see the `canSkip` break check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)