### PR TITLE
fix(tasks): pre-select current list when adding task from toolbar/menu bar

### DIFF
--- a/app/Taskmato/Tasks/Models/SidebarSelection.swift
+++ b/app/Taskmato/Tasks/Models/SidebarSelection.swift
@@ -13,4 +13,13 @@ enum SidebarSelection: Hashable, Codable, Sendable {
 
   /// A specific provider list identified by provider and list IDs.
   case list(SelectedList)
+
+  /// Returns the list ID when this selection belongs to `providerID`.
+  /// - Parameter providerID: The provider ID to match against this selection.
+  func listID(matching providerID: ProviderID) -> String? {
+    guard case .list(let selectedList) = self,
+      selectedList.providerID == providerID
+    else { return nil }
+    return selectedList.listID
+  }
 }

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -54,6 +54,12 @@ struct TaskDetailView: View {
     return writable
   }
 
+  /// The currently selected list to pre-select when creating a task from this detail surface.
+  private var selectedListIDForNewTask: String? {
+    guard let provider = writableProvider else { return nil }
+    return sidebarSelection.selection?.listID(matching: provider.id)
+  }
+
   private var hasClosableProvider: Bool {
     registry.providers.contains { registry.isEnabled($0.id) && $0 is (any ClosableTaskProvider) }
   }
@@ -86,7 +92,8 @@ struct TaskDetailView: View {
       .sheet(isPresented: $isAddingTask) {
         if let provider = writableProvider {
           AddTaskView(
-            provider: provider, isPresented: $isAddingTask, errorPresenter: errorPresenter)
+            provider: provider, isPresented: $isAddingTask, errorPresenter: errorPresenter,
+            initialListID: selectedListIDForNewTask)
         }
       }
       .sheet(isPresented: $isEditingTask) {

--- a/app/TaskmatoTests/SelectionStoreTests.swift
+++ b/app/TaskmatoTests/SelectionStoreTests.swift
@@ -200,3 +200,25 @@ struct SelectionStoreTests {
     #expect(store.selection == .today)
   }
 }
+
+@Suite("SidebarSelection.listID(matching:)")
+struct NewTaskListSelectionTests {
+
+  @Test func returnsCurrentListWhenProviderMatches() {
+    let selection = SidebarSelection.list(
+      SelectedList(providerID: "local", listID: "next-week"))
+
+    #expect(selection.listID(matching: "local") == "next-week")
+  }
+
+  @Test func returnsNilWhenProviderDiffers() {
+    let selection = SidebarSelection.list(
+      SelectedList(providerID: "reminders", listID: "groceries"))
+
+    #expect(selection.listID(matching: "local") == nil)
+  }
+
+  @Test func returnsNilForTodaySelection() {
+    #expect(SidebarSelection.today.listID(matching: "local") == nil)
+  }
+}


### PR DESCRIPTION
## Summary

Triggering "New Task" from the toolbar "+" button or the menu bar's New Task command always opened the Add Task sheet pre-filled with the writable provider's default list, even when a specific non-default list was selected in the sidebar. This was inconsistent with the per-list "Add Task" affordance, which already pre-selects the list it was invoked from. Users adding a task via the toolbar/menu bar while browsing a specific list had to manually re-pick that list in the sheet.

## Linked issue

Closes #535

## Root cause

`TaskDetailView` presented `AddTaskView` without passing an `initialListID`, so the sheet always fell back to the provider's default list regardless of the current sidebar selection.

## Fix

Added `SidebarSelection.listID(matching:)`, which returns the selected list's ID only when the selection belongs to the given (writable) provider — returning `nil` for `.today`, empty selection, or a selection scoped to a different provider. `TaskDetailView` now computes `selectedListIDForNewTask` from the current `sidebarSelection` and the writable provider, and passes it as `initialListID` when presenting `AddTaskView`, matching the existing per-list add behavior.

## Validation

- [x] Lint passes locally
- [ ] Unit tests pass locally
- [x] Added or updated a regression test
- [ ] Manually verified the original bug no longer reproduces

`make sync-version`, `make lint`, and `make format-check` were run locally and pass with zero violations. Unit tests were not run as part of this wrap-up (build/test verification was out of scope for this pass); a code review of the diff found no correctness bugs. A new `NewTaskListSelectionTests` suite in `SelectionStoreTests.swift` covers `listID(matching:)` for matching provider, differing provider, and `.today` selection.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Code review found no correctness bugs in this change. Please run/confirm unit tests and manual verification (select a non-default list in the sidebar, trigger New Task from the toolbar "+" and from the menu bar's New Task command, confirm the sheet pre-selects that list) before merge.