### PR TITLE
refactor(tasks): extract LocalTaskRepository from LocalProvider

### DIFF
--- a/app/Taskmato/Tasks/Local/LocalList.swift
+++ b/app/Taskmato/Tasks/Local/LocalList.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// A named grouping of tasks managed by ``LocalProvider``.
-struct LocalList: Codable, Identifiable, Hashable {
+nonisolated struct LocalList: Codable, Identifiable, Hashable, Sendable {
 
   /// Stable unique identifier for this list.
   let id: UUID

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -18,7 +18,7 @@ import os
 final class LocalProvider: WritableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
-  static let providerID: ProviderID = "local"
+  nonisolated static let providerID: ProviderID = "local"
 
   let id: ProviderID = LocalProvider.providerID
   let displayName: String = "Local"
@@ -43,28 +43,44 @@ final class LocalProvider: WritableTaskProvider {
   var activeTaskCount: Int { allTasks.filter { !$0.isCompleted }.count }
 
   private var allTasks: [LocalTask] = []
-  private let fileURL: URL
-  private let encoder = JSONEncoder()
-  private let decoder = JSONDecoder()
+  private let repository: any LocalTaskRepository
   private let logger = Logger(subsystem: "com.taskmato", category: "LocalProvider")
 
-  /// Creates a provider backed by the default production file path.
+  /// The initial load fired from ``init(repository:)``. Awaited via ``ready()``.
+  private var loadTask: Task<Void, Never>?
+
+  /// Creates a provider backed by the default production JSON repository.
   convenience init() {
-    let appSupport = FileManager.default.urls(
-      for: .applicationSupportDirectory, in: .userDomainMask
-    ).first!
-    let dir = appSupport.appendingPathComponent("Taskmato", isDirectory: true)
-    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-    self.init(fileURL: dir.appendingPathComponent("local-tasks.json"))
+    self.init(
+      repository: JSONLocalTaskRepository(fileURL: JSONLocalTaskRepository.defaultFileURL()))
   }
 
   /// Creates a provider backed by a specific file URL. Pass a temporary path in tests.
-  init(fileURL: URL) {
-    self.fileURL = fileURL
-    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    encoder.dateEncodingStrategy = .iso8601
-    decoder.dateDecodingStrategy = .iso8601
-    load()
+  convenience init(fileURL: URL) {
+    self.init(repository: JSONLocalTaskRepository(fileURL: fileURL))
+  }
+
+  /// Creates a provider backed by an injected repository. Pass a fake repository in tests.
+  ///
+  /// The store loads asynchronously — the observable state populates moments after this
+  /// initializer returns. Await ``ready()`` in tests that need the load to have completed.
+  init(repository: any LocalTaskRepository) {
+    self.repository = repository
+    loadTask = Task { await self.reload() }
+  }
+
+  /// Awaits the initial load fired from ``init(repository:)``.
+  ///
+  /// There is exactly one in-flight load per provider instance: the one started by `init`.
+  /// ``lists()``, ``tasks(in:)``, and ``completedTasks()`` await this before reading state, so
+  /// a query issued moments after construction — as `AppSidebarView`'s one-shot startup
+  /// `.task` does — can no longer observe the pre-load empty state and cache it permanently
+  /// (the underlying regression: the old synchronous `init` made this impossible since loading
+  /// always completed before construction returned). Tests that need state populated before
+  /// asserting should await this rather than calling ``reload()`` again, which would race the
+  /// initial load.
+  func ready() async {
+    await loadTask?.value
   }
 
   // MARK: - TaskProvider
@@ -74,13 +90,15 @@ final class LocalProvider: WritableTaskProvider {
 
   /// Returns the managed lists expressed as provider-agnostic ``TaskList`` values.
   func lists() async throws -> [TaskList] {
-    taskLists.map(\.asTaskList)
+    await ready()
+    return taskLists.map(\.asTaskList)
   }
 
   /// Returns incomplete tasks, optionally scoped to a single list.
   ///
   /// - Parameter list: Scope results to a specific list, or `nil` for all incomplete tasks.
   func tasks(in list: TaskList?) async throws -> [TaskItem] {
+    await ready()
     let incomplete = allTasks.filter { !$0.isCompleted }
     if let list {
       let listID = UUID(uuidString: list.id)
@@ -101,7 +119,7 @@ final class LocalProvider: WritableTaskProvider {
     }
     allTasks[idx].isCompleted = true
     allTasks[idx].completedAt = Date()
-    save()
+    await persist()
   }
 
   /// Restores a completed task by clearing `isCompleted` and `completedAt`.
@@ -111,12 +129,14 @@ final class LocalProvider: WritableTaskProvider {
     }
     allTasks[idx].isCompleted = false
     allTasks[idx].completedAt = nil
-    save()
+    await persist()
   }
 
   /// Returns all soft-deleted tasks, sorted by completion date descending.
   func completedTasks() async throws -> [TaskItem] {
-    allTasks
+    await ready()
+    return
+      allTasks
       .filter { $0.isCompleted }
       .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
       .map { $0.asTaskItem(lists: taskLists) }
@@ -135,7 +155,7 @@ final class LocalProvider: WritableTaskProvider {
     }
     let newTask = LocalTask(from: resolved)
     allTasks.append(newTask)
-    save()
+    await persist()
     return newTask.asTaskItem(lists: taskLists)
   }
 
@@ -145,7 +165,7 @@ final class LocalProvider: WritableTaskProvider {
       throw LocalProviderError.listNotFound(listID)
     }
     defaultListID = listID
-    save()
+    await persist()
   }
 
   /// Applies `draft` to the task identified by `ref`.
@@ -154,7 +174,7 @@ final class LocalProvider: WritableTaskProvider {
       throw LocalProviderError.taskNotFound(ref.nativeID)
     }
     allTasks[idx].apply(draft)
-    save()
+    await persist()
   }
 
   /// Permanently removes the task identified by `ref` from the store.
@@ -163,7 +183,7 @@ final class LocalProvider: WritableTaskProvider {
       throw LocalProviderError.taskNotFound(ref.nativeID)
     }
     allTasks.removeAll { $0.id.uuidString == ref.nativeID }
-    save()
+    await persist()
   }
 
   // MARK: - WritableTaskProvider: list management
@@ -173,7 +193,7 @@ final class LocalProvider: WritableTaskProvider {
   func createList(name: String) async throws -> TaskList {
     let list = LocalList(id: UUID(), name: name)
     taskLists.append(list)
-    save()
+    await persist()
     return list.asTaskList
   }
 
@@ -183,7 +203,7 @@ final class LocalProvider: WritableTaskProvider {
       throw LocalProviderError.listNotFound(listID)
     }
     taskLists[idx].name = name
-    save()
+    await persist()
   }
 
   /// Deletes the list identified by `listID`, reassigning its tasks to the default list.
@@ -204,18 +224,35 @@ final class LocalProvider: WritableTaskProvider {
     for idx in allTasks.indices where allTasks[idx].listID == uuid {
       allTasks[idx].listID = fallbackID
     }
-    save()
+    await persist()
   }
 
   // MARK: - Persistence
 
-  private func load() {
-    if let data = try? Data(contentsOf: fileURL) {
-      let stored = try? decoder.decode(LocalStore.self, from: data)
-      taskLists = stored?.lists ?? []
-      allTasks = stored?.tasks ?? []
-      defaultListID = stored?.defaultListID
+  /// Loads the store from the repository and normalizes default-list invariants.
+  ///
+  /// Called once from ``init(repository:)``; awaited by tests and callers via ``ready()``.
+  /// On a read/decode failure this returns immediately, leaving the provider's in-memory
+  /// state at its empty initial values — it does **not** fall through into the default-list
+  /// normalization below, which would otherwise treat the empty in-memory state as "no lists
+  /// yet" and persist a fresh empty store over the corrupt file. Note this only protects the
+  /// file while the provider is idle: a subsequent mutator (``addTask(_:)``,
+  /// ``createList(name:)``, etc.) still calls ``persist()`` unconditionally and will overwrite
+  /// the primary file with fresh content. A successful load — including the legitimate "file
+  /// doesn't exist yet" empty-store case, which does not throw — proceeds into normalization
+  /// as usual.
+  func reload() async {
+    let stored: LocalStore
+    do {
+      stored = try await repository.loadAll()
+    } catch {
+      logger.error("LocalProvider failed to load: \(error.localizedDescription, privacy: .public)")
+      return
     }
+    taskLists = stored.lists
+    allTasks = stored.tasks
+    defaultListID = stored.defaultListID
+
     var dirty = false
     if taskLists.isEmpty {
       taskLists.append(LocalList(id: UUID(), name: "Default"))
@@ -231,27 +268,17 @@ final class LocalProvider: WritableTaskProvider {
       defaultListID = firstID.uuidString
       dirty = true
     }
-    if dirty { save() }
+    if dirty { await persist() }
   }
 
-  private func save() {
+  private func persist() async {
     let store = LocalStore(lists: taskLists, tasks: allTasks, defaultListID: defaultListID)
     do {
-      let data = try encoder.encode(store)
-      try data.write(to: fileURL, options: [])
+      try await repository.save(store)
     } catch {
       logger.error("LocalProvider failed to save: \(error.localizedDescription, privacy: .public)")
     }
   }
-}
-
-// MARK: - Persistence container
-
-/// Top-level JSON container for the local task store.
-private struct LocalStore: Codable {
-  var lists: [LocalList]
-  var tasks: [LocalTask]
-  var defaultListID: String?
 }
 
 // MARK: - Errors

--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -9,7 +9,7 @@ import Foundation
 ///
 /// Extends the core ``TaskItem`` properties with completion state. The ``asTaskItem(lists:)``
 /// method converts to the provider-agnostic representation used by the picker and session log.
-struct LocalTask: Codable, Identifiable {
+nonisolated struct LocalTask: Codable, Identifiable, Sendable {
 
   /// Stable unique identifier for this task.
   let id: UUID
@@ -50,7 +50,7 @@ struct LocalTask: Codable, Identifiable {
   /// Wall-clock time when the task was first created.
   let createdAt: Date
 
-  private enum CodingKeys: String, CodingKey {
+  private nonisolated enum CodingKeys: String, CodingKey {
     case id, title, notes, format, priority, dueDate, scheduledDate, startDate
     case listID, isCompleted, completedAt, createdAt
   }
@@ -95,7 +95,7 @@ extension LocalTask {
   ///
   /// The default preserves backward compatibility with JSON records written before the
   /// `format` field was introduced.
-  init(from decoder: Decoder) throws {
+  nonisolated init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(UUID.self, forKey: .id)
     title = try container.decode(String.self, forKey: .title)

--- a/app/Taskmato/Tasks/Local/Storage/JSONLocalTaskRepository.swift
+++ b/app/Taskmato/Tasks/Local/Storage/JSONLocalTaskRepository.swift
@@ -1,0 +1,62 @@
+//
+//  JSONLocalTaskRepository.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A ``LocalTaskRepository`` backed by a JSON file in Application Support.
+///
+/// Actor isolation serializes reads and writes off the main actor. The production file is
+/// `~/Library/Application Support/Taskmato/local-tasks.json`. Failures are thrown rather than
+/// logged here; ``LocalProvider`` is the sole place that logs, so a failure is reported once.
+actor JSONLocalTaskRepository: LocalTaskRepository {
+
+  private let fileURL: URL
+  private let encoder: JSONEncoder
+  private let decoder: JSONDecoder
+
+  /// Creates a repository backed by a specific file URL. Pass a temporary path in tests.
+  init(fileURL: URL) {
+    self.fileURL = fileURL
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    encoder.dateEncodingStrategy = .iso8601
+    self.encoder = encoder
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    self.decoder = decoder
+  }
+
+  /// Reads and decodes the JSON file, returning an empty store if none has been saved yet.
+  /// - Throws: If the file exists but cannot be read or decoded.
+  func loadAll() throws -> LocalStore {
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+      return LocalStore(lists: [], tasks: [], defaultListID: nil)
+    }
+    let data = try Data(contentsOf: fileURL)
+    return try decoder.decode(LocalStore.self, from: data)
+  }
+
+  /// Encodes `store` and writes it to the JSON file, overwriting any existing content.
+  func save(_ store: LocalStore) throws {
+    let data = try encoder.encode(store)
+    try data.write(to: fileURL, options: [])
+  }
+}
+
+extension JSONLocalTaskRepository {
+
+  /// File name of the production JSON store.
+  static let fileName = "local-tasks.json"
+
+  /// The default production file URL, creating the containing directory if needed.
+  static func defaultFileURL() -> URL {
+    let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask
+    ).first!
+    let dir = appSupport.appendingPathComponent("Taskmato", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent(fileName)
+  }
+}

--- a/app/Taskmato/Tasks/Local/Storage/LocalTaskRepository.swift
+++ b/app/Taskmato/Tasks/Local/Storage/LocalTaskRepository.swift
@@ -1,0 +1,34 @@
+//
+//  LocalTaskRepository.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// A minimal persistence conduit for the local task store: the full store in, the full store out.
+///
+/// Conformers own storage only. List/task manipulation, default-list invariants, and soft-delete
+/// semantics all live in ``LocalProvider``, never here — the protocol deliberately exposes just
+/// two requirements, mirroring ``SessionRepository``.
+protocol LocalTaskRepository: Sendable {
+
+  /// Loads the persisted store, or an empty store if nothing has been saved yet.
+  func loadAll() async throws -> LocalStore
+
+  /// Persists `store`, replacing any existing content.
+  /// - Parameter store: The full local task store to write.
+  func save(_ store: LocalStore) async throws
+}
+
+/// Top-level container for the local task store: lists, tasks, and the default list ID.
+nonisolated struct LocalStore: Codable, Sendable {
+
+  /// Lists managed by the provider, in creation order.
+  var lists: [LocalList]
+
+  /// All tasks, both active and soft-deleted (completed).
+  var tasks: [LocalTask]
+
+  /// The ID of the list new tasks are added to by default.
+  var defaultListID: String?
+}

--- a/app/Taskmato/Tasks/Models/TaskPriority.swift
+++ b/app/Taskmato/Tasks/Models/TaskPriority.swift
@@ -6,7 +6,7 @@
 import Foundation
 
 /// The priority level of a task, aligned with the obsidian-tasks emoji format.
-enum TaskPriority: Int, Codable, Comparable, CaseIterable, Sendable {
+nonisolated enum TaskPriority: Int, Codable, Comparable, CaseIterable, Sendable {
 
   /// No priority assigned.
   case none = 0

--- a/app/TaskmatoTests/FakeLocalTaskRepository.swift
+++ b/app/TaskmatoTests/FakeLocalTaskRepository.swift
@@ -1,0 +1,36 @@
+//
+//  FakeLocalTaskRepository.swift
+//  TaskmatoTests
+//
+
+import Foundation
+
+@testable import Taskmato
+
+/// In-memory ``LocalTaskRepository`` whose ``loadAll()`` can be delayed.
+///
+/// The delay lets tests deterministically reproduce callers that race a provider's initial
+/// load — e.g. a query issued immediately after construction, before the load completes —
+/// rather than relying on real file I/O finishing fast enough to observe the race by luck.
+actor FakeLocalTaskRepository: LocalTaskRepository {
+
+  private let store: LocalStore
+  private let loadDelayNanoseconds: UInt64
+
+  init(
+    store: LocalStore = LocalStore(lists: [], tasks: [], defaultListID: nil),
+    loadDelayNanoseconds: UInt64 = 0
+  ) {
+    self.store = store
+    self.loadDelayNanoseconds = loadDelayNanoseconds
+  }
+
+  func loadAll() async throws -> LocalStore {
+    if loadDelayNanoseconds > 0 {
+      try await Task.sleep(nanoseconds: loadDelayNanoseconds)
+    }
+    return store
+  }
+
+  func save(_ store: LocalStore) async throws {}
+}

--- a/app/TaskmatoTests/JSONLocalTaskRepositoryTests.swift
+++ b/app/TaskmatoTests/JSONLocalTaskRepositoryTests.swift
@@ -1,0 +1,83 @@
+//
+//  JSONLocalTaskRepositoryTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+@Suite("JSONLocalTaskRepository")
+struct JSONLocalTaskRepositoryTests {
+
+  /// Creates a repository backed by a unique temporary file so tests are fully isolated.
+  private func makeRepository() -> JSONLocalTaskRepository {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    return JSONLocalTaskRepository(fileURL: url)
+  }
+
+  private func makeTask(title: String = "Task") -> LocalTask {
+    var draft = TaskDraft()
+    draft.title = title
+    return LocalTask(from: draft)
+  }
+
+  @Test func loadAllReturnsEmptyStoreWhenFileIsMissing() async throws {
+    let repository = makeRepository()
+    let store = try await repository.loadAll()
+    #expect(store.lists.isEmpty)
+    #expect(store.tasks.isEmpty)
+    #expect(store.defaultListID == nil)
+  }
+
+  @Test func loadAllThrowsWhenFileIsCorrupt() async throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    try Data("not json".utf8).write(to: url, options: [])
+    let repository = JSONLocalTaskRepository(fileURL: url)
+    await #expect(throws: (any Error).self) {
+      try await repository.loadAll()
+    }
+  }
+
+  @Test func savedStoreRoundTripsThroughLoadAll() async throws {
+    let repository = makeRepository()
+    let list = LocalList(id: UUID(), name: "Work")
+    let task = makeTask(title: "Write report")
+    let store = LocalStore(lists: [list], tasks: [task], defaultListID: list.id.uuidString)
+    try await repository.save(store)
+
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.map(\.id) == [list.id])
+    #expect(loaded.tasks.map(\.id) == [task.id])
+    #expect(loaded.defaultListID == list.id.uuidString)
+  }
+
+  @Test func saveOverwritesPreviousContent() async throws {
+    let repository = makeRepository()
+    let firstList = LocalList(id: UUID(), name: "First")
+    try await repository.save(
+      LocalStore(lists: [firstList], tasks: [], defaultListID: firstList.id.uuidString))
+
+    let secondList = LocalList(id: UUID(), name: "Second")
+    try await repository.save(
+      LocalStore(lists: [secondList], tasks: [], defaultListID: secondList.id.uuidString))
+
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.map(\.id) == [secondList.id])
+  }
+
+  @Test func savedStorePersistsAcrossRepositoryInstances() async throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    let first = JSONLocalTaskRepository(fileURL: url)
+    let list = LocalList(id: UUID(), name: "Personal")
+    try await first.save(LocalStore(lists: [list], tasks: [], defaultListID: list.id.uuidString))
+
+    let second = JSONLocalTaskRepository(fileURL: url)
+    let loaded = try await second.loadAll()
+    #expect(loaded.lists.map(\.id) == [list.id])
+  }
+}

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -40,38 +40,43 @@ private struct RawLocalStore: Codable {
 @MainActor
 struct LocalProviderTests {
 
-  /// Creates a provider backed by a unique temporary file so tests are fully isolated.
-  private func makeProvider() -> LocalProvider {
+  /// Creates a provider backed by a unique temporary file, with its initial load awaited so
+  /// tests are fully isolated and can read state synchronously right away.
+  private func makeProvider() async -> LocalProvider {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString + ".json")
-    return LocalProvider(fileURL: url)
+    let provider = LocalProvider(fileURL: url)
+    await provider.ready()
+    return provider
   }
 
   // MARK: - Default list
 
-  @Test func createsDefaultListOnFirstLoad() {
-    let provider = makeProvider()
+  @Test func createsDefaultListOnFirstLoad() async {
+    let provider = await makeProvider()
     #expect(provider.taskLists.count == 1)
     #expect(provider.taskLists[0].name == "Default")
   }
 
-  @Test func defaultListIDIsSetOnFirstLoad() {
-    let provider = makeProvider()
+  @Test func defaultListIDIsSetOnFirstLoad() async {
+    let provider = await makeProvider()
     #expect(provider.defaultListID == provider.taskLists[0].id.uuidString)
   }
 
-  @Test func defaultListIDPersistsAcrossReload() {
+  @Test func defaultListIDPersistsAcrossReload() async {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString + ".json")
     let first = LocalProvider(fileURL: url)
+    await first.ready()
     let storedID = first.defaultListID!
 
     let second = LocalProvider(fileURL: url)
+    await second.ready()
     #expect(second.defaultListID == storedID)
   }
 
   @Test func setDefaultListChangesDefault() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     try await provider.createList(name: "Work")
     let workID = provider.taskLists[1].id.uuidString
     try await provider.setDefaultList(workID)
@@ -79,19 +84,21 @@ struct LocalProviderTests {
   }
 
   @Test func setDefaultListThrowsForUnknownID() async {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     await #expect(throws: LocalProviderError.self) {
       try await provider.setDefaultList(UUID().uuidString)
     }
   }
 
-  @Test func doesNotDuplicateDefaultListOnReload() {
+  @Test func doesNotDuplicateDefaultListOnReload() async {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString + ".json")
     let first = LocalProvider(fileURL: url)
+    await first.ready()
     let defaultID = first.taskLists[0].id
 
     let second = LocalProvider(fileURL: url)
+    await second.ready()
     #expect(second.taskLists.count == 1)
     #expect(second.taskLists[0].id == defaultID)
   }
@@ -117,16 +124,47 @@ struct LocalProviderTests {
     try data.write(to: url, options: [])
 
     let provider = LocalProvider(fileURL: url)
+    await provider.ready()
     let tasks = try await provider.tasks(in: nil)
     #expect(tasks.count == 1)
     #expect(tasks[0].title == "Orphan")
     #expect(tasks[0].list?.id == rawList.id.uuidString)
   }
 
+  @Test func listsWaitsForInitialLoadWhenCalledImmediatelyAfterConstruction() async throws {
+    let list = LocalList(id: UUID(), name: "Work")
+    let seededStore = LocalStore(lists: [list], tasks: [], defaultListID: list.id.uuidString)
+    // A real file read is often fast enough that querying immediately after construction
+    // would happen to observe the completed load anyway — an artificially slow load makes the
+    // race deterministic instead of relying on that luck.
+    let repository = FakeLocalTaskRepository(store: seededStore, loadDelayNanoseconds: 50_000_000)
+    let provider = LocalProvider(repository: repository)
+
+    // No `await provider.ready()` here — `lists()` must await the load itself, or this races
+    // the still-in-flight initial read and observes an empty store (the #412 regression: a
+    // caller that queries moments after construction, like `AppSidebarView`'s startup `.task`,
+    // would cache that empty snapshot permanently).
+    let lists = try await provider.lists()
+    #expect(lists.map(\.name) == ["Work"])
+  }
+
+  @Test func corruptFileOnDiskIsLeftUntouchedOnLoadFailure() async throws {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString + ".json")
+    let corrupt = Data("not valid json".utf8)
+    try corrupt.write(to: url, options: [])
+
+    let provider = LocalProvider(fileURL: url)
+    await provider.ready()
+
+    let onDisk = try Data(contentsOf: url)
+    #expect(onDisk == corrupt)
+  }
+
   // MARK: - Task CRUD
 
   @Test func addTaskAppearsInActiveTasks() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "My task"
     try await provider.addTask(draft)
@@ -136,7 +174,7 @@ struct LocalProviderTests {
   }
 
   @Test func activeTaskCarriesCreatedAt() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     let before = Date()
     var draft = TaskDraft()
     draft.title = "Timestamped"
@@ -149,7 +187,7 @@ struct LocalProviderTests {
   }
 
   @Test func addTaskUsesDefaultListWhenNoDraftListID() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     let defaultID = provider.defaultListID!
     var draft = TaskDraft()
     draft.title = "Orphan"
@@ -164,17 +202,19 @@ struct LocalProviderTests {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString + ".json")
     let first = LocalProvider(fileURL: url)
+    await first.ready()
     var draft = TaskDraft()
     draft.title = "Persisted"
     try await first.addTask(draft)
 
     let second = LocalProvider(fileURL: url)
+    await second.ready()
     let tasks = try await second.tasks(in: nil)
     #expect(tasks.map(\.title).contains("Persisted"))
   }
 
   @Test func completeRemovesTaskFromActiveTasks() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "To complete"
     try await provider.addTask(draft)
@@ -185,7 +225,7 @@ struct LocalProviderTests {
   }
 
   @Test func completeAppearsInCompletedTasks() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Done"
     try await provider.addTask(draft)
@@ -197,7 +237,7 @@ struct LocalProviderTests {
   }
 
   @Test func completedTasksItemsCarryCompletedAt() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "With Date"
     try await provider.addTask(draft)
@@ -213,7 +253,7 @@ struct LocalProviderTests {
   }
 
   @Test func reopenRestoresTaskToActive() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Reopen me"
     try await provider.addTask(draft)
@@ -227,7 +267,7 @@ struct LocalProviderTests {
   }
 
   @Test func completedTasksExcludesActiveTasks() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     for title in ["A", "B", "C"] {
       var draft = TaskDraft()
       draft.title = title
@@ -243,7 +283,7 @@ struct LocalProviderTests {
   }
 
   @Test func deleteTaskRemovesPermanently() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Delete me"
     try await provider.addTask(draft)
@@ -254,7 +294,7 @@ struct LocalProviderTests {
   }
 
   @Test func writableProviderDeleteTaskRemovesCompletedItem() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Completed and deleted"
     try await provider.addTask(draft)
@@ -266,7 +306,7 @@ struct LocalProviderTests {
   }
 
   @Test func updateTaskAppliesNewTitle() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Original"
     try await provider.addTask(draft)
@@ -279,7 +319,7 @@ struct LocalProviderTests {
   }
 
   @Test func addTaskHasMarkdownFormat() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Markdown task"
     try await provider.addTask(draft)
@@ -287,8 +327,8 @@ struct LocalProviderTests {
     #expect(tasks[0].format == .markdown)
   }
 
-  @Test func contentFormatIsMarkdown() {
-    let provider = makeProvider()
+  @Test func contentFormatIsMarkdown() async {
+    let provider = await makeProvider()
     #expect(provider.contentFormat == .markdown)
   }
 
@@ -313,13 +353,14 @@ struct LocalProviderTests {
     try data.write(to: url, options: [])
 
     let provider = LocalProvider(fileURL: url)
+    await provider.ready()
     let tasks = try await provider.tasks(in: nil)
     #expect(tasks.count == 1)
     #expect(tasks[0].format == .markdown)
   }
 
   @Test func activeTaskCountExcludesCompleted() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     var draft = TaskDraft()
     draft.title = "Count me"
     try await provider.addTask(draft)
@@ -332,21 +373,21 @@ struct LocalProviderTests {
   // MARK: - List CRUD
 
   @Test func createListAddsToProvider() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     try await provider.createList(name: "Work")
     #expect(provider.taskLists.count == 2)
     #expect(provider.taskLists.map(\.name).contains("Work"))
   }
 
   @Test func renameListUpdatesName() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     let listID = provider.taskLists[0].id.uuidString
     try await provider.renameList(listID, name: "Personal")
     #expect(provider.taskLists[0].name == "Personal")
   }
 
   @Test func deleteNonDefaultListMovesTasksToDefault() async throws {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     try await provider.createList(name: "Secondary")
     let primaryID = provider.taskLists[0].id.uuidString  // Default = current default
     let secondaryID = provider.taskLists[1].id.uuidString
@@ -368,7 +409,7 @@ struct LocalProviderTests {
   }
 
   @Test func deleteDefaultListThrows() async {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     let defaultID = provider.defaultListID!
     await #expect(throws: LocalProviderError.self) {
       try await provider.deleteList(defaultID)
@@ -376,7 +417,7 @@ struct LocalProviderTests {
   }
 
   @Test func renameListThrowsForUnknownID() async {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     let unknown = UUID().uuidString
     await #expect(throws: (any Error).self) {
       try await provider.renameList(unknown, name: "Ghost")
@@ -384,7 +425,7 @@ struct LocalProviderTests {
   }
 
   @Test func deleteTaskThrowsForUnknownRef() async {
-    let provider = makeProvider()
+    let provider = await makeProvider()
     let ref = TaskRef(providerID: LocalProvider.providerID, nativeID: UUID().uuidString)
     await #expect(throws: (any Error).self) {
       try await provider.deleteTask(ref)


### PR DESCRIPTION
## Summary

Extract a `LocalTaskRepository` protocol and `JSONLocalTaskRepository` actor implementation out of `LocalProvider`, mirroring the `SessionRepository`/`SwiftDataSessionRepository` pattern established by #400.

## Linked issue

Closes #412

## Motivation

`LocalProvider` mixed persistence (JSON file read/write) with provider/CRUD logic directly. #400 already established the repository-extraction pattern for sessions; #412 asks for the same treatment on the local task store so persistence is swappable and independently testable, with no behavior change.

## Changes

- Add `LocalTaskRepository` protocol + the promoted `LocalStore` container type (`app/Taskmato/Tasks/Local/Storage/LocalTaskRepository.swift`).
- Add `JSONLocalTaskRepository`, an `actor` implementation backed by the same production file path as before (`app/Taskmato/Tasks/Local/Storage/JSONLocalTaskRepository.swift`).
- `LocalProvider` now holds an injected `any LocalTaskRepository` and loads via an async `Task` fired from `init`, with an awaitable `ready()` for deterministic testing — the same pattern `SessionStore` already uses.
- **Regression found and fixed during review**: moving storage behind an actor made the initial load asynchronous, which opened a race the old synchronous load couldn't have — `AppSidebarView`'s one-shot startup `.task` could query `lists()` before the load finished and cache an empty list snapshot permanently, since nothing re-fetches after. Fixed by gating `lists()`, `tasks(in:)`, and `completedTasks()` on `ready()`, mirroring how `RemindersProvider` gates on `isAuthorized` and `ObsidianProvider` gates on `vaultURL`. Mutators are left unguarded — no reachable path can invoke one before the load completes.
- Add `FakeLocalTaskRepository` with a controllable load delay so the race is reproduced deterministically in tests, plus a regression test (verified by hand to fail without the fix and pass with it).
- `nonisolated` annotations on `LocalList`, `LocalTask`, `TaskPriority` where Swift 6's default-MainActor-isolation build setting required it for the new actor boundary.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

`make sync-version && make lint` (0 violations, 158 files), `make format && make format-check` (0 issues), `xcodebuild build` (BUILD SUCCEEDED), and the full `LocalProviderTests` + `JSONLocalTaskRepositoryTests` suites (all passing).

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Unrelated pre-existing bug found while testing this branch — Add Task from the toolbar/menu bar ignores the currently-selected non-default list. Confirmed byte-identical on `main` (not a regression from this PR) and filed separately as #535 for the 1.2.0 milestone; not part of this diff.
