### PR TITLE
fix: release check job needs write access to detect draft releases

### DIFF
--- a/.github/workflows/code-release.yaml
+++ b/.github/workflows/code-release.yaml
@@ -26,8 +26,10 @@ jobs:
   check:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
+    # contents: write (not read) — a draft release is only visible to a token with push
+    # access, so `gh release view` on the draft needs write here to detect it.
     permissions:
-      contents: read
+      contents: write
     outputs:
       released: ${{ steps.detect.outputs.released }}
       tag: ${{ steps.detect.outputs.tag }}


### PR DESCRIPTION
## Summary

The release pipeline from #499 never publishes a release: the `check` job can't see the release-please draft, so `package`/`publish`/`deploy-site` all skip. First hit on the real `v0.10.0` release — the draft was created but no DMG, no tag, and no published release.

## Linked issue

N/A — hotfix for the pipeline introduced in #499.

## Root cause

`check` gates the pipeline by calling `gh release view "$TAG"` on the release-please **draft** release. A draft release is only visible to a token with **push access**, but the `check` job is scoped to `permissions: contents: read`. So the GITHUB_TOKEN got "not found" → `released=false` → every downstream job skipped. (Verified in run 30749198589: `No draft release for v0.10.0; nothing to package.` while the `v0.10.0` draft demonstrably exists.)

## Fix

Grant the `check` job `contents: write` so its token has push access and can detect the draft. `package`/`publish` already had `contents: write`; only `check` was under-scoped.

## Validation

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

Workflow YAML only. Confirmed the failure from the live logs and the existing `v0.10.0` draft. End-to-end verification happens on merge (see below).

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

**Merging this recovers `v0.10.0` automatically:** the push to `main` runs release-please, whose completion fires `code-release` with the fixed workflow — `check` sees the `v0.10.0` draft and the pipeline builds/notarizes the DMG, attaches it, publishes (creating the `v0.10.0` tag), and deploys the site (~10–15 min for notarization).

The stale `#501` (0.11.0) PR is expected and will self-correct on the next push to `main` after the `v0.10.0` tag exists — **do not merge `#501` before then.**
