### PR TITLE
feat: quick-select focus duration presets

### DIFF
--- a/app/Taskmato/Services/AppSettings.swift
+++ b/app/Taskmato/Services/AppSettings.swift
@@ -18,6 +18,18 @@ final class AppSettings {
     didSet { store[SettingsStore.Keys.focusMinutes] = focusMinutes }
   }
 
+  /// Ordered focus-length presets, in minutes, offered as quick-select chips on the timer,
+  /// in the menu-bar popover, and in a task's "Start Focus" submenu.
+  ///
+  /// `focusMinutes` holds the currently-selected length; presets are the values it jumps
+  /// between. This setter is persistence-only — it mirrors `focusMinutes`'s `didSet` and does
+  /// no normalization, so it never re-enters `@Observable`. Every mutation should go through
+  /// ``setFocusPresets(_:)`` instead of assigning this property directly, so the stored list
+  /// stays normalized.
+  var focusPresets: [Int] {
+    didSet { store[SettingsStore.Keys.focusPresets] = focusPresets }
+  }
+
   /// Length of a short break, in minutes.
   var shortBreakMinutes: Int {
     didSet { store[SettingsStore.Keys.shortBreakMinutes] = shortBreakMinutes }
@@ -105,6 +117,12 @@ final class AppSettings {
   /// `longBreakMinutes` expressed as a `TimeInterval` in seconds.
   var longBreakDuration: TimeInterval { TimeInterval(longBreakMinutes * 60) }
 
+  /// The valid range for a single focus preset, matching the Focus stepper in Settings.
+  private static let focusPresetRange = 1...60
+
+  /// The maximum number of presets a user can keep in ``focusPresets``.
+  private static let maxFocusPresets = 5
+
   private let store: SettingsStore
 
   /// Creates settings backed by the standard `UserDefaults` suite.
@@ -116,6 +134,7 @@ final class AppSettings {
   init(store: SettingsStore) {
     self.store = store
     focusMinutes = store[SettingsStore.Keys.focusMinutes]
+    focusPresets = store[SettingsStore.Keys.focusPresets]
     shortBreakMinutes = store[SettingsStore.Keys.shortBreakMinutes]
     longBreakMinutes = store[SettingsStore.Keys.longBreakMinutes]
     longBreakAfterSessions = store[SettingsStore.Keys.longBreakAfterSessions]
@@ -129,5 +148,44 @@ final class AppSettings {
     taskSortDirection = store[SettingsStore.Keys.taskSortDirection]
     defaultWritableProviderID = store[SettingsStore.Keys.defaultWritableProviderID]
     collapsedSidebarSections = store[SettingsStore.Keys.collapsedSidebarSections]
+  }
+
+  // MARK: - Focus presets
+
+  /// Normalizes a raw focus-preset list to the rules a valid ``focusPresets`` must satisfy
+  /// (design doc 0009, D5): each value clamped to `1...60`, duplicates dropped, sorted
+  /// ascending, and capped at 5 entries. An empty input falls back to the key's shipped
+  /// default (`[15, 25, 45, 60]`).
+  ///
+  /// Pure and side-effect free, so it is the single, unit-tested source of truth for the
+  /// rule — both ``setFocusPresets(_:)`` and its tests call this directly.
+  static func normalizedPresets(_ raw: [Int]) -> [Int] {
+    let clamped = raw.map { min(max($0, focusPresetRange.lowerBound), focusPresetRange.upperBound) }
+    let deduplicated = Set(clamped).sorted()
+    guard !deduplicated.isEmpty else { return SettingsStore.Keys.focusPresets.defaultValue }
+    return Array(deduplicated.prefix(maxFocusPresets))
+  }
+
+  /// Normalizes `raw` and assigns it to ``focusPresets``.
+  ///
+  /// If the edit drops the value currently held by `focusMinutes`, `focusMinutes` re-snaps to
+  /// the nearest remaining preset (an exact tie snaps to the lower value), so the two never
+  /// disagree. Settings-editor add/remove actions should always route through this method
+  /// rather than assigning `focusPresets` directly — it is the only path that can't produce an
+  /// invalid list.
+  func setFocusPresets(_ raw: [Int]) {
+    let normalized = Self.normalizedPresets(raw)
+    focusPresets = normalized
+    guard !normalized.contains(focusMinutes) else { return }
+    focusMinutes = Self.nearestPreset(to: focusMinutes, in: normalized)
+  }
+
+  /// The value in `presets` closest to `value`; an exact tie resolves to the lower value.
+  private static func nearestPreset(to value: Int, in presets: [Int]) -> Int {
+    presets.min { lhs, rhs in
+      let lhsDistance = abs(lhs - value)
+      let rhsDistance = abs(rhs - value)
+      return lhsDistance == rhsDistance ? lhs < rhs : lhsDistance < rhsDistance
+    } ?? value
   }
 }

--- a/app/Taskmato/Services/SettingsStore.swift
+++ b/app/Taskmato/Services/SettingsStore.swift
@@ -79,6 +79,15 @@ final class SettingsStore {
     set { defaults.set(newValue, forKey: key.name) }
   }
 
+  /// Reads or writes an integer-array setting, returning the key's default when absent.
+  ///
+  /// `UserDefaults` has no `intArray(forKey:)` accessor, so the stored array is cast through
+  /// its untyped `array(forKey:)`.
+  subscript(key: SettingsKey<[Int]>) -> [Int] {
+    get { (defaults.array(forKey: key.name) as? [Int]) ?? key.defaultValue }
+    set { defaults.set(newValue, forKey: key.name) }
+  }
+
   /// Reads or writes a string set stored as an array, returning the key's default when absent.
   subscript(key: SettingsKey<Set<String>>) -> Set<String> {
     get {
@@ -165,6 +174,7 @@ extension SettingsStore {
     // MARK: Timer durations & session cadence
 
     static let focusMinutes = SettingsKey("focusMinutes", default: 25)
+    static let focusPresets = SettingsKey("focusPresets", default: [25])
     static let shortBreakMinutes = SettingsKey("shortBreakMinutes", default: 5)
     static let longBreakMinutes = SettingsKey("longBreakMinutes", default: 15)
     static let longBreakAfterSessions = SettingsKey("longBreakAfterSessions", default: 4)

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -106,6 +106,7 @@ struct MainWindowView: View {
         nav: nav,
         settings: settings,
         errorPresenter: errorPresenter,
+        presenter: presenter,
         refreshToken: taskAddedToken
       )
     case .stats:

--- a/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
+++ b/app/Taskmato/Views/MenuBar/MenuBarPopoverView.swift
@@ -25,7 +25,7 @@ struct MenuBarPopoverView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      TimerReadout(label: presenter.label, phase: presenter.phaseName)
+      FocusPresetReadout(presenter: presenter)
         .padding(.top, .groupGap)
 
       TimerControlsView(

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
   var body: some View {
     Form {
       Section("Durations") {
-        DurationField("Focus", value: $settings.focusMinutes, range: 1...60)
+        FocusPresetsEditor(settings: settings)
         DurationField("Short Break", value: $settings.shortBreakMinutes, range: 1...30)
         DurationField("Long Break", value: $settings.longBreakMinutes, range: 1...60)
       }
@@ -221,6 +221,115 @@ private struct DurationField: View {
       value = parsed
     }
     text = "\(value)"
+  }
+}
+
+/// The **Focus presets** editor (design doc 0009, D5): a static label row per preset, each
+/// removable, plus an "Add Duration" affordance that reveals an inline ``DurationField``.
+///
+/// Every add/remove routes through ``AppSettings/setFocusPresets(_:)`` — this view never
+/// assigns `settings.focusPresets` directly, so it can't produce an invalid list.
+private struct FocusPresetsEditor: View {
+
+  /// The valid range for a single preset, matching the range the old Focus stepper enforced.
+  private static let range = 1...60
+  /// The maximum number of presets, mirroring `AppSettings`'s cap.
+  private static let maxPresets = 5
+  /// The default seed offered when "Add Duration" is first tapped.
+  private static let defaultSeed = 30
+
+  let settings: AppSettings
+
+  @State private var isAdding = false
+  @State private var newValue = FocusPresetsEditor.defaultSeed
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: .contentGap) {
+      Text(AppLabels.FocusPreset.sectionTitle)
+        .foregroundStyle(.secondary)
+
+      ForEach(settings.focusPresets, id: \.self) { minutes in
+        presetRow(minutes)
+      }
+
+      if isAdding {
+        addField
+      } else {
+        addButton
+      }
+    }
+  }
+
+  private func presetRow(_ minutes: Int) -> some View {
+    HStack {
+      Text(label(for: minutes))
+      Spacer()
+      Button {
+        settings.setFocusPresets(settings.focusPresets.filter { $0 != minutes })
+      } label: {
+        Image(systemName: AppLabels.FocusPreset.remove.systemImage)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(.secondary)
+      .disabled(settings.focusPresets.count <= 1)
+      .help(AppLabels.FocusPreset.remove.title)
+      .accessibilityLabel("\(AppLabels.FocusPreset.remove.title) \(label(for: minutes))")
+    }
+  }
+
+  private var addButton: some View {
+    let atMax = settings.focusPresets.count >= Self.maxPresets
+    return Button {
+      newValue = seedValue()
+      isAdding = true
+    } label: {
+      Label(AppLabels.FocusPreset.add.title, systemImage: AppLabels.FocusPreset.add.systemImage)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(atMax ? Color.secondary : Color.accentColor)
+    .disabled(atMax)
+    .help(atMax ? AppLabels.Tooltip.maxFocusPresetsReached : "")
+  }
+
+  private var addField: some View {
+    HStack {
+      DurationField(AppLabels.FocusPreset.add.title, value: $newValue, range: Self.range)
+      Button {
+        settings.setFocusPresets(settings.focusPresets + [newValue])
+        isAdding = false
+      } label: {
+        Image(systemName: "checkmark.circle.fill")
+      }
+      .buttonStyle(.plain)
+      Button {
+        isAdding = false
+      } label: {
+        Image(systemName: "xmark.circle")
+      }
+      .buttonStyle(.plain)
+      .help(AppLabels.Tooltip.cancel)
+    }
+  }
+
+  /// The row label for `minutes`, marking the one matching `focusMinutes` as current.
+  private func label(for minutes: Int) -> String {
+    minutes == settings.focusMinutes
+      ? "\(minutes) min · \(AppLabels.FocusPreset.current)"
+      : "\(minutes) min"
+  }
+
+  /// 30 minutes if unused, otherwise the nearest value in `1...60` not already a preset
+  /// (design doc plan, "Add-stepper seed").
+  private func seedValue() -> Int {
+    let used = Set(settings.focusPresets)
+    guard used.contains(Self.defaultSeed) else { return Self.defaultSeed }
+    for offset in 1...(Self.range.upperBound - Self.range.lowerBound) {
+      let lower = Self.defaultSeed - offset
+      if lower >= Self.range.lowerBound, !used.contains(lower) { return lower }
+      let upper = Self.defaultSeed + offset
+      if upper <= Self.range.upperBound, !used.contains(upper) { return upper }
+    }
+    return Self.defaultSeed
   }
 }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
@@ -50,12 +50,17 @@ enum AppLabels {
     static let showCompleted = "Show completed tasks"
     /// Shown on the Show Completed toolbar button when the section is visible.
     static let hideCompleted = "Hide completed tasks"
+    // Focus presets
+    /// Shown on "Add Duration" once the Focus presets list already holds 5 entries.
+    static let maxFocusPresetsReached = "Up to 5 focus presets"
   }
 
   /// VoiceOver labels for controls whose visible content is not text.
   enum Accessibility {
     /// Announced for the circular countdown ring on the Timer surface.
     static let timer = "Pomodoro timer"
+    /// Announced for the Timer tab's focus-length quick-select chip row.
+    static let focusPresets = "Focus duration"
   }
 
   /// Labels for task CRUD and lifecycle actions.
@@ -72,6 +77,21 @@ enum AppLabels {
     static let restore = AppLabel("Restore Task", systemImage: "arrow.counterclockwise")
     /// Permanently deletes a task via its writable provider.
     static let delete = AppLabel("Delete Permanently", systemImage: "trash")
+  }
+
+  /// Labels for the focus-duration presets feature (design doc 0009): the Settings editor,
+  /// the timer quick-select surfaces, and the task "Start Focus" submenu.
+  enum FocusPreset {
+    /// Section label for the presets editor in Settings → Durations.
+    static let sectionTitle = "Focus Presets"
+    /// Suffix appended to the preset row matching the current `focusMinutes`.
+    static let current = "Current"
+    /// Removes a preset from the list in Settings.
+    static let remove = AppLabel("Remove", systemImage: "minus.circle")
+    /// Reveals the inline control to add a new preset in Settings.
+    static let add = AppLabel("Add Duration", systemImage: "plus.circle")
+    /// The task context-menu submenu offering a one-click "select + start" at a preset length.
+    static let startFocus = AppLabel("Start Focus", systemImage: "bolt.fill")
   }
 
   /// Labels for view-state commands: layout, completed section, sort, and search.

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -22,6 +22,9 @@ struct TaskDetailView: View {
   var nav: MainNavigation
   @Bindable var settings: AppSettings
   var errorPresenter: ErrorPresenter
+  /// Drives the "Start Focus ▸" context-menu submenu (design doc 0009, D7): its preset list,
+  /// idle state, and the start intent.
+  var presenter: TimerPresenter
   /// Bumped by the sidebar after adding a task, so the detail reloads the affected list.
   var refreshToken: Int = 0
 
@@ -293,51 +296,6 @@ struct TaskDetailView: View {
     }
   }
 
-  /// Context menu items shown on secondary-click (right-click or ctrl+click) of an active task row or card.
-  @ViewBuilder
-  private func taskContextMenu(for task: TaskItem) -> some View {
-    Button {
-      select(task)
-    } label: {
-      Label(AppLabels.Task.track.title, systemImage: AppLabels.Task.track.systemImage)
-    }
-    if registry.writableProvider(for: task.id) != nil {
-      Button {
-        taskToEdit = task
-        isEditingTask = true
-      } label: {
-        Label(AppLabels.Task.edit.title, systemImage: AppLabels.Task.edit.systemImage)
-      }
-    }
-    Divider()
-    if registry.closableProvider(for: task.id) != nil {
-      Button {
-        handleComplete(task)
-      } label: {
-        Label(AppLabels.Task.complete.title, systemImage: AppLabels.Task.complete.systemImage)
-      }
-    }
-  }
-
-  /// Context menu items shown on secondary-click of a completed task row or card.
-  @ViewBuilder
-  private func completedTaskContextMenu(for task: TaskItem) -> some View {
-    if registry.closableProvider(for: task.id) != nil {
-      Button {
-        handleRestore(task)
-      } label: {
-        Label(AppLabels.Task.restore.title, systemImage: AppLabels.Task.restore.systemImage)
-      }
-    }
-    if registry.provider(for: task.id) is (any WritableTaskProvider) {
-      Button(role: .destructive) {
-        handleDelete(task)
-      } label: {
-        Label(AppLabels.Task.delete.title, systemImage: AppLabels.Task.delete.systemImage)
-      }
-    }
-  }
-
   // MARK: - Grid layout
 
   private var taskGrid: some View {
@@ -396,6 +354,68 @@ struct TaskDetailView: View {
     }
   }
 
+}
+
+// MARK: - Context menus
+
+extension TaskDetailView {
+
+  /// Context menu items shown on secondary-click (right-click or ctrl+click) of an active task row or card.
+  @ViewBuilder
+  private func taskContextMenu(for task: TaskItem) -> some View {
+    Button {
+      select(task)
+    } label: {
+      Label(AppLabels.Task.track.title, systemImage: AppLabels.Task.track.systemImage)
+    }
+    Menu {
+      ForEach(presenter.focusPresets, id: \.self) { minutes in
+        Button("\(minutes) min") {
+          startFocus(task, minutes: minutes)
+        }
+      }
+    } label: {
+      Label(
+        AppLabels.FocusPreset.startFocus.title,
+        systemImage: AppLabels.FocusPreset.startFocus.systemImage)
+    }
+    .disabled(!presenter.isIdle)
+    if registry.writableProvider(for: task.id) != nil {
+      Button {
+        taskToEdit = task
+        isEditingTask = true
+      } label: {
+        Label(AppLabels.Task.edit.title, systemImage: AppLabels.Task.edit.systemImage)
+      }
+    }
+    Divider()
+    if registry.closableProvider(for: task.id) != nil {
+      Button {
+        handleComplete(task)
+      } label: {
+        Label(AppLabels.Task.complete.title, systemImage: AppLabels.Task.complete.systemImage)
+      }
+    }
+  }
+
+  /// Context menu items shown on secondary-click of a completed task row or card.
+  @ViewBuilder
+  private func completedTaskContextMenu(for task: TaskItem) -> some View {
+    if registry.closableProvider(for: task.id) != nil {
+      Button {
+        handleRestore(task)
+      } label: {
+        Label(AppLabels.Task.restore.title, systemImage: AppLabels.Task.restore.systemImage)
+      }
+    }
+    if registry.provider(for: task.id) is (any WritableTaskProvider) {
+      Button(role: .destructive) {
+        handleDelete(task)
+      } label: {
+        Label(AppLabels.Task.delete.title, systemImage: AppLabels.Task.delete.systemImage)
+      }
+    }
+  }
 }
 
 // MARK: - Data loading
@@ -494,6 +514,17 @@ extension TaskDetailView {
     nav.showTimer()
   }
 
+  /// Selects `task`, sets the focus length to `minutes`, and starts a session on it — the
+  /// "Start Focus ▸" submenu's one-gesture action (design doc 0009, D7). Only reachable while
+  /// `presenter.isIdle` (the submenu is disabled otherwise), so this never interrupts a
+  /// running or paused session.
+  private func startFocus(_ task: TaskItem, minutes: Int) {
+    selectionStore.select(task)
+    settings.focusMinutes = minutes
+    presenter.start()
+    nav.showTimer()
+  }
+
   private func onCompleteHandler(for task: TaskItem) -> (() -> Void)? {
     registry.closableProvider(for: task.id) != nil ? { self.handleComplete(task) } : nil
   }
@@ -546,7 +577,8 @@ extension TaskDetailView {
       nav: MainNavigation(
         settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
       settings: settings,
-      errorPresenter: ErrorPresenter()
+      errorPresenter: ErrorPresenter(),
+      presenter: TimerPresenter(engine: SessionEngine(), settings: settings)
     )
   }
 #endif

--- a/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
+++ b/app/Taskmato/Views/Timer/Components/CircularTimerView.swift
@@ -5,29 +5,28 @@
 
 import SwiftUI
 
-/// A circular progress ring with a countdown label and phase name centered inside.
+/// A circular progress ring with the countdown readout centered inside.
+///
+/// The readout is a ``FocusPresetReadout``, so while idle with more than one preset it doubles as
+/// the compact focus-duration menu. The ring carries the informational VoiceOver announcement as
+/// its own element, leaving the menu independently reachable.
 struct CircularTimerView: View {
 
-  /// Fraction of time remaining, from 1.0 (full) down to 0.0 (elapsed).
-  let progress: Double
-  /// The formatted time string displayed in the center, e.g. `"24:59"`.
-  let label: String
-  /// The phase name displayed below the time, e.g. `"Focus"`.
-  let phase: String
-  /// The VoiceOver value announced for the ring, e.g. `"Focus, 24 minutes remaining"`.
-  let accessibilityValue: String
+  /// The presenter supplying progress, the readout, and the ring's accessibility value.
+  var presenter: TimerPresenter
 
   private let ringDiameter: CGFloat = 180
   private let strokeWidth: CGFloat = 10
 
   var body: some View {
     ZStack {
-      TimerRing(progress: progress, diameter: ringDiameter, strokeWidth: strokeWidth)
-      TimerReadout(label: label, phase: phase)
+      TimerRing(progress: presenter.progress, diameter: ringDiameter, strokeWidth: strokeWidth)
+        .accessibilityElement()
+        .accessibilityLabel(AppLabels.Accessibility.timer)
+        .accessibilityValue(presenter.accessibilityValue)
+      FocusPresetReadout(presenter: presenter, hidesPlainReadoutFromAccessibility: true)
     }
-    .accessibilityElement(children: .ignore)
-    .accessibilityLabel(AppLabels.Accessibility.timer)
-    .accessibilityValue(accessibilityValue)
+    .accessibilityElement(children: .contain)
     .dynamicTypeSize(...DynamicTypeSize.accessibility1)
   }
 }

--- a/app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift
+++ b/app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift
@@ -1,0 +1,59 @@
+//
+//  FocusPresetReadout.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// The countdown readout, which becomes a compact focus-preset menu while idle.
+///
+/// While the engine is idle and more than one preset exists, the ``TimerReadout`` is wrapped in a
+/// borderless menu of checkmarked presets (design doc 0009, D4) — the `25:00 ▾` affordance shared
+/// by the menu-bar popover and the window's Timer surface. Otherwise it renders the plain readout,
+/// so the countdown never shifts position as a session starts or stops. Selecting a preset routes
+/// through `presenter.selectFocusPreset(_:)`.
+struct FocusPresetReadout: View {
+
+  /// The presenter supplying the readout text, preset list, current selection, and selection intent.
+  var presenter: TimerPresenter
+
+  /// When `true`, the plain (non-menu) readout is hidden from VoiceOver because a surrounding
+  /// element — the timer ring — already announces the time. The interactive menu stays reachable.
+  var hidesPlainReadoutFromAccessibility: Bool = false
+
+  var body: some View {
+    if presenter.isIdle && presenter.showsFocusPresetPicker {
+      Menu {
+        ForEach(presenter.focusPresets, id: \.self) { minutes in
+          Button {
+            presenter.selectFocusPreset(minutes)
+          } label: {
+            if minutes == presenter.selectedFocusMinutes {
+              Label("\(minutes) min", systemImage: "checkmark")
+            } else {
+              Text("\(minutes) min")
+            }
+          }
+        }
+      } label: {
+        TimerReadout(label: presenter.label, phase: presenter.phaseName)
+      }
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+      .accessibilityLabel(AppLabels.Accessibility.focusPresets)
+    } else {
+      TimerReadout(label: presenter.label, phase: presenter.phaseName)
+        .accessibilityHidden(hidesPlainReadoutFromAccessibility)
+    }
+  }
+}
+
+#if DEBUG
+  #Preview {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    settings.focusPresets = [15, 25, 45, 60]
+    return FocusPresetReadout(presenter: TimerPresenter(engine: engine, settings: settings))
+      .padding()
+  }
+#endif

--- a/app/Taskmato/Views/Timer/TimerPresenter.swift
+++ b/app/Taskmato/Views/Timer/TimerPresenter.swift
@@ -107,6 +107,35 @@ final class TimerPresenter {
     return queued != .focus  // a break is queued; idle-skip cycles it to focus
   }
 
+  // MARK: - Focus presets
+
+  /// Focus-length presets to offer, ascending, in minutes.
+  ///
+  /// Mirrors `settings.focusPresets`, but prepends the current `focusMinutes` when it holds a
+  /// custom value outside that list (design doc 0009, D6) so a quick-select surface always has
+  /// something to highlight as selected.
+  var focusPresets: [Int] {
+    let presets = settings.focusPresets
+    guard presets.contains(settings.focusMinutes) else {
+      return ([settings.focusMinutes] + presets).sorted()
+    }
+    return presets
+  }
+
+  /// Whether to surface the quick-select picker — only when more than one preset exists, since a
+  /// single focus length offers nothing to choose between (design doc 0009).
+  var showsFocusPresetPicker: Bool { focusPresets.count > 1 }
+
+  /// The currently-selected focus length, in minutes — always `settings.focusMinutes`.
+  var selectedFocusMinutes: Int { settings.focusMinutes }
+
+  /// Selects a focus preset for the next session. Idle-only; a no-op while running or paused,
+  /// since a mid-session duration change only takes effect at the next phase boundary anyway.
+  func selectFocusPreset(_ minutes: Int) {
+    guard isIdle else { return }
+    settings.focusMinutes = minutes
+  }
+
   // MARK: - Intents
 
   /// Syncs the latest durations into the engine, then starts the queued (or focus) phase.

--- a/app/Taskmato/Views/Timer/TimerTabView.swift
+++ b/app/Taskmato/Views/Timer/TimerTabView.swift
@@ -20,12 +20,7 @@ struct TimerTabView: View {
     VStack(spacing: 0) {
       Spacer()
 
-      CircularTimerView(
-        progress: presenter.progress,
-        label: presenter.label,
-        phase: presenter.phaseName,
-        accessibilityValue: presenter.accessibilityValue
-      )
+      CircularTimerView(presenter: presenter)
 
       TimerControlsView(
         presenter: presenter,

--- a/app/TaskmatoTests/AppSettingsTests.swift
+++ b/app/TaskmatoTests/AppSettingsTests.swift
@@ -112,6 +112,69 @@ struct AppSettingsTests {
     #expect(AppSettings(store: SettingsStore(defaults: defaults)).soundName == "Glass")
   }
 
+  // MARK: - Focus presets: normalization
+
+  @Test func normalizedPresetsClampsOutOfRangeValues() {
+    #expect(AppSettings.normalizedPresets([0, -5, 61, 500]) == [1, 60])
+  }
+
+  @Test func normalizedPresetsDropsDuplicates() {
+    #expect(AppSettings.normalizedPresets([25, 25, 15, 15]) == [15, 25])
+  }
+
+  @Test func normalizedPresetsSortsAscending() {
+    #expect(AppSettings.normalizedPresets([45, 15, 60, 25]) == [15, 25, 45, 60])
+  }
+
+  @Test func normalizedPresetsTrimsBeyondFive() {
+    #expect(AppSettings.normalizedPresets([1, 2, 3, 4, 5, 6]).count == 5)
+  }
+
+  @Test func normalizedPresetsFallsBackToDefaultWhenEmpty() {
+    #expect(AppSettings.normalizedPresets([]) == [25])
+  }
+
+  // MARK: - Focus presets: defaults & persistence
+
+  @Test func defaultFocusPresetsMatchTheShippedSet() {
+    #expect(makeSettings().focusPresets == [25])
+  }
+
+  @Test func focusPresetsPersistAcrossInstances() {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    AppSettings(store: SettingsStore(defaults: defaults)).focusPresets = [10, 20, 30]
+    #expect(AppSettings(store: SettingsStore(defaults: defaults)).focusPresets == [10, 20, 30])
+  }
+
+  // MARK: - Focus presets: setFocusPresets re-snap
+
+  @Test func setFocusPresetsKeepsFocusMinutesWhenStillPresent() {
+    let settings = makeSettings()
+    settings.focusMinutes = 25
+    settings.setFocusPresets([15, 25, 45, 60])
+    #expect(settings.focusMinutes == 25)
+  }
+
+  @Test func setFocusPresetsResnapsToNearestRemainingPreset() {
+    let settings = makeSettings()
+    settings.focusMinutes = 25
+    settings.setFocusPresets([15, 45, 60])
+    #expect(settings.focusMinutes == 15)
+  }
+
+  @Test func setFocusPresetsResnapsExactTieToLowerValue() {
+    let settings = makeSettings()
+    settings.focusMinutes = 30
+    settings.setFocusPresets([20, 40])
+    #expect(settings.focusMinutes == 20)
+  }
+
+  @Test func setFocusPresetsNormalizesBeforeAssigning() {
+    let settings = makeSettings()
+    settings.setFocusPresets([100, 100, -5])
+    #expect(settings.focusPresets == [1, 60])
+  }
+
   // MARK: - Persistence
 
   @Test func settingPersistsAcrossInstances() {

--- a/app/TaskmatoTests/TimerPresenterTests.swift
+++ b/app/TaskmatoTests/TimerPresenterTests.swift
@@ -171,6 +171,67 @@ struct TimerPresenterTests {
     #expect(!presenter.canStop)
   }
 
+  // MARK: - Focus presets
+
+  @Test func focusPresetsMirrorsSettingsWhenCurrentValueIsAPreset() {
+    let settings = makeSettings(focus: 25)
+    settings.focusPresets = [15, 25, 45, 60]
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: settings)
+    #expect(presenter.focusPresets == [15, 25, 45, 60])
+    #expect(presenter.selectedFocusMinutes == 25)
+  }
+
+  @Test func focusPresetsPrependsCustomFocusMinutesNotInTheList() {
+    let settings = makeSettings(focus: 30)
+    settings.focusPresets = [15, 25, 45, 60]
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: settings)
+    #expect(presenter.focusPresets == [15, 25, 30, 45, 60])
+    #expect(presenter.selectedFocusMinutes == 30)
+  }
+
+  @Test func showsFocusPresetPickerIsFalseWithASinglePreset() {
+    let settings = makeSettings(focus: 25)
+    settings.focusPresets = [25]
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: settings)
+    #expect(!presenter.showsFocusPresetPicker)
+  }
+
+  @Test func showsFocusPresetPickerIsTrueWithMoreThanOnePreset() {
+    let settings = makeSettings(focus: 25)
+    settings.focusPresets = [25, 45]
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: settings)
+    #expect(presenter.showsFocusPresetPicker)
+  }
+
+  @Test func showsFocusPresetPickerIsTrueWhenCustomFocusMinutesAddsASecondValue() {
+    let settings = makeSettings(focus: 30)
+    settings.focusPresets = [25]
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: settings)
+    #expect(presenter.showsFocusPresetPicker)
+  }
+
+  @Test func selectFocusPresetUpdatesSelectionAndLabelWhileIdle() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings(focus: 25))
+    presenter.selectFocusPreset(45)
+    #expect(presenter.selectedFocusMinutes == 45)
+    #expect(presenter.label == "45:00")
+  }
+
+  @Test func selectFocusPresetIsNoOpWhileRunning() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings(focus: 25))
+    presenter.start()
+    presenter.selectFocusPreset(45)
+    #expect(presenter.selectedFocusMinutes == 25)
+  }
+
+  @Test func selectFocusPresetIsNoOpWhilePaused() {
+    let presenter = TimerPresenter(engine: SessionEngine(), settings: makeSettings(focus: 25))
+    presenter.start()
+    presenter.pause()
+    presenter.selectFocusPreset(45)
+    #expect(presenter.selectedFocusMinutes == 25)
+  }
+
   // MARK: - Enablement
 
   @Test func canSkipDisabledWhenIdleWithNothingQueued() {


### PR DESCRIPTION
## Summary

A focus interval had exactly one length (`focusMinutes`, default 25), changed only via a stepper in **Settings → Durations**. This adds a user-editable list of focus-length presets so a session length can be picked in one click — from the timer, the menu-bar popover, and directly from a task — with the choice persisting as last-used.

Selecting a preset just writes `settings.focusMinutes`, so the idle label, Start, and post-break auto-advance all update with **no `SessionEngine`, `Session`, or `PhaseOrchestrator` change**. The only new persisted state is the ordered preset list.

## Linked issue

Closes #516

## Approach

- **Setting:** `focusPresets: [Int]` (default `[25]`) with a new `[Int]` `SettingsStore` subscript, a pure `AppSettings.normalizedPresets(_:)` (clamp `1...60`, dedupe, sort, cap 5, empty→default), and `setFocusPresets(_:)` which re-snaps `focusMinutes` to the nearest remaining preset (exact tie → lower).
- **Presenter:** thin display-only surface on `TimerPresenter` — `focusPresets` (prepends a custom `focusMinutes` per D6), `selectedFocusMinutes`, `selectFocusPreset(_:)` (idle-only), and `showsFocusPresetPicker` (`> 1` preset).
- **Shared readout:** `FocusPresetReadout` turns the countdown into a compact `25:00 ▾` preset menu while idle with more than one preset, used by **both** the Timer-tab ring (`CircularTimerView`) and the menu-bar popover. The readout is always present, so starting/stopping a session never shifts the layout.
- **Settings:** the single Focus stepper becomes an editable **Focus presets** list — static rows with remove, an inline add (seeded to 30 / nearest unused), all routed through `setFocusPresets`.
- **Task detail:** a right-click **Start Focus ▸ N** submenu selects the task, sets the duration, starts the timer, and shows it; disabled during an active session.

## Out of scope

- Per-task saved durations (duration stays a session preference).
- Break-length presets (breaks remain single steppers).
- Ad-hoc one-off numeric entry on the timer.
- Restarting on a different task mid-session (design doc D7 / Q5).

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [ ] Documentation updated where appropriate

## Release / deploy impact

- [x] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Two intentional refinements diverge from the merged design doc 0009 / issue acceptance criteria, made during review:

1. **Ships with a single default preset `[25]`, not `[15, 25, 45, 60]`.** Quick-select only appears once a second preset is added, so a fresh install stays simple.
2. **The quick-select is a dropdown menu on the countdown readout on every surface** (not a chip row on the Timer tab). A row that appears/disappears on start/stop was visually jarring; the readout-as-menu keeps the countdown fixed and only toggles the chevron.

Design doc 0009 and the issue AC still describe the original pill-row/`[15,25,45,60]` design — happy to update the doc in this PR or a follow-up. Tests cover normalization, re-snap (incl. exact-tie), presenter selection, and picker visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
