### PR TITLE
refactor(tasks): tighten toolbar grouping and share sort menu with commands

### DIFF
--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -253,38 +253,13 @@ struct TaskmatoCommands: Commands {
       .keyboardShortcut("c", modifiers: [.command, .shift])
       .disabled(toggleCompleted == nil)
       Divider()
-      // Each sort option is disabled individually: as action items they re-validate on menu
-      // open and grey live off the task surface, whereas `.disabled` on the parent `Menu`
-      // container alone did not update (see the Layout note above, #426).
+      // Content shared with the toolbar's sort menu (``TaskSortMenuContent``) so field order,
+      // defaults, and checkmarked state cannot drift between the two surfaces. Items are
+      // disabled individually: as action items they re-validate on menu open and grey out live
+      // off the task surface, whereas `.disabled` on the parent `Menu` container alone did not
+      // update (see the Layout note above, #426).
       Menu {
-        ForEach(TaskSortField.allCases, id: \.self) { field in
-          Button {
-            settings.taskSortField = field
-            settings.taskSortDirection = field.defaultSortDirection
-          } label: {
-            Label(
-              field.displayName,
-              systemImage: settings.taskSortField == field ? "checkmark" : "")
-          }
-          .disabled(!isTaskScope)
-        }
-        Divider()
-        Button {
-          settings.taskSortDirection = .ascending
-        } label: {
-          Label(
-            settings.taskSortField.ascendingLabel,
-            systemImage: settings.taskSortDirection == .ascending ? "checkmark" : "")
-        }
-        .disabled(!isTaskScope)
-        Button {
-          settings.taskSortDirection = .descending
-        } label: {
-          Label(
-            settings.taskSortField.descendingLabel,
-            systemImage: settings.taskSortDirection == .descending ? "checkmark" : "")
-        }
-        .disabled(!isTaskScope)
+        TaskSortMenuContent(settings: settings, disabled: !isTaskScope)
       } label: {
         Label(AppLabels.View.sort.title, systemImage: AppLabels.View.sort.systemImage)
       }

--- a/app/Taskmato/Views/Tasks/TaskDetailSortMenu.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailSortMenu.swift
@@ -10,42 +10,63 @@ import SwiftUI
 extension TaskDetailView {
 
   /// Sort menu placed in the toolbar.
-  ///
-  /// Selecting a field also resets the direction to its natural default so the
-  /// picker always lands in a sensible state: due date and creation date default
-  /// to earliest-first, priority defaults to highest-first, title defaults to A→Z.
   var sortMenu: some View {
     Menu {
-      Section("Sort by") {
-        ForEach(TaskSortField.allCases, id: \.self) { field in
-          Button {
-            settings.taskSortField = field
-            settings.taskSortDirection = field.defaultSortDirection
-          } label: {
-            Label(
-              field.displayName,
-              systemImage: settings.taskSortField == field ? "checkmark" : "")
-          }
-        }
-      }
-      Divider()
-      Button {
-        settings.taskSortDirection = .ascending
-      } label: {
-        Label(
-          settings.taskSortField.ascendingLabel,
-          systemImage: settings.taskSortDirection == .ascending ? "checkmark" : "")
-      }
-      Button {
-        settings.taskSortDirection = .descending
-      } label: {
-        Label(
-          settings.taskSortField.descendingLabel,
-          systemImage: settings.taskSortDirection == .descending ? "checkmark" : "")
-      }
+      TaskSortMenuContent(settings: settings)
     } label: {
       Label(AppLabels.View.sort.title, systemImage: AppLabels.View.sort.systemImage)
     }
     .help("Sort tasks")
+  }
+}
+
+// MARK: - Shared sort menu content
+
+/// The sort-by field list and direction toggle shared by the Tasks toolbar sort menu and the
+/// View → Sort By command, so field order, defaults, and checkmarked state cannot drift between
+/// the two surfaces.
+///
+/// Selecting a field also resets the direction to its natural default so the menu always lands
+/// in a sensible state: due date and creation date default to earliest-first, priority defaults
+/// to highest-first, title defaults to A→Z.
+struct TaskSortMenuContent: View {
+
+  /// Backs the sort field and direction state read and written by this menu's controls.
+  var settings: AppSettings
+  /// Disables every item, matching the individual-item disabling `TaskmatoCommands` needs so
+  /// menu items re-validate and grey out live when the task surface leaves the scene (#426).
+  var disabled: Bool = false
+
+  var body: some View {
+    Section("Sort by") {
+      ForEach(TaskSortField.allCases, id: \.self) { field in
+        Button {
+          settings.taskSortField = field
+          settings.taskSortDirection = field.defaultSortDirection
+        } label: {
+          Label(
+            field.displayName,
+            systemImage: settings.taskSortField == field ? "checkmark" : "")
+        }
+        .disabled(disabled)
+      }
+    }
+    Divider()
+    Button {
+      settings.taskSortDirection = .ascending
+    } label: {
+      Label(
+        settings.taskSortField.ascendingLabel,
+        systemImage: settings.taskSortDirection == .ascending ? "checkmark" : "")
+    }
+    .disabled(disabled)
+    Button {
+      settings.taskSortDirection = .descending
+    } label: {
+      Label(
+        settings.taskSortField.descendingLabel,
+        systemImage: settings.taskSortDirection == .descending ? "checkmark" : "")
+    }
+    .disabled(disabled)
   }
 }

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -97,6 +97,8 @@ struct TaskDetailView: View {
         }
       }
       .toolbar {
+        // New Task is the primary creation action, so it stays its own leading item — visually
+        // distinct from the view-state controls that follow.
         if writableProvider != nil {
           ToolbarItem(placement: .automatic) {
             Button {
@@ -108,6 +110,9 @@ struct TaskDetailView: View {
           }
         }
 
+        // Show/Hide Completed stays adjacent to Layout and Sort — all three are task-view
+        // controls — while Layout and Sort are grouped together as one toolbar unit since both
+        // alter task-list presentation.
         if hasClosableProvider {
           ToolbarItem(placement: .automatic) {
             Button {
@@ -121,7 +126,7 @@ struct TaskDetailView: View {
           }
         }
 
-        ToolbarItem(placement: .automatic) {
+        ToolbarItemGroup(placement: .automatic) {
           Picker("Layout", selection: $settings.taskPickerLayout) {
             Label(
               AppLabels.View.listLayout.title, systemImage: AppLabels.View.listLayout.systemImage
@@ -134,9 +139,7 @@ struct TaskDetailView: View {
           }
           .pickerStyle(.segmented)
           .help("Toggle between list and grid view")
-        }
 
-        ToolbarItem(placement: .automatic) {
           sortMenu
         }
       }


### PR DESCRIPTION
## Summary

Cleans up the Tasks toolbar so item placement/grouping is intentional and stays aligned with the equivalent View menu commands.

## Linked issue

Closes #524

## Motivation

`TaskDetailView` placed New Task, Show/Hide Completed, Layout, and Sort as four independent `.automatic` toolbar items alongside toolbar search, leaving ordering/grouping to SwiftUI rather than being explicit. The Sort By field list and direction toggle were also implemented twice — once in the toolbar's sort menu, once in `TaskmatoCommands`' View → Sort By command — with matching but duplicated logic, which risked future drift between the two surfaces.

## Changes

- `TaskDetailView.swift`: New Task remains its own leading toolbar item (primary creation action, visually distinct). Show/Hide Completed, Layout, and Sort are now explicitly grouped — Layout and Sort are bundled into a single `ToolbarItemGroup` since both alter task-list presentation, with Show/Hide Completed adjacent.
- `TaskDetailSortMenu.swift`: extracted the sort-by field list and direction toggle into a new shared `TaskSortMenuContent` view.
- `TaskmatoApp.swift`: the View → Sort By command now renders `TaskSortMenuContent` instead of duplicating the field/direction enumeration, so field order, defaults, and checkmark state can't drift between the toolbar and the menu command.
- No custom sidebar toggle was added — the native system sidebar toolbar item continues to appear when the sidebar is collapsed, per the issue's explicit scope exclusion.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

`make sync-version`, `make lint`, and `make format-check` all pass. `xcodebuild build` succeeds and `TaskmatoTests` all pass. Visual verification of the toolbar grouping in a running window is still pending (sandboxed dev environment lacks Screen Recording/Accessibility permissions to drive the GUI) — the branch owner is verifying manually before merge.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The `writableProvider` fallback behavior that shows "New Task" even when the current selection isn't on a writable provider (falls back to the default writable provider) is pre-existing and unrelated to this change — confirmed via `git log` that it predates this branch (introduced in #442). Not addressed here; flagged separately if a follow-up issue is wanted.
