### PR TITLE
feat(tasks): support creating, editing, and deleting Reminders tasks

### DIFF
--- a/app/Taskmato/Services/SettingsStore.swift
+++ b/app/Taskmato/Services/SettingsStore.swift
@@ -211,6 +211,8 @@ extension SettingsStore {
     // MARK: Reminders provider
 
     static let remindersListPatterns = SettingsKey("reminders.listPatterns", default: [String]())
+    static let remindersDefaultListOverride = SettingsKey<String?>(
+      "reminders.defaultListOverride", default: nil)
 
     // MARK: Codable navigation & selection blobs
 

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -15,7 +15,7 @@ import os
 /// so completed tasks can be surfaced via ``completedTasks()``.
 @Observable
 @MainActor
-final class LocalProvider: WritableTaskProvider {
+final class LocalProvider: WritableListProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
   nonisolated static let providerID: ProviderID = "local"

--- a/app/Taskmato/Tasks/Reminders/LiveRemindersEventStore.swift
+++ b/app/Taskmato/Tasks/Reminders/LiveRemindersEventStore.swift
@@ -56,8 +56,20 @@ final class LiveRemindersEventStore: RemindersEventStore {
     }
   }
 
+  func defaultCalendarForNewReminders() -> EKCalendar? {
+    store.defaultCalendarForNewReminders()
+  }
+
+  func newReminder() -> EKReminder {
+    EKReminder(eventStore: store)
+  }
+
   func save(_ reminder: EKReminder, commit: Bool) throws {
     try store.save(reminder, commit: commit)
+  }
+
+  func remove(_ reminder: EKReminder, commit: Bool) throws {
+    try store.remove(reminder, commit: commit)
   }
 
   func reminder(withIdentifier identifier: String) -> EKReminder? {

--- a/app/Taskmato/Tasks/Reminders/RemindersEventStore.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersEventStore.swift
@@ -38,8 +38,17 @@ protocol RemindersEventStore: AnyObject, Sendable {
     within interval: DateInterval
   ) async throws -> [ReminderSnapshot]
 
+  /// Returns the system default calendar for new reminders, or `nil` if none is configured.
+  func defaultCalendarForNewReminders() -> EKCalendar?
+
+  /// Creates a new, unsaved reminder bound to this store.
+  func newReminder() -> EKReminder
+
   /// Saves a modified reminder to the store.
   func save(_ reminder: EKReminder, commit: Bool) throws
+
+  /// Removes a reminder from the store.
+  func remove(_ reminder: EKReminder, commit: Bool) throws
 
   /// Looks up a reminder by its stable ``EKReminder/calendarItemIdentifier``.
   func reminder(withIdentifier identifier: String) -> EKReminder?

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -9,11 +9,14 @@ import Foundation
 /// A task provider backed by Apple Reminders via EventKit.
 ///
 /// Authorization is lazy: ``lists()`` and ``tasks(in:)`` return empty arrays until
-/// ``authorize()`` succeeds. The provider conforms to ``ClosableTaskProvider`` so
-/// completing a Pomodoro can mark the reminder done in the source system.
+/// ``authorize()`` succeeds. The provider conforms to ``WritableTaskProvider`` so tasks can be
+/// created, edited, completed, and deleted from Taskmato — but not ``WritableListProvider``:
+/// Reminders lists (EventKit calendars) already have a mature native management UI
+/// (Reminders.app, iCloud/Exchange account settings), so list create/rename/delete stays out of
+/// scope. See ADR-0011.
 @Observable
 @MainActor
-final class RemindersProvider: ClosableTaskProvider {
+final class RemindersProvider: WritableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
   static let providerID: ProviderID = "reminders"
@@ -31,6 +34,22 @@ final class RemindersProvider: ClosableTaskProvider {
   /// Empty array means no filtering — all calendars are returned.
   private(set) var listPatterns: [String]
 
+  /// The `ContentFormat` new and edited reminders use — Reminders notes are plain text.
+  let contentFormat: ContentFormat = .plainText
+
+  /// User-selected default calendar identifier, or `nil` to fall back to the system default.
+  private var defaultListOverride: String? {
+    didSet { settings[SettingsStore.Keys.remindersDefaultListOverride] = defaultListOverride }
+  }
+
+  /// The ID of the calendar new tasks target by default.
+  ///
+  /// Reflects an explicit ``setDefaultList(_:)`` override when set, otherwise falls back to
+  /// EventKit's own default calendar for new reminders.
+  var defaultListID: String? {
+    defaultListOverride ?? store.defaultCalendarForNewReminders()?.calendarIdentifier
+  }
+
   private let store: any RemindersEventStore
   private let settings: SettingsStore
   private var streamContinuation: AsyncStream<[TaskItem]>.Continuation?
@@ -47,6 +66,7 @@ final class RemindersProvider: ClosableTaskProvider {
     self.store = store
     self.settings = settings
     self.listPatterns = settings[SettingsStore.Keys.remindersListPatterns]
+    self.defaultListOverride = settings[SettingsStore.Keys.remindersDefaultListOverride]
     isAuthorized = store.authorizationStatus() == .fullAccess
   }
 
@@ -194,6 +214,73 @@ final class RemindersProvider: ClosableTaskProvider {
     try store.save(reminder, commit: true)
   }
 
+  // MARK: - WritableTaskProvider
+
+  /// Persists `listID` as the default target for new tasks.
+  ///
+  /// Validated against the pattern-filtered ``lists()`` set so the default stays consistent
+  /// with what the sidebar actually shows.
+  func setDefaultList(_ listID: String) async throws {
+    guard try await lists().contains(where: { $0.id == listID }) else {
+      throw RemindersProviderError.listNotFound(listID)
+    }
+    defaultListOverride = listID
+  }
+
+  /// Creates a new reminder from `draft` and returns the resulting item.
+  ///
+  /// Targets `draft.listID` if set, otherwise ``defaultListID``.
+  @discardableResult
+  func addTask(_ draft: TaskDraft) async throws -> TaskItem {
+    let calendarID = draft.listID ?? defaultListID
+    guard let calendarID,
+      let calendar = store.calendars(for: .reminder)
+        .first(where: { $0.calendarIdentifier == calendarID })
+    else {
+      throw RemindersProviderError.listNotFound(calendarID ?? "")
+    }
+    let reminder = store.newReminder()
+    apply(draft, to: reminder, calendar: calendar)
+    try store.save(reminder, commit: true)
+    return mapToTaskItem(ReminderSnapshot(reminder))
+  }
+
+  /// Applies `draft` to the reminder identified by `ref`, including re-parenting to a
+  /// different calendar when `draft.listID` differs and resolves to a known calendar.
+  func updateTask(_ ref: TaskRef, draft: TaskDraft) async throws {
+    guard let reminder = store.reminder(withIdentifier: ref.nativeID) else {
+      throw RemindersProviderError.reminderNotFound(ref.nativeID)
+    }
+    let calendarID = draft.listID ?? reminder.calendar?.calendarIdentifier
+    guard let calendarID,
+      let calendar = store.calendars(for: .reminder)
+        .first(where: { $0.calendarIdentifier == calendarID })
+    else {
+      throw RemindersProviderError.listNotFound(calendarID ?? "")
+    }
+    apply(draft, to: reminder, calendar: calendar)
+    try store.save(reminder, commit: true)
+  }
+
+  /// Permanently removes the reminder identified by `ref` from the store.
+  func deleteTask(_ ref: TaskRef) async throws {
+    guard let reminder = store.reminder(withIdentifier: ref.nativeID) else {
+      throw RemindersProviderError.reminderNotFound(ref.nativeID)
+    }
+    try store.remove(reminder, commit: true)
+  }
+
+  /// Applies `draft`'s fields to `reminder`, assigning it to `calendar`.
+  private func apply(_ draft: TaskDraft, to reminder: EKReminder, calendar: EKCalendar) {
+    reminder.title = draft.title
+    reminder.notes = draft.notes.isEmpty ? nil : draft.notes
+    reminder.calendar = calendar
+    reminder.priority = mapPriority(draft.priority)
+    reminder.dueDateComponents = draft.dueDate.map {
+      Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: $0)
+    }
+  }
+
   // MARK: - Mapping
 
   /// Maps a ``ReminderSnapshot`` to a provider-agnostic ``TaskItem``.
@@ -237,6 +324,18 @@ final class RemindersProvider: ClosableTaskProvider {
     default: .none
     }
   }
+
+  /// Maps ``TaskPriority`` to the CalDAV priority integer, collapsing to the same 3 bands the
+  /// read side maps back from — `lowest`/`low` and `high`/`highest` are indistinguishable on
+  /// read, so a write-then-reread round-trips stably.
+  private func mapPriority(_ priority: TaskPriority) -> Int {
+    switch priority {
+    case .none: 0
+    case .lowest, .low: 9
+    case .medium: 5
+    case .high, .highest: 1
+    }
+  }
 }
 
 // MARK: - Errors
@@ -256,6 +355,9 @@ enum RemindersProviderError: LocalizedError, Equatable {
   /// No reminder with the given identifier exists in the store.
   case reminderNotFound(String)
 
+  /// No calendar with the given identifier is among the provider's current lists.
+  case listNotFound(String)
+
   var errorDescription: String? {
     switch self {
     case .accessDenied:
@@ -270,6 +372,8 @@ enum RemindersProviderError: LocalizedError, Equatable {
         + "Grant full access in System Settings > Privacy & Security > Reminders."
     case .reminderNotFound(let id):
       return "Could not find reminder \"\(id)\"."
+    case .listNotFound(let id):
+      return "Could not find Reminders list \"\(id)\"."
     }
   }
 }

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -87,12 +87,11 @@ extension ClosableTaskProvider {
   func completedTasks() async throws -> [TaskItem] { [] }
 }
 
-/// A `ClosableTaskProvider` that also supports creating tasks and managing lists.
+/// A `ClosableTaskProvider` that also supports creating and updating tasks, and choosing a
+/// default target list from among the provider's existing lists.
 ///
-/// Providers conforming to this protocol expose the full write surface: task creation,
-/// list lifecycle (create, rename, delete), task deletion, and a persistent default-list
-/// preference. `LocalProvider` conforms immediately; `ObsidianProvider` and
-/// `RemindersProvider` will conform in follow-on milestones.
+/// `LocalProvider` and `RemindersProvider` conform. Providers that also need to create,
+/// rename, or delete lists (not just tasks) conform to ``WritableListProvider`` instead.
 protocol WritableTaskProvider: ClosableTaskProvider {
 
   /// The ID of the list new tasks target by default, or `nil` if none is set.
@@ -108,8 +107,24 @@ protocol WritableTaskProvider: ClosableTaskProvider {
   func addTask(_ draft: TaskDraft) async throws -> TaskItem
 
   /// Persists `listID` as the default target for new tasks.
-  /// - Throws: if `listID` does not identify a known list.
+  /// - Throws: if `listID` does not identify one of the provider's current ``lists()``.
   func setDefaultList(_ listID: String) async throws
+
+  /// Updates the task identified by `ref` with values from `draft`.
+  /// - Throws: if the task cannot be found or the update fails.
+  func updateTask(_ ref: TaskRef, draft: TaskDraft) async throws
+
+  /// Permanently removes the task identified by `ref` from the provider's store.
+  /// - Throws: if the task cannot be found or removal fails.
+  func deleteTask(_ ref: TaskRef) async throws
+}
+
+/// A `WritableTaskProvider` that also owns list lifecycle: create, rename, and delete.
+///
+/// Only providers where Taskmato is the sole or primary owner of the list structure (e.g.
+/// `LocalProvider`) conform. Providers backed by a system with its own mature list-management
+/// UI (e.g. Reminders.app for `RemindersProvider`) conform to ``WritableTaskProvider`` only.
+protocol WritableListProvider: WritableTaskProvider {
 
   /// Creates a new list with `name` and returns the provider-agnostic ``TaskList``.
   @discardableResult
@@ -125,12 +140,4 @@ protocol WritableTaskProvider: ClosableTaskProvider {
   /// another list before deleting the current default.
   /// - Throws: if `listID` is the default list or does not identify a known list.
   func deleteList(_ listID: String) async throws
-
-  /// Updates the task identified by `ref` with values from `draft`.
-  /// - Throws: if the task cannot be found or the update fails.
-  func updateTask(_ ref: TaskRef, draft: TaskDraft) async throws
-
-  /// Permanently removes the task identified by `ref` from the provider's store.
-  /// - Throws: if the task cannot be found or removal fails.
-  func deleteTask(_ ref: TaskRef) async throws
 }

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -136,7 +136,7 @@ struct AppSidebarView: View {
         listRow(list, provider: provider)
           .tag(AppDestination.list(SelectedList(providerID: provider.id, listID: list.id)))
       }
-      if provider is (any WritableTaskProvider) {
+      if provider is (any WritableListProvider) {
         newListRow(providerID: provider.id)
       }
     } header: {
@@ -264,28 +264,31 @@ struct AppSidebarView: View {
     }
     .disabled(isDefaultList)
 
-    Button {
-      renamingListID = list.id
-      renameBuffer = list.name
-      renameFocused = list.id
-    } label: {
-      Label(AppLabels.Sidebar.rename.title, systemImage: AppLabels.Sidebar.rename.systemImage)
-    }
-
-    Divider()
-
-    Button(role: .destructive) {
-      Task {
-        await errorPresenter.attempt(AppLabels.Error.listDeleteFailed) {
-          try await writable.deleteList(list.id)
-        }
-        await loadLists(for: provider)
+    if let listProvider = resolved.listProvider {
+      Button {
+        renamingListID = list.id
+        renameBuffer = list.name
+        renameFocused = list.id
+      } label: {
+        Label(AppLabels.Sidebar.rename.title, systemImage: AppLabels.Sidebar.rename.systemImage)
       }
-    } label: {
-      Label(
-        AppLabels.Sidebar.deleteList.title, systemImage: AppLabels.Sidebar.deleteList.systemImage)
+
+      Divider()
+
+      Button(role: .destructive) {
+        Task {
+          await errorPresenter.attempt(AppLabels.Error.listDeleteFailed) {
+            try await listProvider.deleteList(list.id)
+          }
+          await loadLists(for: provider)
+        }
+      } label: {
+        Label(
+          AppLabels.Sidebar.deleteList.title,
+          systemImage: AppLabels.Sidebar.deleteList.systemImage)
+      }
+      .disabled(isDefaultList)
     }
-    .disabled(isDefaultList)
   }
 
   /// Resolves the row-targeted context-menu action from a selection set, or `nil` for non-writable rows.
@@ -296,15 +299,18 @@ struct AppSidebarView: View {
       let writable = provider as? (any WritableTaskProvider),
       let list = lists(for: provider).first(where: { $0.id == selectedList.listID })
     else { return nil }
-    return ListAction(list: list, provider: provider, writable: writable)
+    let listProvider = provider as? (any WritableListProvider)
+    return ListAction(
+      list: list, provider: provider, writable: writable, listProvider: listProvider)
   }
 
-  /// Tuple-like value that bundles the list, owning provider, and its writable interface
+  /// Tuple-like value that bundles the list, owning provider, and its writable interfaces
   /// resolved from a context-menu selection.
   private struct ListAction {
     let list: TaskList
     let provider: any TaskProvider
     let writable: any WritableTaskProvider
+    let listProvider: (any WritableListProvider)?
   }
 
   /// Provider and list ID targeted by the "Add Task…" context-menu sheet.
@@ -326,41 +332,6 @@ struct AppSidebarView: View {
       Text(list.name)
         .lineLimit(1)
     }
-  }
-
-  // MARK: - New list row
-
-  @ViewBuilder
-  private func newListRow(providerID: ProviderID) -> some View {
-    let nameBinding = Binding(
-      get: { newListName[providerID] ?? "" },
-      set: { newListName[providerID] = $0 }
-    )
-
-    HStack(spacing: .iconLabel) {
-      Image(systemName: "plus")
-        .imageScale(.small)
-        .foregroundStyle(.secondary)
-
-      TextField("New list", text: nameBinding)
-        .textFieldStyle(.plain)
-        .onSubmit {
-          let trimmed = (newListName[providerID] ?? "").trimmingCharacters(in: .whitespaces)
-          guard !trimmed.isEmpty else { return }
-          guard
-            let writable = registry.providers.first(where: { $0.id == providerID })
-              as? (any WritableTaskProvider)
-          else { return }
-          newListName[providerID] = ""
-          Task {
-            await errorPresenter.attempt(AppLabels.Error.listCreateFailed) {
-              _ = try await writable.createList(name: trimmed)
-            }
-            await loadLists(for: writable)
-          }
-        }
-    }
-    .foregroundStyle(.secondary)
   }
 
   // MARK: - Add Provider menu
@@ -437,11 +408,48 @@ struct AppSidebarView: View {
     (provider as? (any WritableTaskProvider))?.defaultListID == listID
   }
 
-  // MARK: - Rename helpers
+}
 
-  private func commitRename(list: TaskList, provider: any TaskProvider) {
+// MARK: - New list row, rename helpers
+
+extension AppSidebarView {
+
+  @ViewBuilder
+  fileprivate func newListRow(providerID: ProviderID) -> some View {
+    let nameBinding = Binding(
+      get: { newListName[providerID] ?? "" },
+      set: { newListName[providerID] = $0 }
+    )
+
+    HStack(spacing: .iconLabel) {
+      Image(systemName: "plus")
+        .imageScale(.small)
+        .foregroundStyle(.secondary)
+
+      TextField("New list", text: nameBinding)
+        .textFieldStyle(.plain)
+        .onSubmit {
+          let trimmed = (newListName[providerID] ?? "").trimmingCharacters(in: .whitespaces)
+          guard !trimmed.isEmpty else { return }
+          guard
+            let writable = registry.providers.first(where: { $0.id == providerID })
+              as? (any WritableListProvider)
+          else { return }
+          newListName[providerID] = ""
+          Task {
+            await errorPresenter.attempt(AppLabels.Error.listCreateFailed) {
+              _ = try await writable.createList(name: trimmed)
+            }
+            await loadLists(for: writable)
+          }
+        }
+    }
+    .foregroundStyle(.secondary)
+  }
+
+  fileprivate func commitRename(list: TaskList, provider: any TaskProvider) {
     let trimmed = renameBuffer.trimmingCharacters(in: .whitespaces)
-    guard !trimmed.isEmpty, let writable = provider as? (any WritableTaskProvider) else {
+    guard !trimmed.isEmpty, let writable = provider as? (any WritableListProvider) else {
       cancelRename()
       return
     }
@@ -454,7 +462,7 @@ struct AppSidebarView: View {
     }
   }
 
-  private func cancelRename() {
+  fileprivate func cancelRename() {
     renamingListID = nil
     renameBuffer = ""
   }

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -158,18 +158,24 @@ struct AddTaskView: View {
     draft.dueDate = hasDueDate ? dueDate : nil
     draft.listID = selectedListID.isEmpty ? nil : selectedListID
     draft.format = provider.contentFormat
-    isPresented = false
+    // Dismiss only after the write completes — dismissing first (as this used to) races the
+    // sheet's `isAddingTask`-driven refresh against the provider write: for an in-process
+    // provider like LocalProvider the in-memory mutation usually beats the refresh anyway, but
+    // for RemindersProvider the refresh re-fetches from EventKit, which can lose that race and
+    // show a list missing the task that was just added.
     if let task = taskToEdit {
       Task {
         await errorPresenter.attempt(AppLabels.Error.updateFailed) {
           try await provider.updateTask(task.id, draft: draft)
         }
+        isPresented = false
       }
     } else {
       Task {
         await errorPresenter.attempt(AppLabels.Error.addFailed) {
           try await provider.addTask(draft)
         }
+        isPresented = false
       }
     }
   }

--- a/app/TaskmatoTests/FakeRemindersEventStore.swift
+++ b/app/TaskmatoTests/FakeRemindersEventStore.swift
@@ -33,6 +33,12 @@ final class FakeRemindersEventStore: RemindersEventStore {
   /// Reminders passed to ``save(_:commit:)``, in call order.
   private(set) var savedReminders: [EKReminder] = []
 
+  /// Reminders passed to ``remove(_:commit:)``, in call order.
+  private(set) var removedReminders: [EKReminder] = []
+
+  /// Calendar returned by ``defaultCalendarForNewReminders()``.
+  var stubbedDefaultCalendar: EKCalendar?
+
   /// Callback registered via ``addObserver(forName:using:)``.
   /// Call ``fireNotification()`` to invoke it from tests.
   private var observerCallback: (@Sendable () -> Void)?
@@ -77,8 +83,20 @@ final class FakeRemindersEventStore: RemindersEventStore {
     stubbedReminders.filter { $0.isCompleted }.map(ReminderSnapshot.init)
   }
 
+  func defaultCalendarForNewReminders() -> EKCalendar? {
+    stubbedDefaultCalendar
+  }
+
+  func newReminder() -> EKReminder {
+    EKReminder(eventStore: backingStore)
+  }
+
   func save(_ reminder: EKReminder, commit: Bool) throws {
     savedReminders.append(reminder)
+  }
+
+  func remove(_ reminder: EKReminder, commit: Bool) throws {
+    removedReminders.append(reminder)
   }
 
   func reminder(withIdentifier identifier: String) -> EKReminder? {

--- a/app/TaskmatoTests/RemindersProviderWritableTests.swift
+++ b/app/TaskmatoTests/RemindersProviderWritableTests.swift
@@ -1,0 +1,210 @@
+//
+//  RemindersProviderWritableTests.swift
+//  TaskmatoTests
+//
+
+import EventKit
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+// MARK: - Writable tests
+
+@Suite("RemindersProvider — writable")
+@MainActor
+struct RemindersProviderWritableTests {
+  private func makeAuthorizedProvider() async throws -> (
+    provider: RemindersProvider, store: FakeRemindersEventStore
+  ) {
+    let store = FakeRemindersEventStore()
+    store.status = .fullAccess
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let provider = RemindersProvider(store: store, settings: SettingsStore(defaults: defaults))
+    try await provider.authorize()
+    return (provider, store)
+  }
+
+  // MARK: contentFormat
+
+  @Test func contentFormatIsPlainText() async throws {
+    let (provider, _) = try await makeAuthorizedProvider()
+    #expect(provider.contentFormat == .plainText)
+  }
+
+  // MARK: defaultListID
+
+  @Test func defaultListIDFallsBackToStoreDefault() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let cal = store.makeCalendar(title: "Work")
+    store.stubbedDefaultCalendar = cal
+    #expect(provider.defaultListID == cal.calendarIdentifier)
+  }
+
+  @Test func defaultListIDReflectsOverrideAfterSetDefaultList() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    let personal = store.makeCalendar(title: "Personal")
+    store.stubbedCalendars = [work, personal]
+    store.stubbedDefaultCalendar = work
+    try await provider.setDefaultList(personal.calendarIdentifier)
+    #expect(provider.defaultListID == personal.calendarIdentifier)
+  }
+
+  @Test func setDefaultListThrowsForIDOutsideLists() async throws {
+    let (provider, _) = try await makeAuthorizedProvider()
+    await #expect(throws: RemindersProviderError.self) {
+      try await provider.setDefaultList("nonexistent")
+    }
+  }
+
+  @Test func setDefaultListThrowsForIDFilteredOutByListPatterns() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    let personal = store.makeCalendar(title: "Personal")
+    store.stubbedCalendars = [work, personal]
+    provider.setListPatterns(["Work"])
+    await #expect(throws: RemindersProviderError.self) {
+      try await provider.setDefaultList(personal.calendarIdentifier)
+    }
+  }
+
+  // MARK: addTask
+
+  @Test func addTaskTargetsDraftListIDWhenSet() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    let personal = store.makeCalendar(title: "Personal")
+    store.stubbedCalendars = [work, personal]
+    store.stubbedDefaultCalendar = work
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.listID = personal.calendarIdentifier
+    let item = try await provider.addTask(draft)
+    #expect(item.list?.id == personal.calendarIdentifier)
+    #expect(store.savedReminders.count == 1)
+  }
+
+  @Test func addTaskFallsBackToDefaultListID() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    store.stubbedCalendars = [work]
+    store.stubbedDefaultCalendar = work
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    let item = try await provider.addTask(draft)
+    #expect(item.list?.id == work.calendarIdentifier)
+  }
+
+  @Test func addTaskThrowsWhenNoListResolves() async throws {
+    let (provider, _) = try await makeAuthorizedProvider()
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    await #expect(throws: RemindersProviderError.self) {
+      try await provider.addTask(draft)
+    }
+  }
+
+  @Test func addTaskMapsTitleNotesDueDate() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    store.stubbedCalendars = [work]
+    store.stubbedDefaultCalendar = work
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.notes = "2%"
+    draft.dueDate = Calendar.current.date(from: DateComponents(year: 2026, month: 6, day: 15))
+    let item = try await provider.addTask(draft)
+    #expect(item.title == "Buy milk")
+    #expect(item.notes == "2%")
+    let comps = Calendar.current.dateComponents([.year, .month, .day], from: item.dueDate!)
+    #expect(comps.year == 2026)
+    #expect(comps.month == 6)
+    #expect(comps.day == 15)
+  }
+
+  @Test(
+    arguments: [
+      (TaskPriority.none, 0),
+      (TaskPriority.lowest, 9),
+      (TaskPriority.low, 9),
+      (TaskPriority.medium, 5),
+      (TaskPriority.high, 1),
+      (TaskPriority.highest, 1),
+    ]
+  )
+  func addTaskMapsPriorityToThreeBands(
+    priority: TaskPriority, expectedEKPriority: Int
+  ) async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    store.stubbedCalendars = [work]
+    store.stubbedDefaultCalendar = work
+    var draft = TaskDraft()
+    draft.title = "Task"
+    draft.priority = priority
+    _ = try await provider.addTask(draft)
+    #expect(store.savedReminders.first?.priority == expectedEKPriority)
+  }
+
+  // MARK: updateTask
+
+  @Test func updateTaskMutatesAndResaves() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let cal = store.makeCalendar(title: "Work")
+    store.stubbedCalendars = [cal]
+    let reminder = store.makeReminder(title: "Original", calendar: cal)
+    store.stubbedReminders = [reminder]
+    let ref = TaskRef(providerID: "reminders", nativeID: reminder.calendarItemIdentifier)
+    var draft = TaskDraft()
+    draft.title = "Updated"
+    try await provider.updateTask(ref, draft: draft)
+    #expect(reminder.title == "Updated")
+    #expect(store.savedReminders.count == 1)
+  }
+
+  @Test func updateTaskReparentsToNewCalendar() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    let personal = store.makeCalendar(title: "Personal")
+    store.stubbedCalendars = [work, personal]
+    let reminder = store.makeReminder(title: "Task", calendar: work)
+    store.stubbedReminders = [reminder]
+    let ref = TaskRef(providerID: "reminders", nativeID: reminder.calendarItemIdentifier)
+    var draft = TaskDraft()
+    draft.title = "Task"
+    draft.listID = personal.calendarIdentifier
+    try await provider.updateTask(ref, draft: draft)
+    #expect(reminder.calendar?.calendarIdentifier == personal.calendarIdentifier)
+  }
+
+  @Test func updateTaskThrowsForUnknownRef() async throws {
+    let (provider, _) = try await makeAuthorizedProvider()
+    let ref = TaskRef(providerID: "reminders", nativeID: "nonexistent")
+    var draft = TaskDraft()
+    draft.title = "Task"
+    await #expect(throws: RemindersProviderError.self) {
+      try await provider.updateTask(ref, draft: draft)
+    }
+  }
+
+  // MARK: deleteTask
+
+  @Test func deleteTaskCallsStoreRemove() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let cal = store.makeCalendar(title: "Work")
+    let reminder = store.makeReminder(title: "Task", calendar: cal)
+    store.stubbedReminders = [reminder]
+    let ref = TaskRef(providerID: "reminders", nativeID: reminder.calendarItemIdentifier)
+    try await provider.deleteTask(ref)
+    #expect(store.removedReminders.count == 1)
+  }
+
+  @Test func deleteTaskThrowsForUnknownRef() async throws {
+    let (provider, _) = try await makeAuthorizedProvider()
+    let ref = TaskRef(providerID: "reminders", nativeID: "nonexistent")
+    await #expect(throws: RemindersProviderError.self) {
+      try await provider.deleteTask(ref)
+    }
+  }
+}

