### PR TITLE
feat(a11y): timer announcements, control labels, and Dynamic Type

### DIFF
--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -216,6 +216,7 @@ struct AppSidebarView: View {
         .buttonStyle(.borderless)
         .foregroundStyle(isDefaultList ? Color.favoriteStar : Color.secondary)
         .help(isDefaultList ? "Default list" : "Set as default list")
+        .accessibilityLabel(isDefaultList ? "Default list" : "Set as default list")
       }
     }
   }

--- a/app/Taskmato/Views/App/DesignTokens/Typography.swift
+++ b/app/Taskmato/Views/App/DesignTokens/Typography.swift
@@ -16,9 +16,6 @@ extension Font {
   /// Ancestor/lineage breadcrumb shown under a task; sits below metadata in emphasis.
   static let taskLineage: Font = .caption2
 
-  /// Large monospaced countdown at the center of the timer ring.
-  static let timerCountdown: Font = .system(size: 36, weight: .light, design: .monospaced)
-
   /// Phase label ("Focus", "Break") under the timer countdown.
   static let timerPhaseLabel: Font = .subheadline
 

--- a/app/Taskmato/Views/Tasks/Components/TaskDeleteButtonView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskDeleteButtonView.swift
@@ -29,6 +29,7 @@ struct TaskDeleteButtonView: View {
       }
       .buttonStyle(.plain)
       .help(AppLabels.Tooltip.deletePermanently)
+      .accessibilityLabel(AppLabels.Tooltip.deletePermanently)
       .opacity(isHovered ? 1 : 0)
       .allowsHitTesting(isHovered)
       .accessibilityHidden(!isHovered)

--- a/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
@@ -52,6 +52,12 @@ enum AppLabels {
     static let hideCompleted = "Hide completed tasks"
   }
 
+  /// VoiceOver labels for controls whose visible content is not text.
+  enum Accessibility {
+    /// Announced for the circular countdown ring on the Timer surface.
+    static let timer = "Pomodoro timer"
+  }
+
   /// Labels for task CRUD and lifecycle actions.
   enum Task {
     /// Sets the task as active and switches to the Timer tab.

--- a/app/Taskmato/Views/Tasks/Components/TaskStateButtonView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskStateButtonView.swift
@@ -23,6 +23,7 @@ struct TaskStateButtonView: View {
       }
       .buttonStyle(.plain)
       .help(AppLabels.Tooltip.restore)
+      .accessibilityLabel(AppLabels.Tooltip.restore)
     } else if let onComplete = presenter.onComplete {
       TaskCompletionButton(
         action: onComplete, label: AppLabels.Tooltip.markAsCompleted, isHovered: $isHovered)

--- a/app/Taskmato/Views/Timer/ActiveTaskView.swift
+++ b/app/Taskmato/Views/Timer/ActiveTaskView.swift
@@ -78,6 +78,7 @@ struct ActiveTaskView: View {
           }
           .buttonStyle(.plain)
           .help(AppLabels.Tooltip.swapTask)
+          .accessibilityLabel(AppLabels.Tooltip.swapTask)
         }
 
         Button {
@@ -92,6 +93,7 @@ struct ActiveTaskView: View {
         }
         .buttonStyle(.plain)
         .help(AppLabels.Tooltip.clearTask)
+        .accessibilityLabel(AppLabels.Tooltip.clearTask)
       }
     }
   }

--- a/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
+++ b/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
@@ -14,6 +14,8 @@ struct CircularTimerView: View {
   let label: String
   /// The phase name displayed below the time, e.g. `"Focus"`.
   let phase: String
+  /// The VoiceOver value announced for the ring, e.g. `"Focus, 24 minutes remaining"`.
+  let accessibilityValue: String
 
   private let ringDiameter: CGFloat = 180
   private let strokeWidth: CGFloat = 10
@@ -23,5 +25,9 @@ struct CircularTimerView: View {
       TimerRing(progress: progress, diameter: ringDiameter, strokeWidth: strokeWidth)
       TimerReadout(label: label, phase: phase)
     }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(AppLabels.Accessibility.timer)
+    .accessibilityValue(accessibilityValue)
+    .dynamicTypeSize(...DynamicTypeSize.accessibility1)
   }
 }

