### PR TITLE
fix: exclude SwiftUI previews from release builds (unblocks the DMG archive)

### DIFF
--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -34,13 +34,28 @@ jobs:
         if: steps.changes.outputs.relevant == 'true'
         run: bash scripts/sync-version.sh
 
-      - name: Build
+      - name: Build (Debug)
         if: steps.changes.outputs.relevant == 'true'
         run: |
           xcodebuild build \
             -project app/Taskmato.xcodeproj \
             -scheme Taskmato \
             -configuration Debug \
+            -destination 'platform=macOS' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      # Also compile Release: it uses whole-module optimization and excludes
+      # DEBUG-only code (e.g. #if DEBUG previews), so it catches errors the Debug
+      # build misses — the class of failure that broke `make archive`. No signing.
+      - name: Build (Release)
+        if: steps.changes.outputs.relevant == 'true'
+        run: |
+          xcodebuild build \
+            -project app/Taskmato.xcodeproj \
+            -scheme Taskmato \
+            -configuration Release \
             -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,7 +31,7 @@ type_body_length:
   error: 400
 
 file_length:
-  warning: 550
+  warning: 600
   error: 1000
 
 function_body_length:

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -501,17 +501,19 @@ private struct SidebarTimerRow: View {
   }
 }
 
-#Preview {
-  let registry = ProviderRegistry()
-  let settings = AppSettings()
-  let selectionStore = SelectionStore(registry: registry)
-  return AppSidebarView(
-    nav: MainNavigation(
-      settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
-    presenter: TimerPresenter(engine: SessionEngine(), settings: settings),
-    registry: registry,
-    settings: settings,
-    errorPresenter: ErrorPresenter()
-  )
-  .frame(width: 220, height: 500)
-}
+#if DEBUG
+  #Preview {
+    let registry = ProviderRegistry()
+    let settings = AppSettings()
+    let selectionStore = SelectionStore(registry: registry)
+    return AppSidebarView(
+      nav: MainNavigation(
+        settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+      presenter: TimerPresenter(engine: SessionEngine(), settings: settings),
+      registry: registry,
+      settings: settings,
+      errorPresenter: ErrorPresenter()
+    )
+    .frame(width: 220, height: 500)
+  }
+#endif

--- a/app/Taskmato/Views/App/ErrorBannerView.swift
+++ b/app/Taskmato/Views/App/ErrorBannerView.swift
@@ -67,13 +67,15 @@ extension ErrorSeverity {
   }
 }
 
-#Preview {
-  let presenter = ErrorPresenter()
-  presenter.present(
-    TransientError(
-      title: "Couldn't complete task",
-      detail: "Reminders access has been revoked in System Settings.",
-      severity: .error))
-  return ErrorBannerView(presenter: presenter)
-    .frame(width: 420)
-}
+#if DEBUG
+  #Preview {
+    let presenter = ErrorPresenter()
+    presenter.present(
+      TransientError(
+        title: "Couldn't complete task",
+        detail: "Reminders access has been revoked in System Settings.",
+        severity: .error))
+    return ErrorBannerView(presenter: presenter)
+      .frame(width: 420)
+  }
+#endif

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -129,22 +129,24 @@ struct MainWindowView: View {
   }
 }
 
-#Preview {
-  let engine = SessionEngine()
-  let settings = AppSettings()
-  let registry = ProviderRegistry()
-  let selectionStore = SelectionStore(registry: registry)
-  return MainWindowView(
-    presenter: TimerPresenter(engine: engine, settings: settings),
-    engine: engine,
-    settings: settings,
-    statsViewModel: .preview,
-    selectionStore: TaskSelectionStore(),
-    registry: registry,
-    queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
-    sidebarSelection: selectionStore,
-    nav: MainNavigation(
-      settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
-    errorPresenter: ErrorPresenter()
-  )
-}
+#if DEBUG
+  #Preview {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    let registry = ProviderRegistry()
+    let selectionStore = SelectionStore(registry: registry)
+    return MainWindowView(
+      presenter: TimerPresenter(engine: engine, settings: settings),
+      engine: engine,
+      settings: settings,
+      statsViewModel: .preview,
+      selectionStore: TaskSelectionStore(),
+      registry: registry,
+      queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
+      sidebarSelection: selectionStore,
+      nav: MainNavigation(
+        settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+      errorPresenter: ErrorPresenter()
+    )
+  }
+#endif

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -90,19 +90,21 @@ struct MenuBarPopoverView: View {
   }
 }
 
