### PR TITLE
fix: pass --repo to the release publish step

### DIFF
--- a/.github/workflows/code-release.yaml
+++ b/.github/workflows/code-release.yaml
@@ -137,11 +137,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      # This job has no checkout, so pass --repo explicitly; without it `gh release
+      # edit` tries to infer the repo from local git and fails ("not a git repository").
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check.outputs.tag }}
-        run: gh release edit "$TAG" --draft=false
+        run: gh release edit "$TAG" --draft=false --repo "$GITHUB_REPOSITORY"
 
   # Deploys the marketing site from the published tag. Read-only with respect to the
   # release; runs last so the download button (/releases/latest/download/Taskmato.dmg)


### PR DESCRIPTION
## Summary
The `publish` job in `code-release.yaml` un-drafts the release with `gh release edit "$TAG" --draft=false`, but the job has no checkout step. `gh` then tries to infer the repo from local git and fails:

```
failed to run git: fatal: not a git repository
```

This blocked publishing `v0.10.0` even though `package` had already attached the DMG to the draft.

## Linked issue
N/A — hotfix for the pipeline (#499).

## Root cause
No git context in the `publish` job; `gh release edit` needs either a checked-out repo or an explicit `--repo`.

## Fix
Pass `--repo "$GITHUB_REPOSITORY"` (no checkout needed — the job only edits the release). `check` and `package` already work because they check out.

## Validation
- [x] Manually verified the original bug no longer reproduces

Workflow YAML only; parses clean. The `v0.10.0` draft (DMG already attached) can be un-drafted directly meanwhile: `gh release edit v0.10.0 --draft=false --repo richwklein/taskmato`.

## Release / deploy impact
- [x] Safe to label `no-deploy`
