### PR TITLE
fix: present configuration sheet when enabling a provider that needs setup

### DIFF
--- a/app/Taskmato/Tasks/ConfigurableTaskProvider.swift
+++ b/app/Taskmato/Tasks/ConfigurableTaskProvider.swift
@@ -12,6 +12,14 @@ import SwiftUI
 /// existing view needs to change when a new configurable provider is added.
 protocol ConfigurableTaskProvider: TaskProvider {
 
+  /// Whether the provider still needs user setup before it can serve tasks.
+  ///
+  /// Distinct from `isAuthorized`: a provider can be authorized (or not require
+  /// authorization at all) while still missing required configuration, such as
+  /// Obsidian's unselected vault. Enabling a provider for which this is `true`
+  /// immediately presents ``configurationView()``.
+  var needsConfiguration: Bool { get }
+
   /// Produces the view displayed inside the modal configuration sheet.
   @MainActor
   func configurationView() -> AnyView

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -399,9 +399,8 @@ struct AppSidebarView: View {
     let added = registry.providers.filter { addedIDs.contains($0.id) }
     for provider in added {
       settings.collapsedSidebarSections.remove(provider.id.rawValue)
-      if let configurable = provider as? (any ConfigurableTaskProvider),
-        configurable.needsConfiguration
-      {
+      let configurable = provider as? (any ConfigurableTaskProvider)
+      if configurable?.needsConfiguration == true {
         configuringProvider = configurable
       }
     }

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -392,14 +392,16 @@ struct AppSidebarView: View {
   }
 
   /// Reacts to providers becoming enabled from any source: re-expands each section, opens the
-  /// configuration sheet for a configurable provider that is not yet authorized (so lists can
+  /// configuration sheet for a configurable provider that still needs setup (so lists can
   /// load), and refreshes its list cache.
   private func handleNewlyEnabled(_ addedIDs: Set<ProviderID>) {
     guard !addedIDs.isEmpty else { return }
     let added = registry.providers.filter { addedIDs.contains($0.id) }
     for provider in added {
       settings.collapsedSidebarSections.remove(provider.id.rawValue)
-      if let configurable = provider as? (any ConfigurableTaskProvider), !provider.isAuthorized {
+      if let configurable = provider as? (any ConfigurableTaskProvider),
+        configurable.needsConfiguration
+      {
         configuringProvider = configurable
       }
     }

--- a/app/Taskmato/Views/Settings/Obsidian/ObsidianProvider+Configuration.swift
+++ b/app/Taskmato/Views/Settings/Obsidian/ObsidianProvider+Configuration.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 extension ObsidianProvider: ConfigurableTaskProvider {
+  var needsConfiguration: Bool { !isConfigured }
+
   func configurationView() -> AnyView {
     AnyView(ObsidianSetupSheet(provider: self))
   }

--- a/app/Taskmato/Views/Settings/Reminders/RemindersProvider+Configuration.swift
+++ b/app/Taskmato/Views/Settings/Reminders/RemindersProvider+Configuration.swift
@@ -6,6 +6,8 @@
 import SwiftUI
 
 extension RemindersProvider: ConfigurableTaskProvider {
+  var needsConfiguration: Bool { !isAuthorized }
+
   func configurationView() -> AnyView {
     AnyView(RemindersSetupSheet(provider: self))
   }

--- a/app/TaskmatoTests/ObsidianProviderTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderTests.swift
@@ -239,3 +239,24 @@ struct ObsidianProviderBookmarkRestoreTests {
     #expect(provider.vaultURL == nil)
   }
 }
+
+// MARK: - ConfigurableTaskProvider
+
+@Suite("ObsidianProvider — ConfigurableTaskProvider")
+@MainActor
+struct ObsidianProviderConfigurableTests {
+
+  /// A provider with no vault still needs setup, so enabling it should present the sheet.
+  @Test func needsConfigurationWhenNoVaultSelected() {
+    let provider = makeProvider(vaultURL: nil)
+    #expect(provider.needsConfiguration)
+  }
+
+  /// A provider with a vault already selected does not need to reopen the setup sheet.
+  @Test func doesNotNeedConfigurationWhenVaultSelected() throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    let provider = makeProvider(vaultURL: vault)
+    #expect(!provider.needsConfiguration)
+  }
+}

--- a/app/TaskmatoTests/RemindersProviderTests.swift
+++ b/app/TaskmatoTests/RemindersProviderTests.swift
@@ -96,6 +96,16 @@ struct RemindersProviderAuthorizationTests {
     #expect(!makeProvider(status: .notDetermined).0.isAuthorized)
   }
 
+  /// An unauthorized provider still needs setup, so enabling it should present the sheet.
+  @Test func needsConfigurationWhenNotAuthorized() {
+    #expect(makeProvider(status: .notDetermined).0.needsConfiguration)
+  }
+
+  /// An already-authorized provider does not need to reopen the setup sheet.
+  @Test func doesNotNeedConfigurationWhenAuthorized() {
+    #expect(!makeProvider(status: .fullAccess).0.needsConfiguration)
+  }
+
   @Test func authorizeWhenDenied_throwsAccessDenied() async {
     let (provider, _) = makeProvider(status: .denied)
     await #expect(throws: RemindersProviderError.accessDenied) {

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -100,6 +100,7 @@ private final class FakeConfigurableProvider: TaskProvider, ConfigurableTaskProv
   let displayName = "Fake Configurable"
   let icon = "square"
   let entitlement: ProviderEntitlement = .free
+  let needsConfiguration = false
 
   func authorize() async throws {}
   func lists() async throws -> [TaskList] { [] }


### PR DESCRIPTION
## Summary

Enabling a provider from the sidebar's add-provider menu now presents its configuration sheet immediately when the provider still needs setup, matching the Apple Reminders experience described in design doc `0002-provider-sidebar-revisited.md`.

## Linked issue

Closes #508

## Root cause

`AppSidebarView.handleNewlyEnabled` decided whether to open the configuration sheet by checking `!provider.isAuthorized`. `isAuthorized` defaults to `true` for any provider that doesn't override it, and Obsidian doesn't — it tracks setup completeness via its own `isConfigured` (vault selected) property instead. So Obsidian was enabled but its sheet never opened, while Reminders happened to work only because its permission state and setup state are the same thing.

## Fix

Added a `needsConfiguration: Bool` requirement to `ConfigurableTaskProvider`, distinct from `isAuthorized`, so each conformer expresses its own "still needs setup" condition:
- `ObsidianProvider.needsConfiguration` → `!isConfigured`
- `RemindersProvider.needsConfiguration` → `!isAuthorized` (preserves existing behavior)

`AppSidebarView.handleNewlyEnabled` now gates the sheet presentation on `configurable.needsConfiguration` instead of `!provider.isAuthorized`.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

`ConfigurableTaskProvider` gained a new protocol requirement — the only two conformers (`ObsidianProvider`, `RemindersProvider`) and the test double in `TaskProviderTests.swift` were updated accordingly.