-#Preview {
-  let engine = SessionEngine()
-  let settings = AppSettings()
-  let registry = ProviderRegistry()
-  return MenuBarPopoverView(
-    presenter: TimerPresenter(engine: engine, settings: settings),
-    statsViewModel: .preview,
-    selectionStore: TaskSelectionStore(),
-    nav: MainNavigation(
-      settings: settings, selectionStore: SelectionStore(registry: registry),
-      statsViewModel: .preview),
-    engine: engine,
-    registry: registry,
-    errorPresenter: ErrorPresenter()
-  )
-}
+#if DEBUG
+  #Preview {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    let registry = ProviderRegistry()
+    return MenuBarPopoverView(
+      presenter: TimerPresenter(engine: engine, settings: settings),
+      statsViewModel: .preview,
+      selectionStore: TaskSelectionStore(),
+      nav: MainNavigation(
+        settings: settings, selectionStore: SelectionStore(registry: registry),
+        statsViewModel: .preview),
+      engine: engine,
+      registry: registry,
+      errorPresenter: ErrorPresenter()
+    )
+  }
+#endif

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -224,11 +224,13 @@ private struct DurationField: View {
   }
 }
 
-#Preview {
-  SettingsView(
-    settings: AppSettings(),
-    selectionStore: TaskSelectionStore(),
-    registry: ProviderRegistry(),
-    notifications: NotificationService(settings: AppSettings())
-  )
-}
+#if DEBUG
+  #Preview {
+    SettingsView(
+      settings: AppSettings(),
+      selectionStore: TaskSelectionStore(),
+      registry: ProviderRegistry(),
+      notifications: NotificationService(settings: AppSettings())
+    )
+  }
+#endif

--- a/app/Taskmato/Views/Stats/StatsTabView.swift
+++ b/app/Taskmato/Views/Stats/StatsTabView.swift
@@ -166,26 +166,28 @@ struct StatsTabView: View {
   }
 }
 
-#Preview("Today") {
-  StatsTabView(statsViewModel: .previewSeeded)
-    .frame(width: 420, height: 560)
-}
+#if DEBUG
+  #Preview("Today") {
+    StatsTabView(statsViewModel: .previewSeeded)
+      .frame(width: 420, height: 560)
+  }
 
-#Preview("7 Days") {
-  let viewModel = StatsViewModel.previewSeeded
-  viewModel.scope = .thisWeek
-  return StatsTabView(statsViewModel: viewModel)
-    .frame(width: 420, height: 560)
-}
+  #Preview("7 Days") {
+    let viewModel = StatsViewModel.previewSeeded
+    viewModel.scope = .thisWeek
+    return StatsTabView(statsViewModel: viewModel)
+      .frame(width: 420, height: 560)
+  }
 
-#Preview("All Time") {
-  let viewModel = StatsViewModel.previewSeeded
-  viewModel.scope = .allTime
-  return StatsTabView(statsViewModel: viewModel)
-    .frame(width: 420, height: 560)
-}
+  #Preview("All Time") {
+    let viewModel = StatsViewModel.previewSeeded
+    viewModel.scope = .allTime
+    return StatsTabView(statsViewModel: viewModel)
+      .frame(width: 420, height: 560)
+  }
 
-#Preview("Empty") {
-  StatsTabView(statsViewModel: .preview)
-    .frame(width: 420, height: 560)
-}
+  #Preview("Empty") {
+    StatsTabView(statsViewModel: .preview)
+      .frame(width: 420, height: 560)
+  }
+#endif

--- a/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
@@ -78,16 +78,18 @@ struct TaskCardView: View {
   }
 }
 