--- a/app/Taskmato/Views/Timer/Components/TimerReadout.swift
+++ b/app/Taskmato/Views/Timer/Components/TimerReadout.swift
@@ -17,10 +17,13 @@ struct TimerReadout: View {
   /// The phase name shown below the time, e.g. `"Focus"`.
   let phase: String
 
+  /// The countdown's base point size, scaled by Dynamic Type relative to `.largeTitle`.
+  @ScaledMetric(relativeTo: .largeTitle) private var countdownSize: CGFloat = 36
+
   var body: some View {
     VStack(spacing: .rowVertical) {
       Text(label)
-        .font(.timerCountdown)
+        .font(.system(size: countdownSize, weight: .light, design: .monospaced))
         .foregroundStyle(.primary)
       Text(phase)
         .font(.timerPhaseLabel)

--- a/app/Taskmato/Views/Timer/TimerPresenter.swift
+++ b/app/Taskmato/Views/Timer/TimerPresenter.swift
@@ -68,6 +68,20 @@ final class TimerPresenter {
     }
   }
 
+  /// Phase (plus paused) and coarse remaining time announced to VoiceOver, e.g. "Focus, 24 minutes remaining".
+  ///
+  /// Whole-minute granularity avoids per-second VoiceOver re-announcement while focus is parked on the ring;
+  /// the final 10 seconds count down by seconds as an intentional finish cue. The visible `label` stays precise.
+  var accessibilityValue: String {
+    if case .idle = engine.state {
+      let seconds = Int(settingsDuration(for: nextStartPhase))
+      return "\(phaseName), \(Self.spokenRemaining(seconds, includeRemaining: false))"
+    }
+    let seconds = Int(engine.timeRemaining)
+    let phase = isPaused ? "\(phaseName), paused" : phaseName
+    return "\(phase), \(Self.spokenRemaining(seconds, includeRemaining: true))"
+  }
+
   // MARK: - State
 
   /// `true` while a phase is actively counting down.
@@ -136,5 +150,21 @@ final class TimerPresenter {
     case .shortBreak: return settings.shortBreakDuration
     case .longBreak: return settings.longBreakDuration
     }
+  }
+
+  /// Formats a remaining-seconds count for VoiceOver: whole minutes (floored) above a minute,
+  /// a vague phrase in the sub-minute band, and per-second detail in the final 10 seconds.
+  private static func spokenRemaining(_ seconds: Int, includeRemaining: Bool) -> String {
+    let suffix = includeRemaining ? " remaining" : ""
+    if seconds >= 60 {
+      let minutes = seconds / 60
+      let unit = minutes == 1 ? "minute" : "minutes"
+      return "\(minutes) \(unit)\(suffix)"
+    }
+    if seconds > 10 {
+      return "less than a minute\(suffix)"
+    }
+    let unit = seconds == 1 ? "second" : "seconds"
+    return "\(seconds) \(unit)\(suffix)"
   }
 }

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -23,7 +23,8 @@ struct TimerTabView: View {
       CircularTimerView(
         progress: presenter.progress,
         label: presenter.label,
-        phase: presenter.phaseName
+        phase: presenter.phaseName,
+        accessibilityValue: presenter.accessibilityValue
       )
 
       TimerControlsView(

--- a/app/TaskmatoTests/TimerPresenterTests.swift
+++ b/app/TaskmatoTests/TimerPresenterTests.swift
@@ -60,6 +60,76 @@ struct TimerPresenterTests {
     #expect(presenter.phaseName == SessionPhase.focus.idleLabel)
   }
 
+  // MARK: - Accessibility
+
+  @Test func accessibilityValueWhenIdleShowsConfiguredFocusDuration() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings(focus: 25))
+    #expect(presenter.accessibilityValue == "Ready to focus, 25 minutes")
+  }
+
+  // `pause()` is the only way to obtain a deterministic `timeRemaining` read in these tests
+  // (mirroring `labelWhileActiveReflectsTimeRemaining` above), so every case below observes
+  // the presenter mid-pause — hence the ", paused" segment in each expected value.
+
+  @Test func accessibilityValueAtOneMinuteRemainingUsesSingularUnit() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    presenter.pause()
+    #expect(presenter.accessibilityValue == "Focus, paused, 1 minute remaining")
+  }
+
+  @Test func accessibilityValueUnderAMinuteIsVague() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    now = now.addingTimeInterval(20)
+    presenter.pause()
+    #expect(presenter.accessibilityValue == "Focus, paused, less than a minute remaining")
+  }
+
+  @Test func accessibilityValueInFinalTenSecondsCountsDown() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    now = now.addingTimeInterval(50)
+    presenter.pause()
+    #expect(presenter.accessibilityValue == "Focus, paused, 10 seconds remaining")
+  }
+
+  @Test func accessibilityValueAtOneSecondRemainingUsesSingularUnit() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    now = now.addingTimeInterval(59)
+    presenter.pause()
+    #expect(presenter.accessibilityValue == "Focus, paused, 1 second remaining")
+  }
+
+  @Test func accessibilityValueWhenPausedIncludesPausedState() {
+    var now = Date(timeIntervalSinceReferenceDate: 0)
+    let engine = SessionEngine(now: { now })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 25))
+    presenter.start()
+    now = now.addingTimeInterval(60)
+    presenter.pause()
+    #expect(presenter.accessibilityValue == "Focus, paused, 24 minutes remaining")
+  }
+
+  @Test func accessibilityValueWhileRunningOmitsPausedState() {
+    // A freshly started session is running (not paused) with `timeRemaining` at the full
+    // duration, so no advance/pause is needed to read it deterministically.
+    let engine = SessionEngine(now: { Date(timeIntervalSinceReferenceDate: 0) })
+    let presenter = TimerPresenter(engine: engine, settings: makeSettings(focus: 1))
+    presenter.start()
+    #expect(presenter.isRunning)
+    #expect(presenter.accessibilityValue == "Focus, 1 minute remaining")
+  }
+
   // MARK: - Intents
 
   @Test func startFromIdleBeginsFocus() {

--- a/docs/explanation/accessibility.md
+++ b/docs/explanation/accessibility.md
@@ -1,0 +1,57 @@
+# Accessibility conventions
+
+Taskmato's baseline accessibility pass landed pre-1.0, closing Finding Z in [the pre-1.0 architecture pass](../architecture/design/0005-pre-1.0-architecture-pass.md#findings-inventory) ("No accessibility audit"). This document names the conventions that keep the app accessible going forward, so future PRs don't regress what the pass established.
+
+## Icon-only buttons
+
+Every icon-only `Button` (or `.buttonStyle(.plain)` control) whose label is just an `Image(systemName:)` gets an `.accessibilityLabel` alongside its `.help` tooltip, set to the same string:
+
+```swift
+Button(action: swap) {
+  Image(systemName: "arrow.triangle.swap")
+    .foregroundStyle(.secondary)
+}
+.buttonStyle(.plain)
+.help(AppLabels.Tooltip.swapTask)
+.accessibilityLabel(AppLabels.Tooltip.swapTask)
+```
+
+Reuse strings from `AppLabels` (`app/Taskmato/Views/Tasks/Components/TaskLabel.swift`) rather than duplicating literals — `Tooltip` entries already carry the sentence-style copy that both the tooltip and VoiceOver should speak.
+
+## Composite controls
+
+A control built from several sub-views that together represent one piece of information — not several — should present as a single accessibility element:
+
+```swift
+ZStack {
+  TimerRing(progress: progress, diameter: ringDiameter, strokeWidth: strokeWidth)
+  TimerReadout(label: label, phase: phase)
+}
+.accessibilityElement(children: .ignore)
+.accessibilityLabel(AppLabels.Accessibility.timer)
+.accessibilityValue(accessibilityValue)
+```
+
+`CircularTimerView` (`app/Taskmato/Views/Timer/Components/CircularTimerView.swift`) is the reference example: the label is a stable identity ("Pomodoro timer") that never changes, while the value carries the dynamic state (phase, paused-ness, remaining time). Prefer spelled-out durations ("24 minutes remaining") over `MM:SS` strings — VoiceOver reads digit strings awkwardly. Coarsen values that change often (per-second countdowns) to whole minutes so VoiceOver doesn't re-announce every tick; a short final window (e.g. the last 10 seconds) can drop to per-second detail as an intentional finish cue.
+
+## Dynamic Type
+
+Avoid fixed `.system(size:)` fonts for user-facing text — prefer semantic fonts (`.title`, `.callout`, the tokens in `Typography.swift`) so text scales with the system Dynamic Type setting. Where a fixed base size is unavoidable (e.g. matching a specific visual proportion), scale it with `@ScaledMetric(relativeTo:)` instead of a literal:
+
+```swift
+@ScaledMetric(relativeTo: .largeTitle) private var countdownSize: CGFloat = 36
+...
+Text(label)
+  .font(.system(size: countdownSize, weight: .light, design: .monospaced))
+```
+
+`TimerReadout` (`app/Taskmato/Views/Timer/Components/TimerReadout.swift`) does this for the timer countdown. When scaled content sits inside a fixed-size container — the countdown ring has a fixed diameter — cap the growth with `.dynamicTypeSize(...DynamicTypeSize.accessibility1)` so text can't outgrow the space it's centered in.
+
+## Color contrast
+
+Audit checklist for surfaces that pair a low-emphasis color with a low-emphasis background:
+
+- The orange priority glyph (`app/Taskmato/Views/Tasks/Components/PriorityGlyph.swift`, `.orange` via `TaskPriority.accentColor`) sits on `cardSurface` (`.secondary.opacity(.subtle)`, effectively `.secondary` at 10% opacity) in card layouts. Confirm the glyph still reads at that opacity against light and dark backgrounds.
+- The `.tertiary`-styled `TaskLineageRow` sits on that same faint `cardSurface` fill. `.tertiary` is already the lowest-emphasis system style; verify it doesn't drop below legible contrast once layered on the card tint.
+
+To run the check: open Xcode ▸ Open Developer Tool ▸ Accessibility Inspector, point it at the running app, and run an audit against the macOS Human Interface Guidelines contrast guidance. See [Styling Tokens](../reference/styling.md) for where `cardSurface` and the priority colors are defined.

--- a/docs/reference/styling.md
+++ b/docs/reference/styling.md
@@ -17,7 +17,6 @@ are used directly — they are not re-exported as tokens.
 | `taskTitle` | `.callout` | Primary task title in rows, cards, and the active-task label |
 | `taskMetadata` | `.caption2` | Supporting metadata under a title (due date, priority marks) |
 | `taskLineage` | `.caption2` | Ancestor/lineage breadcrumb under a task |
-| `timerCountdown` | `.system(size: 36, weight: .light, design: .monospaced)` | Countdown at the center of the timer ring |
 | `timerPhaseLabel` | `.subheadline` | Phase label under the countdown |
 | `statValue` | `.title.monospacedDigit()` | Prominent numeric value in a stat card |
 | `statLabel` | `.caption` | Caption describing a stat value |


### PR DESCRIPTION
## Summary

Baseline accessibility pass for pre-1.0 — makes the timer and icon controls reachable by VoiceOver, scales the timer countdown with Dynamic Type, and records the conventions so future PRs don't regress. This closes Finding Z / roadmap PR 40 of the pre-1.0 architecture pass.

## Linked issue

Closes #411

## Motivation

The app had **zero** accessibility annotations. VoiceOver reached the circular timer only as three disconnected elements (a decorative ring plus two bare `Text`s) with no phase or time context, five icon-only buttons announced nothing, and the countdown used a fixed 36 pt font that ignored Dynamic Type.

## Changes

- **Timer announcement** — `CircularTimerView` now presents as a single accessibility element (`.accessibilityElement(children: .ignore)`) with a stable label (`"Pomodoro timer"`) and a dynamic value from `TimerPresenter.accessibilityValue`. The value is floored to whole minutes so VoiceOver doesn't re-announce every second while focus is parked, announces paused state, and drops to per-second detail in the final 10 seconds. The visible `MM:SS` is unchanged.
- **Control labels** — added `.accessibilityLabel` to the five previously unlabeled icon buttons (sidebar default-list star, task delete/restore, active-task swap/clear), each matching its existing `.help` string.
- **Dynamic Type** — the countdown scales via `@ScaledMetric(relativeTo: .largeTitle)` (36 pt default preserved), and the ring subtree is capped at `.accessibility1` so enlarged text can't overflow the fixed ring. The now-unused `timerCountdown` font token was removed (and its stale row in `docs/reference/styling.md`).
- **Docs** — new `docs/explanation/accessibility.md` charter documenting the conventions, including a color-contrast audit checklist.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

`make lint` → 0 violations; `make format-check` → clean; `xcodebuild test -only-testing:TaskmatoTests` → **TEST SUCCEEDED** (7 new `TimerPresenter.accessibilityValue` cases covering every band boundary plus running-vs-paused).

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- **Not yet verified (needs an interactive session):** a live VoiceOver pass and the **color-contrast audit** via Accessibility Inspector (orange priority glyph and `.tertiary` lineage row on the faint `cardSurface`). The audit is captured as a checklist in the new doc; any token tweak is intended as a fast follow-up rather than part of this PR.
- Branch is prefixed `fix-` so the labeler will apply `bug`; this is really a `task` (issue #411) — swap the label if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
