### PR TITLE
fix(stats): show focus time before phase completes

### DIFF
--- a/app/Taskmato/Views/Stats/StatsTabView.swift
+++ b/app/Taskmato/Views/Stats/StatsTabView.swift
@@ -33,7 +33,7 @@ struct StatsTabView: View {
         description: "Complete a focus session to see your statistics here.")
     } else {
       let summary = statsViewModel.statCards
-      if summary.focusCount == 0 && summary.breakCount == 0 {
+      if summary.focusCount == 0 && summary.breakCount == 0 && summary.focusSeconds == 0 {
         emptyState(
           "No Sessions",
           description: "No focus sessions in this period.")


### PR DESCRIPTION
## Summary

Today (and 7 Days / This Month) stats showed the "No Sessions" empty state and hid the Focus Time stat and task breakdown whenever focus time had already been credited to a task but no phase had completed naturally yet.

## Linked issue

Closes #531

## Root cause

Completing, swapping, or clearing the active task mid-phase closes a `FocusSegment` and upserts a durable draft `Session` (`wasCompleted: false`) per design doc [0010](docs/architecture/design/0010-focus-time-attribution-slices.md), D7. `SessionSummary` correctly sums `focusSeconds` and builds `taskBreakdown` from all focus segments regardless of `wasCompleted`, so that data is non-zero immediately — but `StatsTabView.content` gated the whole scope view (stat grid, donut chart, ranked task list) on `focusCount == 0 && breakCount == 0`. Those counters only increment on natural phase completion, so the gate fired and hid real, already-credited data.

## Fix

Added a `summary.focusSeconds == 0` check to the empty-state gate in `StatsTabView.content`, so the scope view renders as soon as any focus time is credited (design doc 0010, Q6: "Immediately on slice-close"), not only after a phase completes naturally.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

`make lint` and `make format-check` both pass with zero violations. `make build` succeeds. Ran `StatsViewModelTests` and `SessionSummaryTests` (the two suites covering the data this gate reads) — all pass. Did not run the full test suite or manually reproduce the bug in the running app. No regression test added: this is a single-line `@ViewBuilder` gating condition, which the [testing charter](docs/explanation/testing.md) explicitly excludes from the test-required areas (pure SwiftUI view structure).

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Gap introduced by #528/#529, which updated `SessionSummary`/`StatsViewModel` to credit partial focus time but didn't update this empty-state gate to match the new data shape.
