### PR TITLE
chore: add make test-failures to surface assertions from failed test runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,8 @@ make format-check  # swift-format — must report zero issues
 
 Fix all violations before committing. Do not suppress lint rules without explicit approval.
 
+When a test fails, `make test` prints only the failing test's **name** — the actual assertion lives in the run's `.xcresult` bundle. Run `make test-failures` to print the assertion messages for the latest run instead of re-running the suite, and iterate on a single test with `-only-testing:` before a final full `make test`. See [`docs/how-to/diagnose-failing-tests.md`](docs/how-to/diagnose-failing-tests.md).
+
 ## Documentation Standards
 
 All public types, properties, and methods must have Swift doc comments (`///`).

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RELEASE_SIGN_FLAGS = CODE_SIGN_IDENTITY="Developer ID Application" \
                      CODE_SIGNING_ALLOWED=YES \
                      DEVELOPMENT_TEAM=43757RE978
 
-.PHONY: help sync-version build run open test lint format format-check clean archive notarize release site-install site-dev site-build
+.PHONY: help sync-version build run open test test-failures lint format format-check clean archive notarize release site-install site-dev site-build
 
 help: ## List the available commands
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
@@ -51,6 +51,9 @@ test: ## Run the unit test suite
 		-destination '$(DESTINATION)' \
 		-enableCodeCoverage YES \
 		$(SIGN_FLAGS)
