### PR TITLE
refactor(tasks): back LocalProvider with SwiftData and migrate JSON store

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -7,6 +7,7 @@
 
 import AppKit
 import Foundation
+import SwiftData
 
 /// The composition root for Taskmato — constructs every service and exposes
 /// them as immutable properties for injection into the scene hierarchy.
@@ -46,7 +47,7 @@ struct AppComposition {
     let registry = ProviderRegistry(store: settingsStore)
     let notifications = NotificationService(settings: settings)
     let obsidianProvider = ObsidianProvider(store: settingsStore)
-    let localProvider = LocalProvider()
+    let localProvider = LocalProvider(repository: Self.makeLocalRepository())
     let remindersProvider = RemindersProvider(
       store: LiveRemindersEventStore(), settings: settingsStore)
     let statsViewModel = Self.makeStatsViewModel(store: store, registry: registry)
@@ -106,6 +107,25 @@ struct AppComposition {
     } catch {
       fatalError("Unable to open the Taskmato session store: \(error)")
     }
+  }
+
+  /// Opens the SwiftData local task store, trapping if it cannot be created, then runs the
+  /// one-shot JSON migration before any provider touches the container.
+  ///
+  /// The migration must run before ``LocalProvider`` is constructed — its async `reload()`
+  /// would otherwise be free to normalize an empty store over data the migration hasn't
+  /// imported yet.
+  private static func makeLocalRepository() -> SwiftDataLocalTaskRepository {
+    let container: ModelContainer
+    do {
+      container = try SwiftDataLocalTaskRepository.makeContainer(
+        url: SwiftDataLocalTaskRepository.defaultStoreURL())
+    } catch {
+      fatalError("Unable to open the Taskmato local task store: \(error)")
+    }
+    LocalStoreJSONMigrator.migrateIfNeeded(
+      jsonURL: JSONLocalTaskRepository.defaultFileURL(), into: container)
+    return SwiftDataLocalTaskRepository(modelContainer: container)
   }
 
   /// Builds the stats view model, resolving provider display names and tints through `registry`.

