### PR TITLE
fix(timer): reserve preset dropdown width so the countdown doesn't shift

### DIFF
--- a/app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift
+++ b/app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift
@@ -5,30 +5,32 @@
 
 import SwiftUI
 
-/// The countdown readout, which doubles as a compact focus-preset menu whenever more than one
-/// preset exists.
+/// The countdown readout, which becomes a compact focus-preset menu while idle.
 ///
-/// While more than one preset exists, the ``TimerReadout`` is wrapped in a borderless menu of
-/// checkmarked presets (design doc 0009, D4) — the `25:00 ▾` affordance shared by the menu-bar
-/// popover and the window's Timer surface. The menu stays mounted for the whole session
-/// lifecycle so the countdown never shifts position as a session starts or stops; once the
-/// engine leaves idle it becomes inert (`.allowsHitTesting(false)` for pointer/touch,
-/// `.accessibilityRespondsToUserInteraction(false)` for VoiceOver/Switch Control/Voice Control)
-/// rather than disabled, so the countdown text keeps its normal, undimmed style instead of
-/// picking up SwiftUI's automatic disabled appearance. Selecting a preset routes through
-/// `presenter.selectFocusPreset(_:)`, which is itself a no-op while running or paused.
+/// While the engine is idle and more than one preset exists, the ``TimerReadout`` is wrapped in a
+/// borderless menu of checkmarked presets (design doc 0009, D4) — the `25:00 ▾` affordance shared
+/// by the menu-bar popover and the window's Timer surface. Once the engine leaves idle, the menu
+/// disappears (rather than staying mounted-but-inert — that read as a live control even when
+/// non-interactive) and the trailing space it occupied — roughly the system chevron's width — is
+/// reserved with ``chevronReserve`` so the countdown doesn't shift horizontally when the
+/// affordance appears or disappears. Selecting a preset routes through
+/// `presenter.selectFocusPreset(_:)`.
 struct FocusPresetReadout: View {
+
+  /// The estimated width of the system-drawn menu chevron plus its leading gap, reserved next to
+  /// the plain readout while idle-with-a-picker isn't true, so the countdown's horizontal
+  /// position matches where it sits inside the menu.
+  private static let chevronReserve: CGFloat = 16
 
   /// The presenter supplying the readout text, preset list, current selection, and selection intent.
   var presenter: TimerPresenter
 
-  /// When `true`, the readout is hidden from VoiceOver whenever it isn't interactive — the
-  /// non-menu branch, or the menu branch once the engine leaves idle — because a surrounding
+  /// When `true`, the plain (non-menu) readout is hidden from VoiceOver because a surrounding
   /// element — the timer ring — already announces the time. The interactive menu stays reachable.
   var hidesPlainReadoutFromAccessibility: Bool = false
 
   var body: some View {
-    if presenter.showsFocusPresetPicker {
+    if presenter.isIdle && presenter.showsFocusPresetPicker {
       Menu {
         ForEach(presenter.focusPresets, id: \.self) { minutes in
           Button {
@@ -46,10 +48,14 @@ struct FocusPresetReadout: View {
       }
       .menuStyle(.borderlessButton)
       .fixedSize()
-      .allowsHitTesting(presenter.isIdle)
-      .accessibilityRespondsToUserInteraction(presenter.isIdle)
       .accessibilityLabel(AppLabels.Accessibility.focusPresets)
-      .accessibilityHidden(hidesPlainReadoutFromAccessibility && !presenter.isIdle)
+    } else if presenter.showsFocusPresetPicker {
+      HStack(spacing: 0) {
+        TimerReadout(label: presenter.label, phase: presenter.phaseName)
+        Color.clear.frame(width: Self.chevronReserve, height: 0)
+      }
+      .fixedSize()
+      .accessibilityHidden(hidesPlainReadoutFromAccessibility)
     } else {
       TimerReadout(label: presenter.label, phase: presenter.phaseName)
         .accessibilityHidden(hidesPlainReadoutFromAccessibility)
@@ -58,10 +64,19 @@ struct FocusPresetReadout: View {
 }
 
 #if DEBUG
-  #Preview {
+  #Preview("Idle") {
     let engine = SessionEngine()
     let settings = AppSettings()
     settings.focusPresets = [15, 25, 45, 60]
+    return FocusPresetReadout(presenter: TimerPresenter(engine: engine, settings: settings))
+      .padding()
+  }
+
+  #Preview("Running") {
+    let engine = SessionEngine()
+    let settings = AppSettings()
+    settings.focusPresets = [15, 25, 45, 60]
+    engine.start()
     return FocusPresetReadout(presenter: TimerPresenter(engine: engine, settings: settings))
       .padding()
   }

--- a/app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift
+++ b/app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift
@@ -5,24 +5,30 @@
 
 import SwiftUI
 
-/// The countdown readout, which becomes a compact focus-preset menu while idle.
+/// The countdown readout, which doubles as a compact focus-preset menu whenever more than one
+/// preset exists.
 ///
-/// While the engine is idle and more than one preset exists, the ``TimerReadout`` is wrapped in a
-/// borderless menu of checkmarked presets (design doc 0009, D4) — the `25:00 ▾` affordance shared
-/// by the menu-bar popover and the window's Timer surface. Otherwise it renders the plain readout,
-/// so the countdown never shifts position as a session starts or stops. Selecting a preset routes
-/// through `presenter.selectFocusPreset(_:)`.
+/// While more than one preset exists, the ``TimerReadout`` is wrapped in a borderless menu of
+/// checkmarked presets (design doc 0009, D4) — the `25:00 ▾` affordance shared by the menu-bar
+/// popover and the window's Timer surface. The menu stays mounted for the whole session
+/// lifecycle so the countdown never shifts position as a session starts or stops; once the
+/// engine leaves idle it becomes inert (`.allowsHitTesting(false)` for pointer/touch,
+/// `.accessibilityRespondsToUserInteraction(false)` for VoiceOver/Switch Control/Voice Control)
+/// rather than disabled, so the countdown text keeps its normal, undimmed style instead of
+/// picking up SwiftUI's automatic disabled appearance. Selecting a preset routes through
+/// `presenter.selectFocusPreset(_:)`, which is itself a no-op while running or paused.
 struct FocusPresetReadout: View {
 
   /// The presenter supplying the readout text, preset list, current selection, and selection intent.
   var presenter: TimerPresenter
 
-  /// When `true`, the plain (non-menu) readout is hidden from VoiceOver because a surrounding
+  /// When `true`, the readout is hidden from VoiceOver whenever it isn't interactive — the
+  /// non-menu branch, or the menu branch once the engine leaves idle — because a surrounding
   /// element — the timer ring — already announces the time. The interactive menu stays reachable.
   var hidesPlainReadoutFromAccessibility: Bool = false
 
   var body: some View {
-    if presenter.isIdle && presenter.showsFocusPresetPicker {
+    if presenter.showsFocusPresetPicker {
       Menu {
         ForEach(presenter.focusPresets, id: \.self) { minutes in
           Button {
@@ -40,7 +46,10 @@ struct FocusPresetReadout: View {
       }
       .menuStyle(.borderlessButton)
       .fixedSize()
+      .allowsHitTesting(presenter.isIdle)
+      .accessibilityRespondsToUserInteraction(presenter.isIdle)
       .accessibilityLabel(AppLabels.Accessibility.focusPresets)
+      .accessibilityHidden(hidesPlainReadoutFromAccessibility && !presenter.isIdle)
     } else {
       TimerReadout(label: presenter.label, phase: presenter.phaseName)
         .accessibilityHidden(hidesPlainReadoutFromAccessibility)


### PR DESCRIPTION
## Summary

`FocusPresetReadout` (shared by the Timer tab's `CircularTimerView` and `MenuBarPopoverView`) swaps between a `Menu`-wrapped preset picker while idle and a plain `TimerReadout` once a session starts. The countdown used to visibly shift horizontally on that swap, since the menu's system-drawn chevron adds width the plain readout doesn't have. This reserves that width so the countdown's position stays fixed across the swap.

## Linked issue

Closes #527

## Approach

This PR went through two iterations — see individual commits.

1. **First attempt (reverted):** keep the `Menu` mounted for the whole session lifecycle and make it inert via `.allowsHitTesting(presenter.isIdle)` (to dodge `.disabled()`'s automatic dimming of the countdown text) plus `.accessibilityRespondsToUserInteraction(presenter.isIdle)` for VoiceOver/Switch Control/Voice Control parity. It worked as specified, but felt wrong hands-on: a visible chevron that does nothing while running reads as a live control even though it isn't.
2. **Current approach:** go back to swapping the `Menu`-wrapped readout for a plain `TimerReadout` once the engine leaves idle (the original behavior), and fix the layout shift directly — reserve the trailing space the chevron would have occupied with an invisible `Color.clear` spacer, sized to a hand-tuned constant (`FocusPresetReadout.chevronReserve = 16`). Calibrated and verified visually by rendering idle vs. running Xcode previews overlaid at 50% opacity inside a shared wide frame (mimicking how both real host containers center the readout) — the digits align with no visible ghosting. A measured (PreferenceKey + hidden probe `Menu`) approach was considered for pixel-exact sizing across all Dynamic Type sizes, but the fixed constant was chosen for simplicity per reviewer preference.

This also sidesteps the VoiceOver/Switch Control question raised on the first attempt entirely: since the `Menu` isn't mounted at all while running/paused, there's nothing left to (mis)activate.

`TimerPresenter.selectFocusPreset(_:)` already no-ops while running/paused, so the swap itself is defense in depth, not the only guard against changing the duration mid-session.

Issue #527's acceptance criteria were updated to match this direction (the dropdown is hidden again while running/paused — not mounted-and-disabled).

## Out of scope

- The Settings-panel preset editor (unchanged).
- Which states count as "idle" (`TimerPresenter.isIdle`, unchanged).

## Validation

- [x] Lint passes locally (`make lint` — 0 violations)
- [x] Unit tests pass locally (`make test` — all Swift Testing cases pass; the run's only failure is `TaskmatoUITests.testExample()`, a pre-existing UI-test launch/termination flake unrelated to this change)
- [ ] Added or updated tests covering the new behavior (not required — pure SwiftUI view/modifier structure is exempt per `docs/explanation/testing.md`)
- [x] Manually verified the new behavior (`xcodebuild build` succeeds; idle/running alignment verified via overlaid Xcode preview snapshots, see Approach)
- [x] Documentation updated where appropriate (`FocusPresetReadout`'s doc comment now describes the swap + reserved-space approach; issue #527 updated to match)

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

- `make test` exits non-zero, but the only failing test is `TaskmatoUITests.testExample()` ("Failed to terminate com.richwklein.Taskmato") — an app-termination flake in the UI test runner, unaffected by this change. All `TaskmatoTests` (Swift Testing) suites pass.
- `chevronReserve = 16` is a hand-tuned estimate of the system chevron's width plus its leading gap, not a measured value — it was visually verified to align well at the default text size (see Approach) but could drift a point or two at unusual Dynamic Type sizes. Flagging in case a future pass wants the more robust measured version.
- Only file touched: `app/Taskmato/Views/Timer/Components/FocusPresetReadout.swift`, matching the issue's in-scope list.