+
+test-failures: ## Print assertion messages for the latest test run's failures
+	@bash scripts/test-failures.sh $(SCHEME)
 
 lint: ## Check for SwiftLint violations
 	swiftlint lint --strict

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Screenshots and other images used in the docs (and elsewhere) live at [`assets/`
   - [`Marketing Site`](how-to/marketing-site.md) — Develop and build the Astro site at `site/`.
   - [`Update Icons`](how-to/update-icons.md)
   - [`Reset Stale Dev Builds`](how-to/reset-stale-dev-builds.md)
+  - [`Diagnose a Failing Test`](how-to/diagnose-failing-tests.md) — Surface the real assertion from a failed `make test` via `make test-failures`.
 - **Trying to understand *why* something works the way it does?** Start in [`explanation/`](explanation/).
 - **Wondering why a load-bearing decision was made?** Read the relevant ADR in [`architecture/decisions/`](architecture/decisions/).
 - **Reviewing a design proposal in flight?** Look in [`architecture/design/`](architecture/design/).

--- a/docs/how-to/diagnose-failing-tests.md
+++ b/docs/how-to/diagnose-failing-tests.md
@@ -1,0 +1,66 @@
+# Diagnose a Failing Test
+
+`make test` (which wraps `xcodebuild test`) reports **which** tests failed, but
+not **why**. Its tail looks like:
+
+```
+Failing tests:
+	TaskClipboardTests.readPayloadFallsBackToTitleOnlyWhenOnlyPlainTextIsPresent()
+
+** TEST FAILED **
+```
+
+The actual assertion — `Expectation failed: (payload?.priority → .none) == (.none
+→ nil)` — is written into the run's `.xcresult` bundle, not to stdout. Re-running
+the suite to "see it again" wastes minutes and never surfaces the message. Read it
+from the bundle instead.
+
+## Fast path
+
+```bash
+make test-failures
+```
+
+This finds the most recent readable `.xcresult` under `~/Library/Developer/Xcode/
+DerivedData/Taskmato-*/Logs/Test/` and prints each failure's test name and
+assertion text. Run it right after a failed `make test`.
+
+Sample output:
+
+```
+✘ TaskClipboardTests.readPayloadFallsBackToTitleOnlyWhenOnlyPlainTextIsPresent()
+    Expectation failed: (payload?.priority → .none) == (.none → nil)
+```
+
+It skips corrupt bundles — a run that was interrupted mid-write leaves an
+incomplete bundle that is *newer* than the last good result — and reports "No
+failing tests in the latest result." when the newest good run was clean.
+
+## Iterate on one test
+
+Once you know the failing test, re-run just that suite instead of the whole
+target — a single class against warm `DerivedData` takes seconds:
+
+```bash
+xcodebuild test \
+  -project app/Taskmato.xcodeproj \
+  -scheme Taskmato \
+  -destination 'platform=macOS' \
+  -only-testing:TaskmatoTests/TaskClipboardTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Then `make test-failures` again to confirm the assertion is gone. Do a full
+`make test` only once at the end.
+
+## Under the hood
+
+`make test-failures` runs [`scripts/test-failures.sh`](../../scripts/test-failures.sh),
+which is just:
+
+```bash
+xcrun xcresulttool get test-results summary --path <bundle>
+```
+
+piped through a small JSON extractor for the `testFailures[].failureText` field.
+To inspect a specific bundle directly, pass its path to that command.

--- a/scripts/test-failures.sh
+++ b/scripts/test-failures.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Print the assertion messages for the most recent test run's failures.
+#
+# `xcodebuild test` (via `make test`) prints only "Failing tests: <name>" — the
+# actual assertion ("Expectation failed: …") lives inside the .xcresult bundle.
+# This surfaces it in one shot instead of re-running the suite.
+#
+# Usage: scripts/test-failures.sh [SCHEME]   (SCHEME defaults to Taskmato)
+set -euo pipefail
+
+SCHEME="${1:-Taskmato}"
+results_glob="$HOME/Library/Developer/Xcode/DerivedData/${SCHEME}-*/Logs/Test/*.xcresult"
+
+# Walk bundles newest-first and use the first READABLE one. A run that was
+# killed mid-write leaves a corrupt bundle (missing Info.plist) that is newer
+# than the last good result, so "newest" alone is not enough.
+summary=""
+chosen=""
+for bundle in $(ls -dt $results_glob 2>/dev/null); do
+  if out="$(xcrun xcresulttool get test-results summary --path "$bundle" 2>/dev/null)"; then
+    summary="$out"
+    chosen="$bundle"
+    break
+  fi
+done
+
+if [ -z "$summary" ]; then
+  echo "No readable .xcresult found for scheme '$SCHEME'. Run 'make test' first." >&2
+  exit 1
+fi
+
+echo "Result bundle: $chosen" >&2
+
+printf '%s' "$summary" | python3 -c '
+import sys, json
+
+data = json.load(sys.stdin)
+failures = data.get("testFailures", [])
+if not failures:
+    print("No failing tests in the latest result.")
+else:
+    for f in failures:
+        print("✘ " + f.get("testName", "?"))
+        print("    " + f.get("failureText", "").strip())
+'


### PR DESCRIPTION
## Summary

Add a `make test-failures` fast path that prints the actual assertion messages for failed tests, plus a how-to doc.

## Linked issue

N/A — no tracked issue.

## Motivation

`make test` (via `xcodebuild test`) only prints the failing test's **name**; the actual assertion (`Expectation failed: …`) lives inside the run's `.xcresult` bundle and isn't surfaced to stdout. Digging it out manually — or re-running the suite hoping to "see it again" — has been burning a lot of cycles.

## Changes

- New `scripts/test-failures.sh`: finds the newest **readable** `.xcresult` under `DerivedData` (skipping corrupt bundles left by killed runs) and prints each failure's test name + assertion text via `xcrun xcresulttool` piped through a small JSON extractor.
- New `make test-failures` target wrapping the script; added to `.PHONY`.
- New `docs/how-to/diagnose-failing-tests.md` how-to, indexed in `docs/README.md`.
- `AGENTS.md` Build & Verification section now points at `make test-failures` and the how-to.

## Validation

- [ ] Lint passes locally
- [ ] Unit tests pass locally
- [x] Behavior is unchanged (refactor) or covered by existing/new tests
- [x] Manually verified where applicable

No Swift source changed; `make test-failures` itself was run successfully as verification. Lint/format/build are not applicable to this change.

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

Sample output and the "iterate on one test" workflow (`-only-testing:` before a final full `make test`) are documented in `docs/how-to/diagnose-failing-tests.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)