### PR TITLE
fix(accessibility): expose task forms and stats charts to assistive tech

### DIFF
--- a/app/Taskmato/Views/Stats/Components/DailyBarChart.swift
+++ b/app/Taskmato/Views/Stats/Components/DailyBarChart.swift
@@ -23,6 +23,24 @@ struct DailyBarChart: View {
     Dictionary(uniqueKeysWithValues: providers.map { ($0.providerID, $0.label) })
   }
 
+  /// Total focus minutes across every day/provider segment.
+  private var totalMinutes: Int {
+    totals.reduce(0) { $0 + $1.minutes }
+  }
+
+  /// Provider with the most focus minutes, when more than one provider is present.
+  private var topProvider: ProviderSlice? {
+    providers.max { $0.minutes < $1.minutes }
+  }
+
+  /// Nonvisual summary of the chart's totals for VoiceOver users.
+  private var accessibilitySummary: String {
+    guard totalMinutes > 0 else { return "No focus time recorded" }
+    let total = FocusDuration.label(minutes: totalMinutes)
+    guard let top = topProvider, providers.count > 1 else { return "\(total) total" }
+    return "\(total) total. Most on \(top.label): \(FocusDuration.label(minutes: top.minutes))"
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: .groupGap) {
       Text("Daily Focus")
@@ -42,6 +60,9 @@ struct DailyBarChart: View {
       )
       .chartLegend(position: .bottom, alignment: .leading)
       .frame(height: 200)
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(AppLabels.Accessibility.dailyFocusChart)
+      .accessibilityValue(accessibilitySummary)
     }
   }
 }

--- a/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
+++ b/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
@@ -22,6 +22,20 @@ struct TaskDonutChart: View {
     Color.chartPalette[index % Color.chartPalette.count]
   }
 
+  /// Slice with the most focus seconds, when at least one slice is present.
+  private var topSlice: SessionSummary.TaskSlice? {
+    slices.max { $0.seconds < $1.seconds }
+  }
+
+  /// Nonvisual summary of the chart's totals for VoiceOver users.
+  private var accessibilitySummary: String {
+    guard totalSeconds > 0, let top = topSlice else { return "No focus time recorded" }
+    let total = FocusDuration.label(seconds: totalSeconds)
+    let taskCount = slices.count == 1 ? "1 task" : "\(slices.count) tasks"
+    let topPercent = Int(top.seconds / totalSeconds * 100)
+    return "\(total) total across \(taskCount). Most on \(top.label): \(topPercent)%"
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: .groupGap) {
       Text("Task Breakdown")
@@ -42,6 +56,9 @@ struct TaskDonutChart: View {
       )
       .chartLegend(.hidden)
       .frame(height: 160)
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(AppLabels.Accessibility.taskBreakdownChart)
+      .accessibilityValue(accessibilitySummary)
 
       VStack(spacing: .iconLabel) {
         ForEach(Array(slices.enumerated()), id: \.element.id) { index, slice in

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -61,6 +61,7 @@ struct AddTaskView: View {
             }
           }
           .labelsHidden()
+          .accessibilityLabel("List")
           .frame(maxWidth: .infinity, alignment: .leading)
         }
 
@@ -77,6 +78,7 @@ struct AddTaskView: View {
             }
           }
           .labelsHidden()
+          .accessibilityLabel("Priority")
           .pickerStyle(.menu)
           .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -85,11 +87,14 @@ struct AddTaskView: View {
           Text("Due date")
             .foregroundStyle(.secondary)
           HStack {
-            Toggle("", isOn: $hasDueDate)
+            Toggle("Has due date", isOn: $hasDueDate)
               .labelsHidden()
+              .accessibilityLabel("Has due date")
+              .accessibilityHint("Enables the due date picker")
             if hasDueDate {
-              DatePicker("", selection: $dueDate, displayedComponents: .date)
+              DatePicker("Due date", selection: $dueDate, displayedComponents: .date)
                 .labelsHidden()
+                .accessibilityLabel("Due date")
             }
           }
         }