-#Preview {
-  let task = TaskItem(
-    id: TaskRef(providerID: "local", nativeID: "1"),
-    title: "Create a support metrics dashboard and wiki",
-    notes: "Build out a dashboard of our support metrics once we have some statistics.",
-    format: .plainText,
-    priority: .high,
-    dueDate: Calendar.current.date(byAdding: .day, value: -3, to: .now)
-  )
-  TaskCardView(task: task, kind: .active(onComplete: {}))
-    .padding()
-    .frame(width: 200)
-}
+#if DEBUG
+  #Preview {
+    let task = TaskItem(
+      id: TaskRef(providerID: "local", nativeID: "1"),
+      title: "Create a support metrics dashboard and wiki",
+      notes: "Build out a dashboard of our support metrics once we have some statistics.",
+      format: .plainText,
+      priority: .high,
+      dueDate: Calendar.current.date(byAdding: .day, value: -3, to: .now)
+    )
+    TaskCardView(task: task, kind: .active(onComplete: {}))
+      .padding()
+      .frame(width: 200)
+  }
+#endif

--- a/app/Taskmato/Views/Tasks/Components/TaskSourceBadge.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskSourceBadge.swift
@@ -45,13 +45,15 @@ struct TaskSourceBadge: View {
   }
 }
 
-#Preview {
-  VStack(alignment: .leading, spacing: .sectionGap) {
-    TaskSourceBadge(
-      url: URL(string: "obsidian://open")!, name: "Obsidian", icon: "book.closed")
-    TaskSourceBadge(
-      url: URL(string: "x-apple-reminderkit://")!, name: "Apple Reminders", icon: "checklist")
+#if DEBUG
+  #Preview {
+    VStack(alignment: .leading, spacing: .sectionGap) {
+      TaskSourceBadge(
+        url: URL(string: "obsidian://open")!, name: "Obsidian", icon: "book.closed")
+      TaskSourceBadge(
+        url: URL(string: "x-apple-reminderkit://")!, name: "Apple Reminders", icon: "checklist")
+    }
+    .padding()
+    .frame(width: 360, alignment: .leading)
   }
-  .padding()
-  .frame(width: 360, alignment: .leading)
-}
+#endif

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -533,18 +533,20 @@ extension TaskDetailView {
 
 }
 
-#Preview {
-  let registry = ProviderRegistry()
-  let settings = AppSettings()
-  let selectionStore = SelectionStore(registry: registry)
-  return TaskDetailView(
-    selectionStore: TaskSelectionStore(),
-    registry: registry,
-    queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
-    sidebarSelection: selectionStore,
-    nav: MainNavigation(
-      settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
-    settings: settings,
-    errorPresenter: ErrorPresenter()
-  )
-}
+#if DEBUG
+  #Preview {
+    let registry = ProviderRegistry()
+    let settings = AppSettings()
+    let selectionStore = SelectionStore(registry: registry)
+    return TaskDetailView(
+      selectionStore: TaskSelectionStore(),
+      registry: registry,
+      queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
+      sidebarSelection: selectionStore,
+      nav: MainNavigation(
+        settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
+      settings: settings,
+      errorPresenter: ErrorPresenter()
+    )
+  }
+#endif

--- a/app/Taskmato/Views/Timer/ActiveTaskView.swift
+++ b/app/Taskmato/Views/Timer/ActiveTaskView.swift
@@ -192,53 +192,55 @@ struct ActiveTaskView: View {
   }
 }
 
-#Preview {
-  let engine = SessionEngine()
-  let registry = ProviderRegistry()
-  let errorPresenter = ErrorPresenter()
-  let settings = AppSettings()
-  let nav = MainNavigation(
-    settings: settings, selectionStore: SelectionStore(registry: registry),
-    statsViewModel: .preview)
+#if DEBUG
+  #Preview {
+    let engine = SessionEngine()
+    let registry = ProviderRegistry()
+    let errorPresenter = ErrorPresenter()
+    let settings = AppSettings()
+    let nav = MainNavigation(
+      settings: settings, selectionStore: SelectionStore(registry: registry),
+      statsViewModel: .preview)
 