--- a/docs/architecture/decisions/0011-list-management-protocol-split.md
+++ b/docs/architecture/decisions/0011-list-management-protocol-split.md
@@ -1,0 +1,67 @@
+# ADR-0011: List management protocol split
+
+## Status
+
+Accepted — 2026-08-08. Amends [ADR-0001](0001-pluggable-task-providers.md).
+
+## Context
+
+ADR-0001's three-tier protocol hierarchy put task creation, task deletion, the default-list
+preference, and list lifecycle (`createList` / `renameList` / `deleteList`) all on one
+`WritableTaskProvider` tier. That design assumed a provider capable of writing tasks is also
+the right place for Taskmato to own list management.
+
+Conforming `RemindersProvider` to write support ([#329](https://github.com/richwklein/taskmato/issues/329))
+breaks that assumption. Reminders lists are EventKit calendars, and calendar lifecycle is
+already owned by a mature native UI — Reminders.app, and iCloud/Exchange account settings for
+shared and cross-device calendars. Building in-app create/rename/delete for EventKit calendars
+from inside a Pomodoro timer app would duplicate that UI and add real risk: shared family
+calendars, cross-device sync semantics, and accidental data loss on delete, all for a capability
+users already have elsewhere.
+
+Forcing `RemindersProvider` to implement list CRUD it doesn't want in order to get task CRUD
+would mean either building that risky surface anyway, or stub-throwing from the list methods —
+exactly what ADR-0001 says the layered hierarchy exists to avoid ("no stub throws... UI
+affordances gated at the type level").
+
+## Decision
+
+Split `WritableTaskProvider` into two tiers:
+
+- `WritableTaskProvider: ClosableTaskProvider` — task CRUD (`addTask`, `updateTask`,
+  `deleteTask`) plus a settable `defaultListID` among the provider's *existing* lists
+  (`setDefaultList`, validated against `lists()`).
+- `WritableListProvider: WritableTaskProvider` — adds list lifecycle: `createList`,
+  `renameList`, `deleteList`.
+
+`LocalProvider` conforms to `WritableListProvider` (Taskmato is the sole owner of its list
+structure). `RemindersProvider` conforms to `WritableTaskProvider` only — it gets task CRUD and
+default-list selection among the calendars Reminders already exposes, with no in-app list
+creation, rename, or delete.
+
+UI affordances that create, rename, or delete lists (the sidebar's "New list" row, and the
+Rename/Delete context-menu items) gate on `is WritableListProvider`. Affordances scoped to task
+creation and default-list selection (the "+" add-task button, the sidebar star) continue to
+gate on the base `WritableTaskProvider` tier, so they apply uniformly to every writable
+provider, including Reminders.
+
+`ObsidianProvider`'s future write conformance ([#328](https://github.com/richwklein/taskmato/issues/328))
+should re-evaluate against this same question — whether Taskmato should own vault folder
+lifecycle, or whether that too belongs to a tier below `WritableListProvider` — rather than
+assuming full list CRUD by default.
+
+## Consequences
+
+- Each provider conforms to exactly the write capabilities it can support; no stub throws for
+  list lifecycle on providers that don't want it.
+- UI affordances for list create/rename/delete are gated at the type level via
+  `WritableListProvider`; task creation, editing, deletion, and default-list selection are
+  gated at the type level via `WritableTaskProvider` and work identically for every writable
+  provider.
+- Call sites that only need task creation (`ProviderRegistry`'s writable-provider resolution,
+  the Settings "Default writable provider" picker, the URL scheme handler, task detail actions)
+  stay on `WritableTaskProvider` and pick up Reminders automatically once it conforms — no UI
+  change required for those surfaces.
+- Adding a future provider tier below `WritableListProvider` (e.g., a provider that can rename
+  but not create/delete lists) would mean a further protocol split; the pattern established here
+  extends to that case without disrupting existing conformers.


### PR DESCRIPTION
## Summary

Conforms `RemindersProvider` to `WritableTaskProvider` so tasks can be created, edited, and
deleted in Apple Reminders directly from Taskmato's task picker, with the default list reflecting
`EKEventStore.defaultCalendarForNewReminders` unless the user overrides it.

## Linked issue

Closes #329

## Approach

- **Split `WritableTaskProvider` into two tiers** (amends ADR-0001 via new ADR-0011):
  `WritableTaskProvider` (task CRUD + `defaultListID`/`setDefaultList` among existing lists) and
  `WritableListProvider: WritableTaskProvider` (adds `createList`/`renameList`/`deleteList`).
  Reminders lists are EventKit calendars with a mature native management UI already
  (Reminders.app, iCloud/Exchange account settings) — building in-app calendar CRUD would
  duplicate that and add real risk (shared calendars, cross-device sync, accidental delete) for a
  capability users already have elsewhere. `LocalProvider` conforms to `WritableListProvider`;
  `RemindersProvider` conforms to `WritableTaskProvider` only. Sidebar list-CRUD affordances
  ("New list" row, Rename/Delete) now gate on `WritableListProvider`; the star/"Set as Default"
  and "+" add-task affordances stay on the base `WritableTaskProvider` tier, so they apply
  uniformly to every writable provider including Reminders.
- **`RemindersProvider` write conformance**: `addTask`/`updateTask`/`deleteTask` against
  EventKit via an extended `RemindersEventStore` seam; priority collapses to the same 3 CalDAV
  bands the read side already maps from (so write-then-reread round-trips stably); `setDefaultList`
  validates against the pattern-filtered `lists()` so the default stays consistent with what the
  sidebar shows.
- **Fixed a pre-existing race** (not introduced by this PR, but exposed by testing it):
  `AddTaskView` dismissed its sheet before the provider write had actually completed, racing the
  dismiss-triggered list refresh against the write. In-process providers (`LocalProvider`) mostly
  won that race by luck; `RemindersProvider`'s EventKit-backed `tasks(in:)` could lose it and
  briefly omit a just-added task.
- Also merged in `origin/main`'s #548 (task selection / double-click activation) partway through,
  since it touches the same task-row/context-menu code this PR's manual testing exercised.

## Out of scope

- List creation/rename/delete for Reminders — deliberately dropped, see ADR-0011.
- `ObsidianProvider` write conformance (#328) — should re-evaluate against the same
  `WritableTaskProvider`/`WritableListProvider` split rather than assuming full list CRUD.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior
- [x] Documentation updated where appropriate

## Release / deploy impact

- [x] Safe to label `no-deploy`

## Reviewer notes

Follow-ups not included here, worth tracking separately:
- Comment on/edit #329's acceptance criteria to drop `createList`/`deleteList`, linking ADR-0011.
- Re-evaluate #328 against the new protocol split.