@@ -99,6 +104,7 @@ struct AddTaskView: View {
         TextEditor(text: $notes)
           .frame(height: 72)
           .font(.body)
+          .accessibilityLabel("Notes")
       }
 
       HStack {

--- a/app/Taskmato/Views/Tasks/Components/TaskDeleteButtonView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskDeleteButtonView.swift
@@ -7,17 +7,22 @@ import SwiftUI
 
 /// The trailing permanent-delete control shared by ``TaskRowView`` and ``TaskCardView``.
 ///
-/// Renders for a completed task on a writable provider, revealing on hover; requesting deletion
-/// sets `showConfirmation`, which the host view surfaces via its confirmation dialog. Renders
-/// nothing for tasks that cannot be deleted.
+/// Renders for a completed task on a writable provider, revealing on hover or keyboard focus;
+/// requesting deletion sets `showConfirmation`, which the host view surfaces via its confirmation
+/// dialog. Renders nothing for tasks that cannot be deleted.
 ///
-/// When deletable, the slot keeps its layout footprint at all times and toggles only opacity and
-/// hit-testing on hover, so the surrounding title never reflows as the button appears.
+/// When deletable, the slot keeps its layout footprint at all times and toggles only opacity on
+/// hover/focus, so the surrounding title never reflows as the button appears. The control stays
+/// hit-testable and exposed to accessibility regardless of visual reveal state, so keyboard and
+/// assistive-technology users can always reach it — only sighted pointer users need the hover to
+/// discover it.
 struct TaskDeleteButtonView: View {
 
   let presenter: TaskItemPresenter
   let isHovered: Bool
   @Binding var showConfirmation: Bool
+
+  @FocusState private var isFocused: Bool
 
   var body: some View {
     if presenter.canDelete {
@@ -30,9 +35,8 @@ struct TaskDeleteButtonView: View {
       .buttonStyle(.plain)
       .help(AppLabels.Tooltip.deletePermanently)
       .accessibilityLabel(AppLabels.Tooltip.deletePermanently)
-      .opacity(isHovered ? 1 : 0)
-      .allowsHitTesting(isHovered)
-      .accessibilityHidden(!isHovered)
+      .focused($isFocused)
+      .opacity(isHovered || isFocused ? 1 : 0)
     }
   }
 }

--- a/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskLabel.swift
@@ -61,6 +61,10 @@ enum AppLabels {
     static let timer = "Pomodoro timer"
     /// Announced for the Timer tab's focus-length quick-select chip row.
     static let focusPresets = "Focus duration"
+    /// Announced for the Stats daily focus stacked bar chart.
+    static let dailyFocusChart = "Daily focus chart"
+    /// Announced for the Stats task breakdown donut chart.
+    static let taskBreakdownChart = "Task breakdown chart"
   }
 
   /// Labels for task CRUD and lifecycle actions.


### PR DESCRIPTION
## Summary

Addresses the must-fix and should-fix accessibility issues found during the non-Settings UI review: keyboard/AT-discoverable delete on completed tasks, real accessible labels on the Add/Edit Task sheet, and nonvisual summaries for the Stats charts.

## Linked issue

Closes #522

## Motivation

Several controls and visualizations in the non-Settings UI were hard or impossible to discover nonvisually:

- `TaskDeleteButtonView` hid the delete control until hover and removed it from the accessibility tree while hidden, making permanent delete unreachable via keyboard or VoiceOver outside the context menu.
- `AddTaskView`'s due-date `Toggle`/`DatePicker` passed empty-string labels and relied on `.labelsHidden()`, leaving them with no accessible name; the Notes `TextEditor` had no label at all.
- `DailyBarChart` and `TaskDonutChart` encoded totals and rankings purely visually, with no VoiceOver-facing summary.

## Changes

- `TaskDeleteButtonView.swift`: removed `.accessibilityHidden(!isHovered)` and `.allowsHitTesting(isHovered)`; the button is now always hit-testable and exposed to accessibility. Added `@FocusState` so keyboard Tab focus also reveals it visually, matching the hover-reveal treatment. Only the opacity (visual reveal) is gated on hover/focus now, consistent with the sibling `TaskCompletionButton` pattern.
- `AddTaskView.swift`: gave the due-date `Toggle` and `DatePicker` real labels (previously `""`) plus explicit `.accessibilityLabel`; added `.accessibilityLabel("Notes")` to the previously-unlabeled `TextEditor`; added explicit `.accessibilityLabel` to the List/Priority pickers for robustness across picker styles.
- `DailyBarChart.swift` / `TaskDonutChart.swift`: added `.accessibilityElement(children: .ignore)` + `.accessibilityLabel` + `.accessibilityValue` on each chart, summarizing total minutes, entity count, and the top provider/task by share — following the existing label/value pattern used by the Timer tab's countdown ring.
- `TaskLabel.swift`: added `AppLabels.Accessibility.dailyFocusChart` / `taskBreakdownChart` constants for the new chart labels.

No visual layout changes; light/dark mode and minimum window size are unaffected in every case.

## Validation

- [x] Lint passes locally (`make lint`)
- [x] Unit tests pass locally (`make test`)
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable (`make build` succeeded; full `make test` suite green)

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Chart and form accessibility summaries were built only from data already passed into each component (no period/scope context is threaded into the charts today), per the issue's "where available" caveat. Settings views remain intentionally out of scope, per the issue.