--- a/app/Taskmato/Tasks/Local/LocalList.swift
+++ b/app/Taskmato/Tasks/Local/LocalList.swift
@@ -14,8 +14,31 @@ nonisolated struct LocalList: Codable, Identifiable, Hashable, Sendable {
   /// User-visible name shown in the task picker and add-task sheet.
   var name: String
 
+  /// Wall-clock time when this list was first created; the stored ordering key.
+  let createdAt: Date
+
+  private nonisolated enum CodingKeys: String, CodingKey {
+    case id, name, createdAt
+  }
+
   /// Returns this list expressed as the provider-agnostic ``TaskList`` type.
   var asTaskList: TaskList {
     TaskList(id: id.uuidString, providerID: LocalProvider.providerID, name: name)
+  }
+}
+
+extension LocalList {
+
+  /// Decodes a ``LocalList`` from `decoder`, defaulting `createdAt` to `.distantPast` when
+  /// absent.
+  ///
+  /// The default preserves backward compatibility with JSON records written before the
+  /// `createdAt` field was introduced; ``LocalStoreJSONMigrator`` overrides it with
+  /// order-preserving synthesized timestamps during the one-shot migration.
+  nonisolated init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(UUID.self, forKey: .id)
+    name = try container.decode(String.self, forKey: .name)
+    createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? .distantPast
   }
 }

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -191,7 +191,7 @@ final class LocalProvider: WritableTaskProvider {
   /// Appends a new list with the given name and returns the provider-agnostic ``TaskList``.
   @discardableResult
   func createList(name: String) async throws -> TaskList {
-    let list = LocalList(id: UUID(), name: name)
+    let list = LocalList(id: UUID(), name: name, createdAt: Date())
     taskLists.append(list)
     await persist()
     return list.asTaskList
@@ -255,7 +255,7 @@ final class LocalProvider: WritableTaskProvider {
 
     var dirty = false
     if taskLists.isEmpty {
-      taskLists.append(LocalList(id: UUID(), name: "Default"))
+      taskLists.append(LocalList(id: UUID(), name: "Default", createdAt: Date()))
       dirty = true
     }
     let firstID = taskLists[0].id

--- a/app/Taskmato/Tasks/Local/Storage/LocalListEntity.swift
+++ b/app/Taskmato/Tasks/Local/Storage/LocalListEntity.swift
@@ -1,0 +1,65 @@
+//
+//  LocalListEntity.swift
+//  Taskmato
+//
+
+import Foundation
+import SwiftData
+
+/// The SwiftData persistence record mirroring a ``LocalList``'s stored fields.
+///
+/// `isDefault` encodes ``LocalStore/defaultListID`` (a `String?` uuidString with no natural
+/// entity home) as a flag on the list entity itself, keeping to the two-entity model.
+@Model
+final class LocalListEntity {
+
+  /// Stable unique identifier and the record's identity.
+  @Attribute(.unique) var id: UUID
+
+  /// User-visible name shown in the task picker and add-task sheet.
+  var name: String
+
+  /// Wall-clock time when this list was first created; the stored ordering key.
+  var createdAt: Date
+
+  /// `true` when this list is the provider's current default target for new tasks.
+  var isDefault: Bool
+
+  /// Creates a persistence record from explicit field values.
+  init(id: UUID, name: String, createdAt: Date, isDefault: Bool) {
+    self.id = id
+    self.name = name
+    self.createdAt = createdAt
+    self.isDefault = isDefault
+  }
+}
+
+extension LocalListEntity {
+
+  /// Creates a persistence record from a domain ``LocalList``.
+  /// - Parameters:
+  ///   - list: The list to copy fields from.
+  ///   - isDefault: Whether `list` is the provider's current default list.
+  convenience init(list: LocalList, isDefault: Bool) {
+    self.init(id: list.id, name: list.name, createdAt: list.createdAt, isDefault: isDefault)
+  }
+
+  /// Updates this record's fields in place from a domain ``LocalList``, keeping its identity —
+  /// the mutate branch of ``SwiftDataLocalTaskRepository/save(_:)``.
+  /// - Parameters:
+  ///   - list: The list to copy fields from.
+  ///   - isDefault: Whether `list` is the provider's current default list.
+  func update(from list: LocalList, isDefault: Bool) {
+    name = list.name
+    createdAt = list.createdAt
+    self.isDefault = isDefault
+  }
+}
+
+extension LocalList {
+
+  /// Reconstructs a domain ``LocalList`` from its persistence record.
+  nonisolated init(entity: LocalListEntity) {
+    self.init(id: entity.id, name: entity.name, createdAt: entity.createdAt)
+  }
+}

--- a/app/Taskmato/Tasks/Local/Storage/LocalStoreJSONMigrator.swift
+++ b/app/Taskmato/Tasks/Local/Storage/LocalStoreJSONMigrator.swift
@@ -1,0 +1,96 @@
+//
+//  LocalStoreJSONMigrator.swift
+//  Taskmato
+//
+
+import Foundation
+import SwiftData
+import os
+
+/// One-shot migration of the legacy `local-tasks.json` store into a SwiftData
+/// ``SwiftDataLocalTaskRepository`` container.
+///
+/// Runs synchronously during composition, before ``LocalProvider`` is constructed, using a
+/// fresh `ModelContext` over the already-open container — never through the `@ModelActor`, so
+/// no `await` is needed and the provider can never race an in-flight import. It never throws:
+/// data-shaped failures (missing file, corrupt JSON) are logged and handled internally so they
+/// never reach the composition-root `fatalError`, which is reserved for container-open
+/// failures only.
+enum LocalStoreJSONMigrator {
+
+  private static let logger = Logger(subsystem: "com.taskmato", category: "LocalStoreJSONMigrator")
+
+  /// Imports `jsonURL` into `container` if this is the first launch under SwiftData, then
+  /// archives the JSON file so the import never repeats.
+  ///
+  /// No-op if `jsonURL` does not exist. If `container` is already populated, the import is
+  /// skipped but the stale JSON is still archived (idempotency: presence of the JSON file is
+  /// the sole "first launch" signal). On a decode or write failure, the store is left empty and
+  /// `jsonURL` is left in place, unarchived, for manual recovery — a subsequent
+  /// ``LocalProvider`` load still succeeds by creating a fresh Default list.
+  /// - Parameters:
+  ///   - jsonURL: The legacy JSON store file to import.
+  ///   - container: The already-open SwiftData container to import into.
+  static func migrateIfNeeded(jsonURL: URL, into container: ModelContainer) {
+    guard FileManager.default.fileExists(atPath: jsonURL.path) else { return }
+
+    let context = ModelContext(container)
+    let alreadyPopulated: Int
+    do {
+      alreadyPopulated = try context.fetchCount(FetchDescriptor<LocalListEntity>())
+    } catch {
+      logger.error(
+        "Failed to check existing store before migration: \(error.localizedDescription, privacy: .public)"
+      )
+      return
+    }
+    if alreadyPopulated > 0 {
+      archive(jsonURL)
+      return
+    }
+
+    do {
+      let data = try Data(contentsOf: jsonURL)
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .iso8601
+      let store = try decoder.decode(LocalStore.self, from: data)
+      for (index, list) in store.lists.enumerated() {
+        let isDefault = list.id.uuidString == store.defaultListID
+        // Legacy lists carry no createdAt (decoded as .distantPast) — synthesize ascending
+        // timestamps anchored well before any real Date() so migrated order is preserved and
+        // new in-app lists always sort after the migrated set.
+        let synthesizedCreatedAt = Date(timeIntervalSince1970: Double(index))
+        context.insert(
+          LocalListEntity(
+            id: list.id, name: list.name, createdAt: synthesizedCreatedAt, isDefault: isDefault))
+      }
+      for task in store.tasks {
+        context.insert(LocalTaskEntity(task: task))
+      }
+      try context.save()
+    } catch {
+      logger.error(
+        "Failed to migrate local task store from JSON: \(error.localizedDescription, privacy: .public)"
+      )
+      return
+    }
+
+    archive(jsonURL)
+  }
+
+  /// Renames `jsonURL` to `.archived`, removing any stale archive from a previous run first.
+  private static func archive(_ jsonURL: URL) {
+    let archivedURL = jsonURL.appendingPathExtension("archived")
+    let fileManager = FileManager.default
+    if fileManager.fileExists(atPath: archivedURL.path) {
+      try? fileManager.removeItem(at: archivedURL)
+    }
+    do {
+      try fileManager.moveItem(at: jsonURL, to: archivedURL)
+    } catch {
+      logger.error(
+        "Failed to archive migrated local-tasks.json: \(error.localizedDescription, privacy: .public)"
+      )
+    }
+  }
+}

--- a/app/Taskmato/Tasks/Local/Storage/LocalTaskEntity.swift
+++ b/app/Taskmato/Tasks/Local/Storage/LocalTaskEntity.swift
@@ -1,0 +1,114 @@
+//
+//  LocalTaskEntity.swift
+//  Taskmato
+//
+
+import Foundation
+import SwiftData
+
+/// The SwiftData persistence record mirroring a ``LocalTask``'s stored fields.
+///
+/// `format` and `priority` are stored directly as their enum values (the `SessionEntity`/
+/// `SessionPhase` precedent). No `sortIndex` — task display order is always recomputed by
+/// `TaskQueryService`'s sorter, never read from storage; `createdAt` alone is enough for a
+/// deterministic fetch order.
+@Model
+final class LocalTaskEntity {
+
+  /// Stable unique identifier and the record's identity.
+  @Attribute(.unique) var id: UUID
+
+  /// The task title shown in the picker and active-task label.
+  var title: String
+
+  /// Optional supplementary notes or description.
+  var notes: String?
+
+  /// How the task's `notes` string should be interpreted for display.
+  var format: ContentFormat
+
+  /// Priority level, used for sorting and badging in the picker.
+  var priority: TaskPriority
+
+  /// The date by which the task is due.
+  var dueDate: Date?
+
+  /// The date the task is scheduled to be worked on.
+  var scheduledDate: Date?
+
+  /// The earliest date the task should appear in the picker.
+  var startDate: Date?
+
+  /// The list this task belongs to, or `nil` if uncategorized.
+  var listID: UUID?
+
+  /// `true` when the task has been marked complete.
+  var isCompleted: Bool
+
+  /// Wall-clock time when the task was completed, or `nil` if still open.
+  var completedAt: Date?
+
+  /// Wall-clock time when the task was first created.
+  var createdAt: Date
+
+  /// Creates a persistence record from explicit field values.
+  init(
+    id: UUID, title: String, notes: String?, format: ContentFormat, priority: TaskPriority,
+    dueDate: Date?, scheduledDate: Date?, startDate: Date?, listID: UUID?, isCompleted: Bool,
+    completedAt: Date?, createdAt: Date
+  ) {
+    self.id = id
+    self.title = title
+    self.notes = notes
+    self.format = format
+    self.priority = priority
+    self.dueDate = dueDate
+    self.scheduledDate = scheduledDate
+    self.startDate = startDate
+    self.listID = listID
+    self.isCompleted = isCompleted
+    self.completedAt = completedAt
+    self.createdAt = createdAt
+  }
+}
+
+extension LocalTaskEntity {
+
+  /// Creates a persistence record from a domain ``LocalTask``.
+  convenience init(task: LocalTask) {
+    self.init(
+      id: task.id, title: task.title, notes: task.notes, format: task.format,
+      priority: task.priority, dueDate: task.dueDate, scheduledDate: task.scheduledDate,
+      startDate: task.startDate, listID: task.listID, isCompleted: task.isCompleted,
+      completedAt: task.completedAt, createdAt: task.createdAt)
+  }
+
+  /// Updates this record's fields in place from a domain ``LocalTask``, keeping its identity —
+  /// the mutate branch of ``SwiftDataLocalTaskRepository/save(_:)``.
+  /// - Parameter task: The task to copy fields from.
+  func update(from task: LocalTask) {
+    title = task.title
+    notes = task.notes
+    format = task.format
+    priority = task.priority
+    dueDate = task.dueDate
+    scheduledDate = task.scheduledDate
+    startDate = task.startDate
+    listID = task.listID
+    isCompleted = task.isCompleted
+    completedAt = task.completedAt
+    createdAt = task.createdAt
+  }
+}
+
+extension LocalTask {
+
+  /// Reconstructs a domain ``LocalTask`` from its persistence record.
+  nonisolated init(entity: LocalTaskEntity) {
+    self.init(
+      id: entity.id, title: entity.title, notes: entity.notes, format: entity.format,
+      priority: entity.priority, dueDate: entity.dueDate, scheduledDate: entity.scheduledDate,
+      startDate: entity.startDate, listID: entity.listID, isCompleted: entity.isCompleted,
+      completedAt: entity.completedAt, createdAt: entity.createdAt)
+  }
+}

--- a/app/Taskmato/Tasks/Local/Storage/SwiftDataLocalTaskRepository.swift
+++ b/app/Taskmato/Tasks/Local/Storage/SwiftDataLocalTaskRepository.swift
@@ -1,0 +1,98 @@
+//
+//  SwiftDataLocalTaskRepository.swift
+//  Taskmato
+//
+
+import Foundation
+import SwiftData
+
+/// A ``LocalTaskRepository`` backed by a SwiftData store.
+///
+/// `@ModelActor` isolates the non-`Sendable` `ModelContext` to this actor's executor.
+/// The production store is `~/Library/Application Support/Taskmato/LocalTasks.store`.
+@ModelActor
+actor SwiftDataLocalTaskRepository: LocalTaskRepository {
+
+  func loadAll() throws -> LocalStore {
+    let lists = try modelContext.fetch(
+      FetchDescriptor<LocalListEntity>(sortBy: [SortDescriptor(\.createdAt, order: .forward)]))
+    let tasks = try modelContext.fetch(
+      FetchDescriptor<LocalTaskEntity>(sortBy: [SortDescriptor(\.createdAt, order: .forward)]))
+    let defaultListID = lists.first(where: \.isDefault)?.id.uuidString
+    return LocalStore(
+      lists: lists.map(LocalList.init(entity:)), tasks: tasks.map(LocalTask.init(entity:)),
+      defaultListID: defaultListID)
+  }
+
+  func save(_ store: LocalStore) throws {
+    try upsertLists(store.lists, defaultListID: store.defaultListID)
+    try upsertTasks(store.tasks)
+    try modelContext.save()
+  }
+
+  /// Diff-based upsert of `lists` against the current rows: mutates matching ids in place,
+  /// inserts new ones, and deletes rows absent from `lists`.
+  private func upsertLists(_ lists: [LocalList], defaultListID: String?) throws {
+    let existing = try modelContext.fetch(FetchDescriptor<LocalListEntity>())
+    var existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+    for list in lists {
+      let isDefault = list.id.uuidString == defaultListID
+      if let entity = existingByID.removeValue(forKey: list.id) {
+        entity.update(from: list, isDefault: isDefault)
+      } else {
+        modelContext.insert(LocalListEntity(list: list, isDefault: isDefault))
+      }
+    }
+    for orphan in existingByID.values { modelContext.delete(orphan) }
+  }
+
+  /// Diff-based upsert of `tasks` against the current rows: mutates matching ids in place,
+  /// inserts new ones, and deletes rows absent from `tasks`.
+  private func upsertTasks(_ tasks: [LocalTask]) throws {
+    let existing = try modelContext.fetch(FetchDescriptor<LocalTaskEntity>())
+    var existingByID = Dictionary(uniqueKeysWithValues: existing.map { ($0.id, $0) })
+    for task in tasks {
+      if let entity = existingByID.removeValue(forKey: task.id) {
+        entity.update(from: task)
+      } else {
+        modelContext.insert(LocalTaskEntity(task: task))
+      }
+    }
+    for orphan in existingByID.values { modelContext.delete(orphan) }
+  }
+}
+
+extension SwiftDataLocalTaskRepository {
+
+  /// File name of the production SwiftData store.
+  static let storeFileName = "LocalTasks.store"
+
+  /// The default production store URL, creating the containing directory if needed.
+  static func defaultStoreURL() -> URL {
+    let appSupport = FileManager.default.urls(
+      for: .applicationSupportDirectory, in: .userDomainMask
+    ).first!
+    let dir = appSupport.appendingPathComponent("Taskmato", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir.appendingPathComponent(storeFileName)
+  }
+
+  /// Builds a persistent container at `url`.
+  static func makeContainer(url: URL) throws -> ModelContainer {
+    let configuration = ModelConfiguration(url: url)
+    return try ModelContainer(
+      for: LocalTaskEntity.self, LocalListEntity.self, configurations: configuration)
+  }
+
+  /// Builds an ephemeral in-memory container for tests and previews.
+  static func makeInMemoryContainer() throws -> ModelContainer {
+    let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try ModelContainer(
+      for: LocalTaskEntity.self, LocalListEntity.self, configurations: configuration)
+  }
+
+  /// A repository over a fresh in-memory container; the extractable fixture for tests and previews.
+  static func makeInMemory() throws -> SwiftDataLocalTaskRepository {
+    SwiftDataLocalTaskRepository(modelContainer: try makeInMemoryContainer())
+  }
+}

--- a/app/TaskmatoTests/JSONLocalTaskRepositoryTests.swift
+++ b/app/TaskmatoTests/JSONLocalTaskRepositoryTests.swift
@@ -44,7 +44,7 @@ struct JSONLocalTaskRepositoryTests {
 
   @Test func savedStoreRoundTripsThroughLoadAll() async throws {
     let repository = makeRepository()
-    let list = LocalList(id: UUID(), name: "Work")
+    let list = LocalList(id: UUID(), name: "Work", createdAt: Date())
     let task = makeTask(title: "Write report")
     let store = LocalStore(lists: [list], tasks: [task], defaultListID: list.id.uuidString)
     try await repository.save(store)
@@ -57,11 +57,11 @@ struct JSONLocalTaskRepositoryTests {
 
   @Test func saveOverwritesPreviousContent() async throws {
     let repository = makeRepository()
-    let firstList = LocalList(id: UUID(), name: "First")
+    let firstList = LocalList(id: UUID(), name: "First", createdAt: Date())
     try await repository.save(
       LocalStore(lists: [firstList], tasks: [], defaultListID: firstList.id.uuidString))
 
-    let secondList = LocalList(id: UUID(), name: "Second")
+    let secondList = LocalList(id: UUID(), name: "Second", createdAt: Date())
     try await repository.save(
       LocalStore(lists: [secondList], tasks: [], defaultListID: secondList.id.uuidString))
 
@@ -73,7 +73,7 @@ struct JSONLocalTaskRepositoryTests {
     let url = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString + ".json")
     let first = JSONLocalTaskRepository(fileURL: url)
-    let list = LocalList(id: UUID(), name: "Personal")
+    let list = LocalList(id: UUID(), name: "Personal", createdAt: Date())
     try await first.save(LocalStore(lists: [list], tasks: [], defaultListID: list.id.uuidString))
 
     let second = JSONLocalTaskRepository(fileURL: url)

--- a/app/TaskmatoTests/LocalProviderSwiftDataTests.swift
+++ b/app/TaskmatoTests/LocalProviderSwiftDataTests.swift
@@ -1,0 +1,39 @@
+//
+//  LocalProviderSwiftDataTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+/// Smoke test exercising ``LocalProvider`` against a real ``SwiftDataLocalTaskRepository``
+/// actor, the one path the direct-repository and direct-provider suites don't cover together.
+@Suite("LocalProvider+SwiftData")
+@MainActor
+struct LocalProviderSwiftDataTests {
+
+  @Test func addCompleteAndListRoundTripThroughSwiftData() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let provider = LocalProvider(repository: repository)
+    await provider.ready()
+
+    var draft = TaskDraft()
+    draft.title = "Ship the migration"
+    try await provider.addTask(draft)
+
+    let active = try await provider.tasks(in: nil)
+    #expect(active.count == 1)
+    #expect(active[0].title == "Ship the migration")
+
+    try await provider.complete(active[0].id)
+
+    let remaining = try await provider.tasks(in: nil)
+    #expect(remaining.isEmpty)
+
+    let completed = try await provider.completedTasks()
+    #expect(completed.count == 1)
+    #expect(completed[0].title == "Ship the migration")
+  }
+}

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -132,7 +132,7 @@ struct LocalProviderTests {
   }
 
   @Test func listsWaitsForInitialLoadWhenCalledImmediatelyAfterConstruction() async throws {
-    let list = LocalList(id: UUID(), name: "Work")
+    let list = LocalList(id: UUID(), name: "Work", createdAt: Date())
     let seededStore = LocalStore(lists: [list], tasks: [], defaultListID: list.id.uuidString)
     // A real file read is often fast enough that querying immediately after construction
     // would happen to observe the completed load anyway — an artificially slow load makes the

--- a/app/TaskmatoTests/LocalStoreJSONMigratorTests.swift
+++ b/app/TaskmatoTests/LocalStoreJSONMigratorTests.swift
@@ -1,0 +1,119 @@
+//
+//  LocalStoreJSONMigratorTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Taskmato
+
+@Suite("LocalStoreJSONMigrator")
+struct LocalStoreJSONMigratorTests {
+
+  /// A unique JSON file path under a real temp directory, so the archive rename genuinely
+  /// exercises the filesystem.
+  private func makeJSONURL() -> URL {
+    FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".json")
+  }
+
+  private func makeTask(title: String = "Task") -> LocalTask {
+    var draft = TaskDraft()
+    draft.title = title
+    return LocalTask(from: draft)
+  }
+
+  @Test func happyPathImportsAndArchives() async throws {
+    let jsonURL = makeJSONURL()
+    let firstList = LocalList(id: UUID(), name: "First", createdAt: Date())
+    let secondList = LocalList(id: UUID(), name: "Second", createdAt: Date())
+    let task = makeTask(title: "Write report")
+    let store = LocalStore(
+      lists: [firstList, secondList], tasks: [task], defaultListID: secondList.id.uuidString)
+    try await JSONLocalTaskRepository(fileURL: jsonURL).save(store)
+
+    let container = try SwiftDataLocalTaskRepository.makeInMemoryContainer()
+    LocalStoreJSONMigrator.migrateIfNeeded(jsonURL: jsonURL, into: container)
+
+    let repository = SwiftDataLocalTaskRepository(modelContainer: container)
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.map(\.id) == [firstList.id, secondList.id])
+    #expect(loaded.tasks.map(\.id) == [task.id])
+    #expect(loaded.defaultListID == secondList.id.uuidString)
+
+    let archivedURL = jsonURL.appendingPathExtension("archived")
+    #expect(FileManager.default.fileExists(atPath: archivedURL.path))
+    #expect(!FileManager.default.fileExists(atPath: jsonURL.path))
+  }
+
+  @Test func emptyJSONStoreArchivesWithEmptyResult() async throws {
+    let jsonURL = makeJSONURL()
+    let store = LocalStore(lists: [], tasks: [], defaultListID: nil)
+    try await JSONLocalTaskRepository(fileURL: jsonURL).save(store)
+
+    let container = try SwiftDataLocalTaskRepository.makeInMemoryContainer()
+    LocalStoreJSONMigrator.migrateIfNeeded(jsonURL: jsonURL, into: container)
+
+    let repository = SwiftDataLocalTaskRepository(modelContainer: container)
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.isEmpty)
+    #expect(loaded.tasks.isEmpty)
+
+    let archivedURL = jsonURL.appendingPathExtension("archived")
+    #expect(FileManager.default.fileExists(atPath: archivedURL.path))
+  }
+
+  @Test func missingJSONIsANoOp() async throws {
+    let jsonURL = makeJSONURL()
+    let container = try SwiftDataLocalTaskRepository.makeInMemoryContainer()
+    LocalStoreJSONMigrator.migrateIfNeeded(jsonURL: jsonURL, into: container)
+
+    let repository = SwiftDataLocalTaskRepository(modelContainer: container)
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.isEmpty)
+    #expect(loaded.tasks.isEmpty)
+
+    let archivedURL = jsonURL.appendingPathExtension("archived")
+    #expect(!FileManager.default.fileExists(atPath: archivedURL.path))
+  }
+
+  @Test func alreadyPopulatedStoreSkipsImportButStillArchives() async throws {
+    let jsonURL = makeJSONURL()
+    let jsonList = LocalList(id: UUID(), name: "FromJSON", createdAt: Date())
+    let store = LocalStore(lists: [jsonList], tasks: [], defaultListID: jsonList.id.uuidString)
+    try await JSONLocalTaskRepository(fileURL: jsonURL).save(store)
+
+    let container = try SwiftDataLocalTaskRepository.makeInMemoryContainer()
+    let existingList = LocalList(id: UUID(), name: "AlreadyThere", createdAt: Date())
+    let seedRepository = SwiftDataLocalTaskRepository(modelContainer: container)
+    try await seedRepository.save(
+      LocalStore(lists: [existingList], tasks: [], defaultListID: existingList.id.uuidString))
+
+    LocalStoreJSONMigrator.migrateIfNeeded(jsonURL: jsonURL, into: container)
+
+    let loaded = try await seedRepository.loadAll()
+    #expect(loaded.lists.map(\.id) == [existingList.id])
+
+    let archivedURL = jsonURL.appendingPathExtension("archived")
+    #expect(FileManager.default.fileExists(atPath: archivedURL.path))
+    #expect(!FileManager.default.fileExists(atPath: jsonURL.path))
+  }
+
+  @Test func corruptJSONLeavesStoreEmptyAndFileUnarchived() async throws {
+    let jsonURL = makeJSONURL()
+    try Data("not valid json".utf8).write(to: jsonURL, options: [])
+
+    let container = try SwiftDataLocalTaskRepository.makeInMemoryContainer()
+    LocalStoreJSONMigrator.migrateIfNeeded(jsonURL: jsonURL, into: container)
+
+    let repository = SwiftDataLocalTaskRepository(modelContainer: container)
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.isEmpty)
+    #expect(loaded.tasks.isEmpty)
+
+    let archivedURL = jsonURL.appendingPathExtension("archived")
+    #expect(!FileManager.default.fileExists(atPath: archivedURL.path))
+    #expect(FileManager.default.fileExists(atPath: jsonURL.path))
+  }
+}

--- a/app/TaskmatoTests/SwiftDataLocalTaskRepositoryTests.swift
+++ b/app/TaskmatoTests/SwiftDataLocalTaskRepositoryTests.swift
@@ -1,0 +1,117 @@
+//
+//  SwiftDataLocalTaskRepositoryTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import SwiftData
+import Testing
+
+@testable import Taskmato
+
+@Suite("SwiftDataLocalTaskRepository")
+struct SwiftDataLocalTaskRepositoryTests {
+
+  private func makeTask(
+    title: String = "Task", notes: String? = nil, format: ContentFormat = .markdown,
+    priority: TaskPriority = .none, dueDate: Date? = nil, scheduledDate: Date? = nil,
+    startDate: Date? = nil, listID: UUID? = nil, isCompleted: Bool = false,
+    completedAt: Date? = nil, createdAt: Date = Date()
+  ) -> LocalTask {
+    LocalTask(
+      id: UUID(), title: title, notes: notes, format: format, priority: priority,
+      dueDate: dueDate, scheduledDate: scheduledDate, startDate: startDate, listID: listID,
+      isCompleted: isCompleted, completedAt: completedAt, createdAt: createdAt)
+  }
+
+  @Test func emptyStoreLoadAllReturnsEmpty() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let store = try await repository.loadAll()
+    #expect(store.lists.isEmpty)
+    #expect(store.tasks.isEmpty)
+    #expect(store.defaultListID == nil)
+  }
+
+  @Test func listOrderRoundTripsByCreatedAt() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let first = LocalList(
+      id: UUID(), name: "First", createdAt: Date(timeIntervalSinceReferenceDate: 0))
+    let second = LocalList(
+      id: UUID(), name: "Second", createdAt: Date(timeIntervalSinceReferenceDate: 1_000))
+    // Save out of order on purpose.
+    try await repository.save(
+      LocalStore(lists: [second, first], tasks: [], defaultListID: first.id.uuidString))
+
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.map(\.id) == [first.id, second.id])
+  }
+
+  @Test func defaultListIDRoundTripsThroughIsDefault() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let list = LocalList(id: UUID(), name: "Work", createdAt: Date())
+    try await repository.save(
+      LocalStore(lists: [list], tasks: [], defaultListID: list.id.uuidString))
+
+    let loaded = try await repository.loadAll()
+    #expect(loaded.defaultListID == list.id.uuidString)
+  }
+
+  @Test func taskRoundTripsByCreatedAt() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let first = makeTask(title: "First", createdAt: Date(timeIntervalSinceReferenceDate: 0))
+    let second = makeTask(title: "Second", createdAt: Date(timeIntervalSinceReferenceDate: 1_000))
+    try await repository.save(
+      LocalStore(lists: [], tasks: [second, first], defaultListID: nil))
+
+    let loaded = try await repository.loadAll()
+    #expect(loaded.tasks.map(\.id) == [first.id, second.id])
+  }
+
+  @Test func saveReplacesRatherThanAppends() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let listA = LocalList(id: UUID(), name: "A", createdAt: Date())
+    let taskA = makeTask(title: "A")
+    let storeA = LocalStore(lists: [listA], tasks: [taskA], defaultListID: listA.id.uuidString)
+    try await repository.save(storeA)
+
+    let listB = LocalList(id: UUID(), name: "B", createdAt: Date())
+    let taskB = makeTask(title: "B")
+    let storeB = LocalStore(lists: [listB], tasks: [taskB], defaultListID: listB.id.uuidString)
+    try await repository.save(storeB)
+
+    let loaded = try await repository.loadAll()
+    #expect(loaded.lists.map(\.id) == [listB.id])
+    #expect(loaded.tasks.map(\.id) == [taskB.id])
+    #expect(loaded.defaultListID == listB.id.uuidString)
+  }
+
+  @Test func allLocalTaskFieldsSurviveRoundTrip() async throws {
+    let repository = try SwiftDataLocalTaskRepository.makeInMemory()
+    let listID = UUID()
+    let created = Date(timeIntervalSinceReferenceDate: 0)
+    let due = Date(timeIntervalSinceReferenceDate: 100)
+    let scheduled = Date(timeIntervalSinceReferenceDate: 200)
+    let start = Date(timeIntervalSinceReferenceDate: 300)
+    let completed = Date(timeIntervalSinceReferenceDate: 400)
+    let task = makeTask(
+      title: "Full", notes: "Some notes", format: .plainText, priority: .highest,
+      dueDate: due, scheduledDate: scheduled, startDate: start, listID: listID,
+      isCompleted: true, completedAt: completed, createdAt: created)
+    try await repository.save(LocalStore(lists: [], tasks: [task], defaultListID: nil))
+
+    let loaded = try await repository.loadAll()
+    let roundTripped = try #require(loaded.tasks.first)
+    #expect(roundTripped.id == task.id)
+    #expect(roundTripped.title == "Full")
+    #expect(roundTripped.notes == "Some notes")
+    #expect(roundTripped.format == .plainText)
+    #expect(roundTripped.priority == .highest)
+    #expect(roundTripped.dueDate == due)
+    #expect(roundTripped.scheduledDate == scheduled)
+    #expect(roundTripped.startDate == start)
+    #expect(roundTripped.listID == listID)
+    #expect(roundTripped.isCompleted == true)
+    #expect(roundTripped.completedAt == completed)
+    #expect(roundTripped.createdAt == created)
+  }
+}