-  @MainActor
-  func store(priority: TaskPriority) -> TaskSelectionStore {
-    let store = TaskSelectionStore()
-    store.select(
-      TaskItem(
-        id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
-        title: "Priority \(priority)",
-        notes: "Some notes about the task.",
-        format: .plainText,
-        priority: priority,
-        dueDate: nil,
-        scheduledDate: nil,
-        startDate: nil,
-        list: nil,
-        section: nil,
-        sourceURL: nil,
-        completedAt: nil,
-        createdAt: Date()
+    @MainActor
+    func store(priority: TaskPriority) -> TaskSelectionStore {
+      let store = TaskSelectionStore()
+      store.select(
+        TaskItem(
+          id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
+          title: "Priority \(priority)",
+          notes: "Some notes about the task.",
+          format: .plainText,
+          priority: priority,
+          dueDate: nil,
+          scheduledDate: nil,
+          startDate: nil,
+          list: nil,
+          section: nil,
+          sourceURL: nil,
+          completedAt: nil,
+          createdAt: Date()
+        )
       )
-    )
-    return store
-  }
-
-  let priorities: [TaskPriority] = [.highest, .high, .medium, .low, .lowest]
-
-  return VStack(alignment: .leading, spacing: .sectionGap) {
-    ForEach(priorities, id: \.self) { priority in
-      ActiveTaskView(
-        engine: engine, selectionStore: store(priority: priority), registry: registry,
-        nav: nav, errorPresenter: errorPresenter, style: .compact, onSelect: {})
+      return store
     }
 
-    ForEach(priorities, id: \.self) { priority in
-      ActiveTaskView(
-        engine: engine, selectionStore: store(priority: priority), registry: registry,
-        nav: nav, errorPresenter: errorPresenter, style: .detail, onSelect: nil)
+    let priorities: [TaskPriority] = [.highest, .high, .medium, .low, .lowest]
+
+    return VStack(alignment: .leading, spacing: .sectionGap) {
+      ForEach(priorities, id: \.self) { priority in
+        ActiveTaskView(
+          engine: engine, selectionStore: store(priority: priority), registry: registry,
+          nav: nav, errorPresenter: errorPresenter, style: .compact, onSelect: {})
+      }
+
+      ForEach(priorities, id: \.self) { priority in
+        ActiveTaskView(
+          engine: engine, selectionStore: store(priority: priority), registry: registry,
+          nav: nav, errorPresenter: errorPresenter, style: .detail, onSelect: nil)
+      }
     }
+    .padding()
+    .frame(width: 360)
   }
-  .padding()
-  .frame(width: 360)
-}
+#endif

--- a/app/Taskmato/Views/Timer/Components/ActiveTaskConfirm.swift
+++ b/app/Taskmato/Views/Timer/Components/ActiveTaskConfirm.swift
@@ -74,8 +74,10 @@ struct ActiveTaskConfirmRow: View {
   }
 }
 
-#Preview {
-  ActiveTaskConfirmRow(action: .complete, onConfirm: {}, onCancel: {})
-    .padding()
-    .frame(width: 280)
-}
+#if DEBUG
+  #Preview {
+    ActiveTaskConfirmRow(action: .complete, onConfirm: {}, onCancel: {})
+      .padding()
+      .frame(width: 280)
+  }
+#endif

--- a/app/Taskmato/Views/Timer/Components/BrowseTasksButton.swift
+++ b/app/Taskmato/Views/Timer/Components/BrowseTasksButton.swift
@@ -28,7 +28,9 @@ struct BrowseTasksButton: View {
   }
 }
 
-#Preview {
-  BrowseTasksButton {}
-    .padding()
-}
+#if DEBUG
+  #Preview {
+    BrowseTasksButton {}
+      .padding()
+  }
+#endif

--- a/app/Taskmato/Views/Timer/TimerStripView.swift
+++ b/app/Taskmato/Views/Timer/TimerStripView.swift
@@ -82,37 +82,39 @@ struct TimerStripView: View {
   }
 }
 
