### PR TITLE
chore: add wrap-up agent dry-run scratch file

### DIFF
--- a/WRAP_UP_DRYRUN.md
+++ b/WRAP_UP_DRYRUN.md
@@ -1,0 +1,5 @@
+# Wrap-up agent dry run
+
+This is a throwaway file created to exercise the `wrap-up` agent end-to-end
+(branch guard → commit → push → draft PR). It should be deleted and its branch
+and PR torn down after the dry run.


### PR DESCRIPTION
## Summary

Adds a single throwaway file, `WRAP_UP_DRYRUN.md`, at the repo root solely to exercise the new `wrap-up` agent end-to-end (branch guard → commit → push → draft PR).

## Linked issue

None — this is a dry-run exercise with no tracking issue.

## Motivation

Validates the `wrap-up` agent workflow against a real repository before relying on it. The change is intentionally trivial and meant to be torn down (file, branch, and PR) once the dry run is confirmed.

## Changes

- Add `WRAP_UP_DRYRUN.md` scratch file at the repository root.

## Validation

_Put an `x` in the boxes that apply._

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [ ] Behavior is unchanged (refactor) or covered by existing/new tests
- [ ] Manually verified where applicable

Nothing was run: the caller explicitly instructed the wrap-up agent not to build, lint, format, or test. The change touches only a Markdown scratch file with no runtime surface.

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Throwaway. Do not merge — delete the file, branch, and PR after the dry run is confirmed.