--- a/docs/architecture/decisions/0002-json-persistence-mvp.md
+++ b/docs/architecture/decisions/0002-json-persistence-mvp.md
@@ -6,6 +6,8 @@ Accepted — 2026-05-22. Revisited at 0.8.0 when stats aggregation helpers land;
 
 **Amended for the session log by [design doc 0007](../design/0007-session-repository-swiftdata.md) (2026-07-21):** the session log moves from JSON to SwiftData at 0.8.0, a clean cutover with no migration. `LocalTasks.json` and the `UserDefaults` settings store are unchanged by that decision and remain governed by this ADR.
 
+**Amended for the local task list by [design doc 0005, D2](../design/0005-pre-1.0-architecture-pass.md) (2026-08-05):** the `LocalProvider` task list moves from `local-tasks.json` to SwiftData (`LocalTasks.store`) this release, via a one-shot import that then archives the JSON file. Unlike the session log, existing user-authored tasks and lists are real data worth preserving, so this is a migration, not a clean cutover. The `UserDefaults` settings store is unchanged and remains governed by this ADR.
+
 ## Context
 
 Taskmato stores three things: app settings, the local task list (for `LocalProvider`), and the session log (for stats). The session log is append-mostly with occasional aggregation reads. The local task list is small (~hundreds of items, not millions). Settings are tiny.


