### PR TITLE
feat(tasks): support inline Markdown in task titles and notes

### DIFF
--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -27,6 +27,9 @@ final class LocalProvider: WritableTaskProvider {
   let tint: ProviderTint = .green
   let entitlement: ProviderEntitlement = .free
 
+  /// Local tasks always support inline Markdown for titles and notes.
+  let contentFormat: ContentFormat = .markdown
+
   /// Lists managed by this provider, in creation order.
   private(set) var taskLists: [LocalList] = []
 

--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -116,7 +116,7 @@ extension LocalTask {
     id = UUID()
     title = draft.title
     notes = draft.notes.isEmpty ? nil : draft.notes
-    format = .markdown
+    format = draft.format
     priority = draft.priority
     dueDate = draft.dueDate
     scheduledDate = nil

--- a/app/Taskmato/Tasks/Models/ContentFormat.swift
+++ b/app/Taskmato/Tasks/Models/ContentFormat.swift
@@ -14,3 +14,34 @@ nonisolated enum ContentFormat: Codable, Sendable {
   /// Markdown — rendered via `AttributedString(markdown:)` where supported.
   case markdown
 }
+
+extension ContentFormat {
+
+  /// Renders `text` per this format: verbatim for `.plainText`, inline-Markdown-parsed for
+  /// `.markdown` (falling back to plain text on parse failure). Parsed results are cached so
+  /// dense list/grid rendering does not re-parse identical strings on every `body` evaluation.
+  func attributedString(for text: String) -> AttributedString {
+    guard self == .markdown else { return AttributedString(text) }
+    let key = text as NSString
+    if let cached = Self.parseCache.object(forKey: key) { return cached.value }
+    let options = AttributedString.MarkdownParsingOptions(
+      interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+    let parsed = (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+    Self.parseCache.setObject(Box(parsed), forKey: key)
+    return parsed
+  }
+
+  /// Boxes an `AttributedString` for storage in `NSCache`, which requires class-typed values.
+  private final class Box {
+    let value: AttributedString
+    init(_ value: AttributedString) { self.value = value }
+  }
+
+  /// Thread-safe by construction (`NSCache`), so no additional isolation is needed here.
+  private static let parseCache: NSCache<NSString, Box> = {
+    let cache = NSCache<NSString, Box>()
+    cache.countLimit = 500
+    return cache
+  }()
+}

--- a/app/Taskmato/Tasks/Models/TaskDraft.swift
+++ b/app/Taskmato/Tasks/Models/TaskDraft.swift
@@ -18,6 +18,10 @@ struct TaskDraft {
   /// Optional notes for the task.
   var notes: String = ""
 
+  /// The content format the created/updated task should use, stamped from
+  /// `WritableTaskProvider.contentFormat` before submission.
+  var format: ContentFormat = .markdown
+
   /// Priority level.
   var priority: TaskPriority = .none
 

--- a/app/Taskmato/Tasks/Models/TaskItem.swift
+++ b/app/Taskmato/Tasks/Models/TaskItem.swift
@@ -60,10 +60,6 @@ extension TaskItem {
   ///
   /// Falls back to plain text when `format` is not `.markdown` or when parsing fails.
   var markdownTitle: AttributedString {
-    guard format == .markdown else { return AttributedString(title) }
-    let options = AttributedString.MarkdownParsingOptions(
-      interpretedSyntax: .inlineOnlyPreservingWhitespace
-    )
-    return (try? AttributedString(markdown: title, options: options)) ?? AttributedString(title)
+    format.attributedString(for: title)
   }
 }

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -98,6 +98,9 @@ protocol WritableTaskProvider: ClosableTaskProvider {
   /// The ID of the list new tasks target by default, or `nil` if none is set.
   var defaultListID: String? { get }
 
+  /// The `ContentFormat` this provider creates new tasks with.
+  var contentFormat: ContentFormat { get }
+
   /// Creates a new task from `draft` and returns the resulting item.
   ///
   /// If `draft.listID` is `nil` the provider uses its default list.

--- a/app/Taskmato/Views/Stats/Components/AllTimeTaskTable.swift
+++ b/app/Taskmato/Views/Stats/Components/AllTimeTaskTable.swift
@@ -21,7 +21,7 @@ struct AllTimeTaskTable: View {
   var body: some View {
     Table(rows.sorted(using: sortOrder), sortOrder: $sortOrder) {
       TableColumn("Task", value: \.title) { row in
-        Text(row.title).lineLimit(1)
+        Text(ContentFormat.markdown.attributedString(for: row.title)).lineLimit(1)
       }
       TableColumn("Provider", value: \.providerLabel) { row in
         Text(row.providerLabel).foregroundStyle(.secondary)

--- a/app/Taskmato/Views/Stats/Components/RankedTaskList.swift
+++ b/app/Taskmato/Views/Stats/Components/RankedTaskList.swift
@@ -21,7 +21,7 @@ struct RankedTaskList: View {
       VStack(spacing: .iconLabel) {
         ForEach(slices) { slice in
           HStack(spacing: .contentGap) {
-            Text(slice.label)
+            Text(ContentFormat.markdown.attributedString(for: slice.label))
               .lineLimit(1)
             Spacer()
             Text(FocusDuration.label(seconds: slice.seconds))

--- a/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
+++ b/app/Taskmato/Views/Stats/Components/TaskDonutChart.swift
@@ -49,7 +49,7 @@ struct TaskDonutChart: View {
             Circle()
               .fill(color(index))
               .frame(width: 10, height: 10)
-            Text(slice.label)
+            Text(ContentFormat.markdown.attributedString(for: slice.label))
               .lineLimit(1)
             Spacer()
             let pct = totalSeconds > 0 ? Int(slice.seconds / totalSeconds * 100) : 0

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -41,6 +41,8 @@ struct AddTaskView: View {
     !title.trimmingCharacters(in: .whitespaces).isEmpty
   }
 
+  private var isMarkdownCapable: Bool { provider.contentFormat == .markdown }
+
   var body: some View {
     VStack(alignment: .leading, spacing: .sectionGap) {
       Text(sheetTitle)
@@ -50,6 +52,12 @@ struct AddTaskView: View {
         .textFieldStyle(.roundedBorder)
         .focused($isTitleFocused)
         .onSubmit { if canSubmit { submit() } }
+
+      if isMarkdownCapable {
+        Text("Supports Markdown — **bold**, *italic*, `code`, [links]")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
 
       Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 10) {
         GridRow {
@@ -143,6 +151,7 @@ struct AddTaskView: View {
     draft.priority = priority
     draft.dueDate = hasDueDate ? dueDate : nil
     draft.listID = selectedListID.isEmpty ? nil : selectedListID
+    draft.format = provider.contentFormat
     isPresented = false
     if let task = taskToEdit {
       Task {

--- a/app/Taskmato/Views/Tasks/Components/TaskMarkdownTitle.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskMarkdownTitle.swift
@@ -28,5 +28,6 @@ struct TaskMarkdownTitle: View {
       .foregroundStyle(isCompleted ? .secondary : .primary)
       .lineLimit(lineLimit)
       .frame(maxWidth: fill ? .infinity : nil, alignment: .leading)
+      .help(task.title)
   }
 }

--- a/app/Taskmato/Views/Tasks/Components/TaskNoteView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskNoteView.swift
@@ -16,24 +16,10 @@ struct TaskNoteView: View {
   let format: ContentFormat
 
   var body: some View {
-    Group {
-      switch format {
-      case .plainText:
-        Text(notes)
-      case .markdown:
-        Text(attributedNotes)
-      }
-    }
-    .font(.caption)
-    .foregroundStyle(.secondary)
-    .multilineTextAlignment(.leading)
-    .frame(maxWidth: .infinity, alignment: .leading)
-  }
-
-  private var attributedNotes: AttributedString {
-    let options = AttributedString.MarkdownParsingOptions(
-      interpretedSyntax: .inlineOnlyPreservingWhitespace
-    )
-    return (try? AttributedString(markdown: notes, options: options)) ?? AttributedString(notes)
+    Text(format.attributedString(for: notes))
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .multilineTextAlignment(.leading)
+      .frame(maxWidth: .infinity, alignment: .leading)
   }
 }

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -287,6 +287,11 @@ struct LocalProviderTests {
     #expect(tasks[0].format == .markdown)
   }
 
+  @Test func contentFormatIsMarkdown() {
+    let provider = makeProvider()
+    #expect(provider.contentFormat == .markdown)
+  }
+
   @Test func existingTaskWithoutFormatFieldDecodesAsMarkdown() async throws {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString + ".json")

--- a/app/TaskmatoTests/ProviderRegistryTests.swift
+++ b/app/TaskmatoTests/ProviderRegistryTests.swift
@@ -42,6 +42,7 @@ private final class StubWritableProvider: WritableTaskProvider {
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   private(set) var defaultListID: String?
+  let contentFormat: ContentFormat = .markdown
 
   init(id: ProviderID) {
     self.id = id

--- a/app/TaskmatoTests/SelectionStoreTests.swift
+++ b/app/TaskmatoTests/SelectionStoreTests.swift
@@ -37,6 +37,7 @@ private final class SelectionWritableProvider: WritableTaskProvider {
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let defaultListID: String?
+  let contentFormat: ContentFormat = .markdown
 
   init(id: ProviderID, defaultListID: String? = nil) {
     self.id = id

--- a/app/TaskmatoTests/TaskItemTests.swift
+++ b/app/TaskmatoTests/TaskItemTests.swift
@@ -124,4 +124,15 @@ struct TaskItemTests {
       #expect(decoded == format)
     }
   }
+
+  @Test func plainTextFormatRendersVerbatim() {
+    let result = ContentFormat.plainText.attributedString(for: "**not bold**")
+    #expect(String(result.characters) == "**not bold**")
+  }
+
+  @Test func markdownFormatParsesStrongEmphasis() {
+    let result = ContentFormat.markdown.attributedString(for: "**bold**")
+    let hasBold = result.runs.contains { $0.inlinePresentationIntent == .stronglyEmphasized }
+    #expect(hasBold)
+  }
 }

--- a/app/TaskmatoTests/TaskProviderTests.swift
+++ b/app/TaskmatoTests/TaskProviderTests.swift
@@ -18,6 +18,7 @@ private final class FakeWritableProvider: WritableTaskProvider {
   let entitlement: ProviderEntitlement = .free
 
   private(set) var defaultListID: String?
+  let contentFormat: ContentFormat = .plainText
   private(set) var addedDrafts: [TaskDraft] = []
   private(set) var setDefaultListCalls: [String] = []
   private(set) var createListCalls: [String] = []

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -46,6 +46,7 @@ private final class StubWritableProvider: WritableTaskProvider {
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
   let defaultListID: String? = nil
+  let contentFormat: ContentFormat = .markdown
 
   init(id: ProviderID) {
     self.id = id


### PR DESCRIPTION
## Summary

Makes inline Markdown an explicit, consistent feature for task titles and notes wherever the backing provider supports it, instead of an implicit side effect of Local always defaulting to `.markdown`.

## Linked issue

Closes #523

## Approach

- Added `ContentFormat.attributedString(for:)` as the single rendering entry point, backed by an `NSCache`, replacing two duplicated `AttributedString(markdown:)` call sites (`TaskItem.markdownTitle`, `TaskNoteView`) that re-parsed identical strings on every `body` evaluation.
- Added a full-title `.help()` tooltip to `TaskMarkdownTitle`, inherited by every consumer (list rows, grid cards, active-task detail/compact, timer strip, menu-bar popover).
- Brought the three Stats views (`AllTimeTaskTable`, `RankedTaskList`, `TaskDonutChart`) in line — they were rendering task titles as plain `Text`. These rows are `Session`-log title snapshots with no per-row `format` field, so they render through `ContentFormat.markdown.attributedString(for:)` unconditionally; that's visually identical to plain rendering for the overwhelming majority of titles (no Markdown syntax) and correct for the rare one that has it.
- Added `contentFormat` to `WritableTaskProvider` (`LocalProvider` declares `.markdown`) and a `format` field on `TaskDraft`, so the "explicit signal" flows through the write path too, not just rendering. `AddTaskView` now shows a "Supports Markdown" cue and stamps the draft from `provider.contentFormat` before submission. This is scaffolding ahead of Obsidian/Reminders conforming to `WritableTaskProvider`, so their own `contentFormat` declarations slot in without reworking `AddTaskView`.

## Out of scope

- Full rich-text editing controls.
- Block-level Markdown (lists, tables, headings, code blocks, images, block quotes) in compact rows/cards.
- Changing plain-text providers (Reminders) to Markdown.
- A full expanded task detail/preview surface.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [ ] Manually verified the new behavior
- [ ] Documentation updated where appropriate

`make sync-version`, `make lint`, `make format-check`, and `make test` all pass (full Swift Testing suite, including the new `ContentFormat` parsing tests and `LocalProvider.contentFormat`). `make run` builds and launches the app successfully. I could not manually drive the running GUI in this environment (no automation available for a native AppKit/SwiftUI app) — the visual pass (Markdown styling in rows/cards/timer surfaces/Stats, the tooltip, and the AddTaskView caption) is still worth a quick manual look before merge.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

While implementing this, I also tried disabling (rather than hiding) the focus-preset dropdown in `FocusPresetReadout` per a side request — reverted it after finding `.disabled()` on the wrapping `Menu` dimmed the countdown text along with the chevron. Filed #527 (milestone 1.2.0) to track that separately; no changes from it are in this PR.
