### PR TITLE
fix: name the release DMG asset Taskmato.dmg so the download link resolves

### DIFF
--- a/.github/workflows/code-release.yaml
+++ b/.github/workflows/code-release.yaml
@@ -112,13 +112,19 @@ jobs:
             --wait
           xcrun stapler staple "build/Taskmato-${VERSION}.dmg"
 
+      # `gh release upload file#text` sets the display LABEL, not the asset name — the
+      # asset name (and thus its download URL) is always the file's basename. The marketing
+      # site links to the stable /releases/latest/download/Taskmato.dmg, so the asset must
+      # be named exactly Taskmato.dmg. Rename the stapled DMG on disk before uploading (cp
+      # preserves the notarization ticket); the version stays visible via the label.
       - name: Attach DMG to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.check.outputs.tag }}
         run: |
           VERSION=$(cat version.txt | tr -d '[:space:]')
-          gh release upload "$TAG" "build/Taskmato-${VERSION}.dmg#Taskmato.dmg" --clobber
+          cp "build/Taskmato-${VERSION}.dmg" "build/Taskmato.dmg"
+          gh release upload "$TAG" "build/Taskmato.dmg#Taskmato ${VERSION}" --clobber
 
       - name: Clean up keychain
         if: always()


### PR DESCRIPTION
## Summary

The marketing site's download button (`/releases/latest/download/Taskmato.dmg`) 404s because no release asset is actually **named** `Taskmato.dmg`.

## Root cause

`gh release upload <file>#<text>` sets the asset's **display label**, not its filename. The asset name — and therefore its download URL — is always the file's basename. So the `package` job's

```
gh release upload "$TAG" "build/Taskmato-${VERSION}.dmg#Taskmato.dmg"
```

produced an asset **named** `Taskmato-0.10.1.dmg` with a cosmetic **label** of `Taskmato.dmg`:

```
name:  Taskmato-0.10.1.dmg   ← URL uses this
label: Taskmato.dmg          ← only shown in the UI
```

The stable `latest/download/Taskmato.dmg` path never matched an asset. (v0.10.0 hit the same broken URL via a hand-upload; v0.10.1 via the pipeline — same root cause.)

## Fix

Copy the stapled DMG to `build/Taskmato.dmg` before upload, then upload *that* file, so the asset is genuinely named `Taskmato.dmg`. `cp` preserves the embedded notarization ticket. The version stays visible through the label (`Taskmato <version>`).

## Impact

- v0.10.0 / v0.10.1 are immutable and can't be fixed retroactively.
- Merging this cuts **v0.10.2** through the pipeline, which attaches an asset named `Taskmato.dmg`, moves `latest`, and the download link finally resolves.

## Validation

- [x] YAML parses
- [ ] Verified end-to-end by the v0.10.2 release run (post-merge)