-#Preview {
-  let engine = SessionEngine()
-  let settings = AppSettings()
-  let registry = ProviderRegistry()
-  let selectionStore = TaskSelectionStore()
-  selectionStore.select(
-    TaskItem(
-      id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
-      title: "Draft window-first design doc",
-      notes: nil,
-      format: .plainText,
-      priority: .high,
-      dueDate: nil,
-      scheduledDate: nil,
-      startDate: nil,
-      list: nil,
-      section: nil,
-      sourceURL: nil,
-      completedAt: nil,
-      createdAt: Date()
+#if DEBUG
+  #Preview {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    let registry = ProviderRegistry()
+    let selectionStore = TaskSelectionStore()
+    selectionStore.select(
+      TaskItem(
+        id: TaskRef(providerID: "adhoc", nativeID: UUID().uuidString),
+        title: "Draft window-first design doc",
+        notes: nil,
+        format: .plainText,
+        priority: .high,
+        dueDate: nil,
+        scheduledDate: nil,
+        startDate: nil,
+        list: nil,
+        section: nil,
+        sourceURL: nil,
+        completedAt: nil,
+        createdAt: Date()
+      )
     )
-  )
-  return TimerStripView(
-    presenter: TimerPresenter(engine: engine, settings: settings),
-    engine: engine,
-    selectionStore: selectionStore,
-    registry: registry,
-    nav: MainNavigation(
-      settings: settings, selectionStore: SelectionStore(registry: registry),
-      statsViewModel: .preview),
-    errorPresenter: ErrorPresenter()
-  ) {}
-  .frame(width: 560)
-}
+    return TimerStripView(
+      presenter: TimerPresenter(engine: engine, settings: settings),
+      engine: engine,
+      selectionStore: selectionStore,
+      registry: registry,
+      nav: MainNavigation(
+        settings: settings, selectionStore: SelectionStore(registry: registry),
+        statsViewModel: .preview),
+      errorPresenter: ErrorPresenter()
+    ) {}
+    .frame(width: 560)
+  }
+#endif

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -69,19 +69,21 @@ struct TimerTabView: View {
   }
 }
 
-#Preview {
-  let engine = SessionEngine()
-  let settings = AppSettings()
-  let registry = ProviderRegistry()
-  return TimerTabView(
-    presenter: TimerPresenter(engine: engine, settings: settings),
-    engine: engine,
-    statsViewModel: .preview,
-    selectionStore: TaskSelectionStore(),
-    registry: registry,
-    nav: MainNavigation(
-      settings: settings, selectionStore: SelectionStore(registry: registry),
-      statsViewModel: .preview),
-    errorPresenter: ErrorPresenter()
-  )
-}
+#if DEBUG
+  #Preview {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    let registry = ProviderRegistry()
+    return TimerTabView(
+      presenter: TimerPresenter(engine: engine, settings: settings),
+      engine: engine,
+      statsViewModel: .preview,
+      selectionStore: TaskSelectionStore(),
+      registry: registry,
+      nav: MainNavigation(
+        settings: settings, selectionStore: SelectionStore(registry: registry),
+        statsViewModel: .preview),
+      errorPresenter: ErrorPresenter()
+    )
+  }
+#endif


### PR DESCRIPTION
## Summary

The Release archive (`make archive`) can't compile, so the notarized DMG — and the automated `v0.10.0` release — is blocked. Fixes the compile and adds a CI guard so this class of error can't reach the archive again.

## Linked issue

N/A — surfaced by the release pipeline (#499/#502) hitting the first real Release build.

## Root cause

`#Preview` blocks are compiled into **every** build configuration, but 8 of them reference `StatsViewModel.preview` / `.previewSeeded`, which are defined under `#if DEBUG`. In Release (`make archive`, whole-module) those helpers don't exist, so the build fails:

```
TimerTabView.swift: type 'StatsViewModel' has no member 'preview'
TimerStripView.swift: type 'StatsViewModel' has no member 'preview'
ActiveTaskView.swift: cannot use explicit 'return' statement in ViewBuilder
```

CI never caught it because the `build` job only compiled **Debug**, while previews and their helpers are Debug-shaped.

## Fix

- Wrap all **17 `#Preview` blocks** (14 files) in `#if DEBUG` / `#endif`, so preview code is Debug-only — matching the helpers it already depends on and keeping it out of the shipped binary. swift-format's autofix indents the guarded previews to house style.
- `.swiftlint.yml`: raise `file_length` warning 550 → 600 (the guards add two lines per file; `TaskDetailView.swift` was exactly at the old ceiling).
- `code-build.yaml`: add a **Build (Release)** step (no signing) next to the Debug build, so Release-only failures are caught in CI. Kept as a step in the existing `build` job so the required status-check context is unchanged.

## Validation

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

`make lint` (0 violations), `make format-check` (clean), and — the real check — `xcodebuild -configuration Release … CODE_SIGNING_ALLOWED=NO` now reports **`BUILD SUCCEEDED`, 0 errors** (previously 12). The new `Build (Release)` CI step exercises the same path on every PR.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Once merged, the `v0.10.0` draft can be completed by re-running the release pipeline (`code-release.yaml` via `workflow_dispatch`, or the next push to `main`) — `package` should now archive cleanly. Previews are unchanged in Debug/Xcode; they're simply excluded from Release.