### PR DESCRIPTION
## Summary

Add `SwiftDataLocalTaskRepository`, a `@ModelActor`-backed conformer for the LocalProvider task store, and flip `AppComposition` to use it by default. A one-shot `LocalStoreJSONMigrator` imports the existing `local-tasks.json` into SwiftData on first launch and archives the JSON file afterward.

## Linked issue

Closes #413

## Motivation

Finishes moving Taskmato persistence off JSON (ADR-0002) and onto SwiftData for the local provider, the last provider still JSON-backed. A follow-up (#414, targeted for the 2.0.0 milestone) removes the JSON implementation after a soak period.

## Changes

- `app/Taskmato/Tasks/Local/Storage/SwiftDataLocalTaskRepository.swift` — new `@ModelActor` conformer of the local task repository protocol backed by SwiftData.
- `app/Taskmato/Tasks/Local/Storage/LocalTaskEntity.swift`, `LocalListEntity.swift` — SwiftData model entities. Lists gain a stored `createdAt` (date added) for deterministic ordering; tasks are re-sorted downstream, so no stored order is needed.
- `app/Taskmato/Tasks/Local/Storage/LocalStoreJSONMigrator.swift` — one-shot migrator that imports `local-tasks.json` into SwiftData on first launch and archives the JSON file.
- `app/Taskmato/AppComposition.swift` — flips the default local task repository to the SwiftData-backed implementation.
- `app/Taskmato/Tasks/Local/LocalList.swift`, `LocalProvider.swift` — ripple edits to support the new repository.
- `docs/architecture/decisions/0002-json-persistence-mvp.md` — updated to note the SwiftData migration.
- New test suites: `LocalProviderSwiftDataTests.swift`, `LocalStoreJSONMigratorTests.swift`, `SwiftDataLocalTaskRepositoryTests.swift`, plus ripple edits to `JSONLocalTaskRepositoryTests.swift` and `LocalProviderTests.swift`.

`JSONLocalTaskRepository` stays in the tree for one release as a rollback path (revert the default flip); #414 removes it.

## Validation

- [x] Lint passes locally (`make lint` — 0 violations)
- [x] Unit tests pass locally (`TaskmatoTests` — 610/610)
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable — real migration verified from an Xcode run: 3 lists / 24 tasks round-tripped, list order preserved, `defaultList` mapped correctly, JSON archived.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change

## Reviewer notes

`make format-check` also reported clean. JSON removal is intentionally deferred to #414 to give the SwiftData path a soak period before deleting the old implementation.