### PR TITLE
feat(tasks): writable Obsidian provider with section-targeted writes

### DIFF
--- a/app/Taskmato/Services/SettingsStore.swift
+++ b/app/Taskmato/Services/SettingsStore.swift
@@ -207,6 +207,8 @@ extension SettingsStore {
 
     static let obsidianFilePatterns = SettingsKey("obsidian.filePatterns", default: ["**/*.md"])
     static let obsidianVaultBookmark = "obsidian.vaultBookmark"
+    static let obsidianDefaultListID = SettingsKey<String?>(
+      "obsidian.defaultListID", default: nil)
 
     // MARK: Reminders provider
 

--- a/app/Taskmato/Tasks/Local/LocalTask.swift
+++ b/app/Taskmato/Tasks/Local/LocalTask.swift
@@ -32,6 +32,9 @@ nonisolated struct LocalTask: Codable, Identifiable, Sendable {
   /// The date by which the task is due.
   var dueDate: Date?
 
+  /// Whether `dueDate` carries a meaningful time-of-day, or is date-only.
+  var dueDateIncludesTime: Bool = false
+
   /// The date the task is scheduled to be worked on.
   var scheduledDate: Date?
 
@@ -51,7 +54,7 @@ nonisolated struct LocalTask: Codable, Identifiable, Sendable {
   let createdAt: Date
 
   private nonisolated enum CodingKeys: String, CodingKey {
-    case id, title, notes, format, priority, dueDate, scheduledDate, startDate
+    case id, title, notes, format, priority, dueDate, dueDateIncludesTime, scheduledDate, startDate
     case listID, isCompleted, completedAt, createdAt
   }
 
@@ -71,6 +74,7 @@ nonisolated struct LocalTask: Codable, Identifiable, Sendable {
       format: format,
       priority: priority,
       dueDate: dueDate,
+      dueDateIncludesTime: dueDateIncludesTime,
       scheduledDate: scheduledDate,
       startDate: startDate,
       list: taskList,
@@ -85,6 +89,7 @@ nonisolated struct LocalTask: Codable, Identifiable, Sendable {
     notes = draft.notes.isEmpty ? nil : draft.notes
     priority = draft.priority
     dueDate = draft.dueDate
+    dueDateIncludesTime = draft.dueDateIncludesTime
     listID = draft.listID.flatMap(UUID.init)
   }
 }
@@ -103,6 +108,8 @@ extension LocalTask {
     format = try container.decodeIfPresent(ContentFormat.self, forKey: .format) ?? .markdown
     priority = try container.decode(TaskPriority.self, forKey: .priority)
     dueDate = try container.decodeIfPresent(Date.self, forKey: .dueDate)
+    dueDateIncludesTime =
+      try container.decodeIfPresent(Bool.self, forKey: .dueDateIncludesTime) ?? false
     scheduledDate = try container.decodeIfPresent(Date.self, forKey: .scheduledDate)
     startDate = try container.decodeIfPresent(Date.self, forKey: .startDate)
     listID = try container.decodeIfPresent(UUID.self, forKey: .listID)
@@ -119,6 +126,7 @@ extension LocalTask {
     format = draft.format
     priority = draft.priority
     dueDate = draft.dueDate
+    dueDateIncludesTime = draft.dueDateIncludesTime
     scheduledDate = nil
     startDate = nil
     listID = draft.listID.flatMap(UUID.init)

--- a/app/Taskmato/Tasks/Local/Storage/LocalTaskEntity.swift
+++ b/app/Taskmato/Tasks/Local/Storage/LocalTaskEntity.swift
@@ -33,6 +33,12 @@ final class LocalTaskEntity {
   /// The date by which the task is due.
   var dueDate: Date?
 
+  /// Whether `dueDate` carries a meaningful time-of-day, or is date-only.
+  ///
+  /// Defaults to `false` so lightweight SwiftData migration fills existing records that
+  /// predate this field.
+  var dueDateIncludesTime: Bool = false
+
   /// The date the task is scheduled to be worked on.
   var scheduledDate: Date?
 
@@ -54,8 +60,8 @@ final class LocalTaskEntity {
   /// Creates a persistence record from explicit field values.
   init(
     id: UUID, title: String, notes: String?, format: ContentFormat, priority: TaskPriority,
-    dueDate: Date?, scheduledDate: Date?, startDate: Date?, listID: UUID?, isCompleted: Bool,
-    completedAt: Date?, createdAt: Date
+    dueDate: Date?, dueDateIncludesTime: Bool = false, scheduledDate: Date?, startDate: Date?,
+    listID: UUID?, isCompleted: Bool, completedAt: Date?, createdAt: Date
   ) {
     self.id = id
     self.title = title
@@ -63,6 +69,7 @@ final class LocalTaskEntity {
     self.format = format
     self.priority = priority
     self.dueDate = dueDate
+    self.dueDateIncludesTime = dueDateIncludesTime
     self.scheduledDate = scheduledDate
     self.startDate = startDate
     self.listID = listID
@@ -78,7 +85,8 @@ extension LocalTaskEntity {
   convenience init(task: LocalTask) {
     self.init(
       id: task.id, title: task.title, notes: task.notes, format: task.format,
-      priority: task.priority, dueDate: task.dueDate, scheduledDate: task.scheduledDate,
+      priority: task.priority, dueDate: task.dueDate,
+      dueDateIncludesTime: task.dueDateIncludesTime, scheduledDate: task.scheduledDate,
       startDate: task.startDate, listID: task.listID, isCompleted: task.isCompleted,
       completedAt: task.completedAt, createdAt: task.createdAt)
   }
@@ -92,6 +100,7 @@ extension LocalTaskEntity {
     format = task.format
     priority = task.priority
     dueDate = task.dueDate
+    dueDateIncludesTime = task.dueDateIncludesTime
     scheduledDate = task.scheduledDate
     startDate = task.startDate
     listID = task.listID
@@ -107,7 +116,8 @@ extension LocalTask {
   nonisolated init(entity: LocalTaskEntity) {
     self.init(
       id: entity.id, title: entity.title, notes: entity.notes, format: entity.format,
-      priority: entity.priority, dueDate: entity.dueDate, scheduledDate: entity.scheduledDate,
+      priority: entity.priority, dueDate: entity.dueDate,
+      dueDateIncludesTime: entity.dueDateIncludesTime, scheduledDate: entity.scheduledDate,
       startDate: entity.startDate, listID: entity.listID, isCompleted: entity.isCompleted,
       completedAt: entity.completedAt, createdAt: entity.createdAt)
   }

--- a/app/Taskmato/Tasks/Models/TaskDraft.swift
+++ b/app/Taskmato/Tasks/Models/TaskDraft.swift
@@ -28,6 +28,13 @@ struct TaskDraft {
   /// Due date, or `nil` if no due date is set.
   var dueDate: Date?
 
+  /// Whether `dueDate` carries a meaningful time-of-day, or is date-only.
+  var dueDateIncludesTime: Bool = false
+
   /// The provider-local list ID this task should belong to, or `nil` for the default list.
   var listID: String?
+
+  /// An optional sub-grouping within the target list (e.g. a markdown heading in Obsidian).
+  /// `nil` targets the list's top level. Providers without sections ignore this field.
+  var section: String?
 }

--- a/app/Taskmato/Tasks/Models/TaskItem.swift
+++ b/app/Taskmato/Tasks/Models/TaskItem.swift
@@ -30,6 +30,9 @@ nonisolated struct TaskItem: Identifiable, Hashable, Codable, Sendable {
   /// The date by which the task is due.
   var dueDate: Date?
 
+  /// Whether `dueDate` carries a meaningful time-of-day, or is date-only.
+  var dueDateIncludesTime: Bool = false
+
   /// The date the task is scheduled to be worked on.
   var scheduledDate: Date?
 

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift
@@ -1,0 +1,274 @@
+//
+//  ObsidianProvider+Writable.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// ``TaskProvider/sections(in:)`` and ``WritableTaskProvider`` conformance for
+/// ``ObsidianProvider``: heading discovery, task creation, editing, and deletion against vault
+/// files, plus the section-boundary and line-range helpers that let a write target a specific
+/// markdown heading (see ``insertionIndex(forSection:in:list:)``).
+///
+/// Split into its own file — alongside ``ObsidianProvider``'s existing read/`ClosableTaskProvider`
+/// logic — purely to keep both files under the project's size lint limits; there is no
+/// architectural boundary between the two.
+extension ObsidianProvider {
+
+  // MARK: - TaskProvider
+
+  /// Returns every heading in `list`'s file, in document order, regardless of whether it
+  /// currently has any tasks under it — unlike deriving sections from ``tasks(in:)`` results,
+  /// this surfaces headings a user could target even if nothing has been filed under them yet.
+  func sections(in list: TaskList) async throws -> [String] {
+    guard let vaultURL else { return [] }
+    let fileURL = vaultURL.appending(path: list.id)
+    return try await Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { return [] }
+      return try self.withVaultAccess(vaultURL) { _ in
+        let content = (try? String(contentsOf: fileURL, encoding: .utf8)) ?? ""
+        var seen = Set<String>()
+        return content.components(separatedBy: "\n")
+          .compactMap { ObsidianTaskParser.subheading($0) }
+          .filter { seen.insert($0).inserted }
+      }
+    }.value
+  }
+
+  // MARK: - WritableTaskProvider
+
+  /// Persists `listID` (a vault-relative file path) as the default target for new tasks.
+  ///
+  /// Validated against `lists()` so the default stays consistent with what the sidebar shows.
+  func setDefaultList(_ listID: String) async throws {
+    guard try await lists().contains(where: { $0.id == listID }) else {
+      throw ObsidianProviderError.listNotFound(listID)
+    }
+    defaultListOverride = listID
+  }
+
+  /// Appends a new task line to the target file.
+  ///
+  /// When `draft.section` is given, the line is inserted as the last item in that heading's
+  /// existing task block (a continuation of that section's list), rather than at the end of the
+  /// file. Targets `draft.listID` if set, otherwise ``defaultListID``.
+  @discardableResult
+  func addTask(_ draft: TaskDraft) async throws -> TaskItem {
+    guard let vaultURL else {
+      throw ObsidianProviderError.vaultNotConfigured
+    }
+    guard let relPath = draft.listID ?? defaultListID else {
+      throw ObsidianProviderError.listNotFound("")
+    }
+    let fileURL = vaultURL.appending(path: relPath)
+    let (taskLine, noteLines) = Self.formatLines(for: draft)
+
+    let insertedLineNumber = try await Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { throw ObsidianProviderError.vaultNotConfigured }
+      return try self.withVaultAccess(vaultURL) { _ in
+        var lines = try String(contentsOf: fileURL, encoding: .utf8)
+          .components(separatedBy: "\n")
+        let insertionIndex = try Self.insertionIndex(
+          forSection: draft.section, in: lines, list: relPath
+        )
+        lines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
+        let updated = lines.joined(separator: "\n")
+        try Data(updated.utf8).write(to: fileURL, options: [])
+        return insertionIndex + 1
+      }
+    }.value
+
+    let taskList = TaskList(id: relPath, providerID: Self.providerID, name: "")
+    let nativeID = "\(relPath):\(insertedLineNumber)"
+    guard let item = try await tasks(in: taskList).first(where: { $0.id.nativeID == nativeID })
+    else {
+      throw ObsidianProviderError.taskNotFound(nativeID)
+    }
+    return item
+  }
+
+  /// Applies `draft` to the task identified by `ref`.
+  ///
+  /// If `draft.listID`/`draft.section` differ from the task's current file/section, the task is
+  /// moved: removed from its current location and inserted at the destination using the same
+  /// section-continuation rule as ``addTask(_:)``. Otherwise the line is rewritten in place.
+  func updateTask(_ ref: TaskRef, draft: TaskDraft) async throws {
+    guard let vaultURL else {
+      throw ObsidianProviderError.vaultNotConfigured
+    }
+    let (currentRelPath, lineNumber) = try Self.parseNativeID(ref.nativeID)
+    let targetRelPath = draft.listID ?? currentRelPath
+    let (taskLine, noteLines) = Self.formatLines(for: draft)
+
+    try await Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { return }
+      try self.withVaultAccess(vaultURL) { _ in
+        let sourceFileURL = vaultURL.appending(path: currentRelPath)
+        var sourceLines = try String(contentsOf: sourceFileURL, encoding: .utf8)
+          .components(separatedBy: "\n")
+        let (taskIndex, noteEndIndex) = try Self.lineRange(
+          atLine: lineNumber, in: sourceLines, ref: ref.nativeID
+        )
+        let currentSection = Self.section(ofLineAt: taskIndex, in: sourceLines)
+
+        if targetRelPath == currentRelPath, draft.section == currentSection {
+          sourceLines.replaceSubrange(taskIndex..<noteEndIndex, with: [taskLine] + noteLines)
+          try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
+          return
+        }
+
+        sourceLines.removeSubrange(taskIndex..<noteEndIndex)
+
+        if targetRelPath == currentRelPath {
+          let insertionIndex = try Self.insertionIndex(
+            forSection: draft.section, in: sourceLines, list: targetRelPath
+          )
+          sourceLines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
+          try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
+        } else {
+          try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
+
+          let destFileURL = vaultURL.appending(path: targetRelPath)
+          var destLines = try String(contentsOf: destFileURL, encoding: .utf8)
+            .components(separatedBy: "\n")
+          let insertionIndex = try Self.insertionIndex(
+            forSection: draft.section, in: destLines, list: targetRelPath
+          )
+          destLines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
+          try Data(destLines.joined(separator: "\n").utf8).write(to: destFileURL, options: [])
+        }
+      }
+    }.value
+  }
+
+  /// Removes the task identified by `ref`, including its trailing indented note lines.
+  func deleteTask(_ ref: TaskRef) async throws {
+    guard let vaultURL else {
+      throw ObsidianProviderError.vaultNotConfigured
+    }
+    let (relPath, lineNumber) = try Self.parseNativeID(ref.nativeID)
+    let fileURL = vaultURL.appending(path: relPath)
+
+    try await Task.detached(priority: .userInitiated) { [weak self] in
+      guard let self else { return }
+      try self.withVaultAccess(vaultURL) { _ in
+        var lines = try String(contentsOf: fileURL, encoding: .utf8)
+          .components(separatedBy: "\n")
+        let (taskIndex, noteEndIndex) = try Self.lineRange(
+          atLine: lineNumber, in: lines, ref: ref.nativeID
+        )
+        lines.removeSubrange(taskIndex..<noteEndIndex)
+        try Data(lines.joined(separator: "\n").utf8).write(to: fileURL, options: [])
+      }
+    }.value
+  }
+
+  /// Builds the task line and note lines for `draft` via ``ObsidianTaskLineFormatter``.
+  private nonisolated static func formatLines(for draft: TaskDraft) -> (
+    taskLine: String, noteLines: [String]
+  ) {
+    let formatter = ObsidianTaskLineFormatter()
+    let taskLine = formatter.formatLine(
+      title: draft.title,
+      priority: draft.priority,
+      dueDate: draft.dueDate
+    )
+    return (taskLine, formatter.formatNoteLines(draft.notes))
+  }
+
+  // MARK: - Write-side section/line-range helpers
+
+  /// Splits `nativeID` into its vault-relative path and 1-based line number.
+  private nonisolated static func parseNativeID(_ nativeID: String) throws -> (
+    relPath: String, lineNumber: Int
+  ) {
+    let parts = nativeID.split(separator: ":", maxSplits: 1)
+    guard parts.count == 2, let lineNumber = Int(parts[1]) else {
+      throw ObsidianProviderError.invalidNativeID(nativeID)
+    }
+    return (String(parts[0]), lineNumber)
+  }
+
+  /// Resolves the task line at `lineNumber` (1-based) in `lines`, verifying it's still a task
+  /// line, and returns its index plus the index just past its trailing indented note lines.
+  ///
+  /// Unlike `complete`/`reopen`'s checkbox-swap fallback, there's no reliable secondary key to
+  /// re-locate a moved line here (`TaskRef` carries no title), so a stale line number surfaces
+  /// as `.taskNotFound` rather than being silently relocated by a file-wide scan.
+  private nonisolated static func lineRange(
+    atLine lineNumber: Int,
+    in lines: [String],
+    ref nativeID: String
+  ) throws -> (taskIndex: Int, noteEndIndex: Int) {
+    let index = lineNumber - 1
+    guard index >= 0, index < lines.count,
+      ObsidianTaskParser.isIncompleteTask(lines[index])
+        || ObsidianTaskParser.isCompletedTask(
+          lines[index])
+    else {
+      throw ObsidianProviderError.taskNotFound(nativeID)
+    }
+    var noteEnd = index + 1
+    while noteEnd < lines.count, ObsidianTaskParser.isIndented(lines[noteEnd]) {
+      noteEnd += 1
+    }
+    return (index, noteEnd)
+  }
+
+  /// Returns the section (nearest preceding subheading) for the line at `index`, scanning
+  /// backward until a heading of any level or the start of the file.
+  private nonisolated static func section(ofLineAt index: Int, in lines: [String]) -> String? {
+    var lineIndex = index - 1
+    while lineIndex >= 0 {
+      if let heading = ObsidianTaskParser.subheading(lines[lineIndex]) { return heading }
+      if ObsidianTaskParser.h1(lines[lineIndex]) != nil { return nil }
+      lineIndex -= 1
+    }
+    return nil
+  }
+
+  /// Computes the insertion index for a new task line targeting `section` within `lines`.
+  ///
+  /// `nil` section inserts at the end of the file (before a single trailing blank line, if
+  /// present). A given section inserts after the last non-blank line in that heading's block (or
+  /// immediately after the heading if the block is empty), so the new task continues that
+  /// section's existing list rather than landing at end of file. The first heading whose text
+  /// matches `section` wins on duplicate headings, matching the parser's own read-side behavior.
+  private nonisolated static func insertionIndex(
+    forSection section: String?,
+    in lines: [String],
+    list: String
+  ) throws -> Int {
+    guard let section else {
+      return (lines.last?.isEmpty ?? false) ? max(lines.count - 1, 0) : lines.count
+    }
+
+    guard
+      let headingIndex = lines.firstIndex(where: { ObsidianTaskParser.subheading($0) == section })
+    else {
+      throw ObsidianProviderError.sectionNotFound(list: list, section: section)
+    }
+
+    var blockEnd = lines.count
+    for lineIndex in (headingIndex + 1)..<lines.count {
+      let line = lines[lineIndex]
+      let isHeading =
+        ObsidianTaskParser.h1(line) != nil || ObsidianTaskParser.subheading(line) != nil
+      if isHeading {
+        blockEnd = lineIndex
+        break
+      }
+    }
+
+    var lastContentIndex = headingIndex
+    var lineIndex = blockEnd - 1
+    while lineIndex > headingIndex {
+      if !lines[lineIndex].trimmingCharacters(in: .whitespaces).isEmpty {
+        lastContentIndex = lineIndex
+        break
+      }
+      lineIndex -= 1
+    }
+    return lastContentIndex + 1
+  }
+}

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider.swift
@@ -8,18 +8,21 @@ import CoreServices
 import Foundation
 import Observation
 
-/// A task provider that reads incomplete tasks from all matching markdown files in an Obsidian vault.
+/// A task provider that reads and writes tasks in all matching markdown files in an Obsidian vault.
 ///
 /// Vault directory access uses a security-scoped bookmark persisted in ``UserDefaults``.
-/// The provider is read-write: `complete(_:)` rewrites the task line from `- [ ]` to `- [x]`
-/// in place; `reopen(_:)` reverses the operation; `completedTasks()` scans the vault for
-/// `- [x]` lines and returns them sorted by their `✅` completion date.
+/// `complete(_:)` rewrites the task line from `- [ ]` to `- [x]` in place; `reopen(_:)` reverses
+/// the operation; `completedTasks()` scans the vault for `- [x]` lines and returns them sorted by
+/// their `✅` completion date. The provider conforms to ``WritableTaskProvider`` so tasks can also
+/// be created, edited, and deleted — but not ``WritableListProvider``: vault files already have a
+/// mature native lifecycle (Obsidian.app, Finder, sync tools), so file create/rename/delete stays
+/// out of scope. See ADR-0011.
 ///
 /// - Note: `observe()` watches the vault recursively using `FSEventStreamCreate`. Rapid
 ///   change notifications are coalesced by a 250 ms debounce before a rescan is triggered.
 @Observable
 @MainActor
-final class ObsidianProvider: ClosableTaskProvider {
+final class ObsidianProvider: WritableTaskProvider {
 
   /// Stable provider identifier used in ``TaskRef`` values.
   nonisolated static let providerID: ProviderID = "obsidian"
@@ -30,12 +33,29 @@ final class ObsidianProvider: ClosableTaskProvider {
   let tint: ProviderTint = .purple
   let entitlement: ProviderEntitlement = .free
 
+  /// The `ContentFormat` new and edited tasks use — Obsidian task lines are markdown.
+  let contentFormat: ContentFormat = .markdown
+
+  /// Obsidian's `📅 YYYY-MM-DD` task-line format has no time-of-day convention — writes are
+  /// always date-only, matching the obsidian-tasks plugin other tools in a vault expect.
+  let supportsDueTime: Bool = false
+
   /// The user-selected vault directory, resolved from the stored security-scoped bookmark.
   private(set) var vaultURL: URL?
 
   /// Glob patterns (relative to vault root) used to select which markdown files are scanned.
   /// Supported date tokens are documented on ``expandTokens(_:now:)``.
   private(set) var filePatterns: [String]
+
+  /// User-selected default file (vault-relative path), or `nil` if none has been chosen.
+  ///
+  /// Unlike Reminders, Obsidian has no system-level default to fall back to.
+  var defaultListOverride: String? {
+    didSet { store[SettingsStore.Keys.obsidianDefaultListID] = defaultListOverride }
+  }
+
+  /// The vault-relative path of the file new tasks target by default, or `nil` if none is set.
+  var defaultListID: String? { defaultListOverride }
 
   /// Human-readable vault name derived from the last path component of `vaultURL`.
   var vaultName: String { vaultURL?.lastPathComponent ?? "" }
@@ -54,6 +74,7 @@ final class ObsidianProvider: ClosableTaskProvider {
   init(store: SettingsStore = SettingsStore()) {
     self.store = store
     self.filePatterns = store[SettingsStore.Keys.obsidianFilePatterns]
+    self.defaultListOverride = store[SettingsStore.Keys.obsidianDefaultListID]
     restoreVaultBookmark()
   }
 
@@ -61,11 +82,13 @@ final class ObsidianProvider: ClosableTaskProvider {
   init(
     store: SettingsStore,
     vaultURL: URL?,
-    filePatterns: [String] = ObsidianProvider.defaultPatterns
+    filePatterns: [String] = ObsidianProvider.defaultPatterns,
+    defaultListID: String? = nil
   ) {
     self.store = store
     self.filePatterns = filePatterns
     self.vaultURL = vaultURL
+    self.defaultListOverride = defaultListID
   }
 
   // MARK: - TaskProvider
@@ -244,7 +267,7 @@ final class ObsidianProvider: ClosableTaskProvider {
   }
 
   /// Wraps `perform` with security-scoped resource access for `url`.
-  private nonisolated func withVaultAccess<T>(_ url: URL, perform: (URL) throws -> T) throws -> T {
+  nonisolated func withVaultAccess<T>(_ url: URL, perform: (URL) throws -> T) throws -> T {
     let didStart = url.startAccessingSecurityScopedResource()
     defer { if didStart { url.stopAccessingSecurityScopedResource() } }
     return try perform(url)
@@ -498,6 +521,10 @@ enum ObsidianProviderError: LocalizedError {
   case invalidNativeID(String)
   /// No matching task line was found in the vault file.
   case taskNotFound(String)
+  /// No file matches the given vault-relative list ID.
+  case listNotFound(String)
+  /// No heading matching the given section text was found in the target file.
+  case sectionNotFound(list: String, section: String)
 
   var errorDescription: String? {
     switch self {
@@ -507,6 +534,10 @@ enum ObsidianProviderError: LocalizedError {
       return "Invalid task reference: \"\(id)\"."
     case .taskNotFound(let id):
       return "Could not locate task \"\(id)\" in the vault."
+    case .listNotFound(let id):
+      return "Could not locate list \"\(id)\" in the vault."
+    case .sectionNotFound(let list, let section):
+      return "Could not locate section \"\(section)\" in \"\(list)\"."
     }
   }
 }

--- a/app/Taskmato/Tasks/Obsidian/ObsidianTaskLineFormatter.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianTaskLineFormatter.swift
@@ -1,0 +1,71 @@
+//
+//  ObsidianTaskLineFormatter.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// Serializes task fields into an obsidian-tasks-plugin formatted markdown line.
+///
+/// The inverse of ``ObsidianTaskParser``'s field extraction — produces lines the parser can
+/// read back unchanged. All formatting is pure (no file I/O), making this testable without a
+/// filesystem.
+nonisolated struct ObsidianTaskLineFormatter: Sendable {
+
+  /// Builds a single `- [ ] Title 🔺 🛫 yyyy-MM-dd ⏰ yyyy-MM-dd 📅 yyyy-MM-dd` task line.
+  ///
+  /// - Parameters:
+  ///   - title: The task title, written verbatim (trimmed).
+  ///   - checkbox: The checkbox character (`" "` for incomplete, `"x"` for complete).
+  ///   - priority: Appended as the matching priority emoji, omitted for `.none`.
+  ///   - startDate: Appended as `🛫 yyyy-MM-dd`, when present.
+  ///   - scheduledDate: Appended as `⏰ yyyy-MM-dd`, when present.
+  ///   - dueDate: Appended as `📅 yyyy-MM-dd`, when present.
+  /// - Returns: The formatted task line, with no trailing newline.
+  func formatLine(
+    title: String,
+    checkbox: String = " ",
+    priority: TaskPriority = .none,
+    startDate: Date? = nil,
+    scheduledDate: Date? = nil,
+    dueDate: Date? = nil
+  ) -> String {
+    var line = "- [\(checkbox)] \(title.trimmingCharacters(in: .whitespaces))"
+
+    if let emoji = Self.priorityEmoji(for: priority) {
+      line += " \(emoji)"
+    }
+    if let startDate {
+      line += " 🛫 \(Self.dateString(startDate))"
+    }
+    if let scheduledDate {
+      line += " ⏰ \(Self.dateString(scheduledDate))"
+    }
+    if let dueDate {
+      line += " 📅 \(Self.dateString(dueDate))"
+    }
+    return line
+  }
+
+  /// Formats `notes` as 4-space-indented continuation lines following a task line, matching how
+  /// ``ObsidianTaskParser`` reads indented lines back as a task's `notes`.
+  ///
+  /// Returns an empty array when `notes` is blank.
+  func formatNoteLines(_ notes: String) -> [String] {
+    let trimmed = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return [] }
+    return trimmed.components(separatedBy: "\n").map { "    " + $0 }
+  }
+
+  /// Returns the priority emoji for `priority`, or `nil` for `.none`.
+  private static func priorityEmoji(for priority: TaskPriority) -> String? {
+    ObsidianTaskParser.priorityEmojis.first { $0.1 == priority }?.0
+  }
+
+  /// Formats `date` as `yyyy-MM-dd`, matching ``ObsidianTaskParser``'s date-extraction format.
+  private static func dateString(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withFullDate]
+    return formatter.string(from: date)
+  }
+}

--- a/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
@@ -54,8 +54,8 @@ nonisolated struct ObsidianTaskParser: Sendable {
     )
     let (raw, listName) = collectEntries(
       from: content,
-      isTarget: isIncompleteTask,
-      shouldSkip: isCompletedTask
+      isTarget: Self.isIncompleteTask,
+      shouldSkip: Self.isCompletedTask
     )
     let items = raw.map { entry in
       buildTaskItem(
@@ -85,8 +85,8 @@ nonisolated struct ObsidianTaskParser: Sendable {
     )
     let (raw, listName) = collectEntries(
       from: content,
-      isTarget: isCompletedTask,
-      shouldSkip: isIncompleteTask
+      isTarget: Self.isCompletedTask,
+      shouldSkip: Self.isIncompleteTask
     )
     let entries = raw.map { entry in
       buildCompletedEntry(
@@ -144,10 +144,10 @@ nonisolated struct ObsidianTaskParser: Sendable {
 
     for (zeroIndex, line) in lines.enumerated() {
       let lineNumber = zeroIndex + 1
-      if let heading = h1(line) {
+      if let heading = Self.h1(line) {
         finalize()
         if listName == nil { listName = heading }
-      } else if let heading = subheading(line) {
+      } else if let heading = Self.subheading(line) {
         finalize()
         currentSection = heading
       } else if isTarget(line) {
@@ -157,7 +157,7 @@ nonisolated struct ObsidianTaskParser: Sendable {
         pendingSection = currentSection
       } else if shouldSkip(line) {
         finalize()
-      } else if pendingLine != nil, isIndented(line) {
+      } else if pendingLine != nil, Self.isIndented(line) {
         notesBuffer.append(stripIndent(line))
       } else if !line.trimmingCharacters(in: .whitespaces).isEmpty {
         finalize()
@@ -170,12 +170,19 @@ nonisolated struct ObsidianTaskParser: Sendable {
 
   // MARK: - Line classification
 
-  private func h1(_ line: String) -> String? {
+  /// Returns the heading text of `line` if it is an H1 (`# `) markdown heading, or `nil`.
+  ///
+  /// Shared with ``ObsidianProvider``'s write-side section-block boundary detection.
+  static func h1(_ line: String) -> String? {
     guard line.hasPrefix("# ") else { return nil }
     return String(line.dropFirst(2)).trimmingCharacters(in: .whitespaces)
   }
 
-  private func subheading(_ line: String) -> String? {
+  /// Returns the heading text of `line` if it is a `##`–`######` markdown subheading, or `nil`.
+  ///
+  /// Shared with ``ObsidianProvider``'s write-side section matching so both read and write use
+  /// the exact same heading-classification rule.
+  static func subheading(_ line: String) -> String? {
     guard
       line.hasPrefix("## ") || line.hasPrefix("### ") || line.hasPrefix("#### ")
         || line.hasPrefix("##### ") || line.hasPrefix("###### ")
@@ -186,18 +193,23 @@ nonisolated struct ObsidianTaskParser: Sendable {
     return nil
   }
 
-  private func isIncompleteTask(_ line: String) -> Bool {
+  /// Returns `true` if `line` is an incomplete task list item (`- [ ] ` or `N. [ ] `).
+  ///
+  /// Shared with ``ObsidianProvider``'s write-side task-line lookup so both read and write agree
+  /// on what counts as a task line.
+  static func isIncompleteTask(_ line: String) -> Bool {
     line.hasPrefix("- [ ] ") || matchesOrderedItem(line, bracket: "[ ]")
   }
 
-  private func isCompletedTask(_ line: String) -> Bool {
+  /// Returns `true` if `line` is a completed task list item (`- [x] `/`- [X] ` or `N. [x/X] `).
+  static func isCompletedTask(_ line: String) -> Bool {
     line.hasPrefix("- [x] ") || line.hasPrefix("- [X] ")
       || matchesOrderedItem(line, bracket: "[x]")
       || matchesOrderedItem(line, bracket: "[X]")
   }
 
   /// Returns `true` when `line` is an ordered list item (`1. <bracket> `) with the given bracket content.
-  private func matchesOrderedItem(_ line: String, bracket: String) -> Bool {
+  private static func matchesOrderedItem(_ line: String, bracket: String) -> Bool {
     var idx = line.startIndex
     while idx < line.endIndex, line[idx].isNumber {
       idx = line.index(after: idx)
@@ -222,7 +234,11 @@ nonisolated struct ObsidianTaskParser: Sendable {
     return line
   }
 
-  private func isIndented(_ line: String) -> Bool {
+  /// Returns `true` if `line` is indented (a task's note/continuation line).
+  ///
+  /// Shared with ``ObsidianProvider``'s write-side note-block detection so both read and write
+  /// agree on what counts as a task's trailing notes.
+  static func isIndented(_ line: String) -> Bool {
     line.hasPrefix("    ") || line.hasPrefix("\t")
   }
 
@@ -315,7 +331,9 @@ nonisolated struct ObsidianTaskParser: Sendable {
 
   // MARK: - Field extraction
 
-  nonisolated private static let priorityEmojis: [(String, TaskPriority)] = [
+  /// Priority emoji, in match-priority order. Shared with ``ObsidianTaskLineFormatter`` so read
+  /// and write use the exact same emoji↔priority mapping.
+  nonisolated static let priorityEmojis: [(String, TaskPriority)] = [
     ("🔺", .highest),
     ("⏫", .high),
     ("🔼", .medium),

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -276,8 +276,12 @@ final class RemindersProvider: WritableTaskProvider {
     reminder.notes = draft.notes.isEmpty ? nil : draft.notes
     reminder.calendar = calendar
     reminder.priority = mapPriority(draft.priority)
-    reminder.dueDateComponents = draft.dueDate.map {
-      Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: $0)
+    reminder.dueDateComponents = draft.dueDate.map { date in
+      let components: Set<Calendar.Component> =
+        draft.dueDateIncludesTime
+        ? [.year, .month, .day, .hour, .minute]
+        : [.year, .month, .day]
+      return Calendar.current.dateComponents(components, from: date)
     }
   }
 
@@ -297,6 +301,7 @@ final class RemindersProvider: WritableTaskProvider {
       dueDate: reminder.dueDateComponents.flatMap {
         Calendar.current.date(from: $0)
       },
+      dueDateIncludesTime: reminder.dueDateComponents?.hour != nil,
       scheduledDate: nil,
       startDate: reminder.startDateComponents.flatMap {
         Calendar.current.date(from: $0)

--- a/app/Taskmato/Tasks/TaskProvider.swift
+++ b/app/Taskmato/Tasks/TaskProvider.swift
@@ -53,6 +53,15 @@ protocol TaskProvider: AnyObject, Sendable {
   /// - Parameter list: The list to scope results to, or `nil` for all lists.
   func tasks(in list: TaskList?) async throws -> [TaskItem]
 
+  /// Returns all sections (e.g. markdown headings) available within `list`, in document order,
+  /// whether or not they currently contain any tasks.
+  ///
+  /// Sections are an organizational concept independent of writability — a read-only provider
+  /// could group tasks by section too. Providers that don't group tasks into sections return an
+  /// empty array; only ``ObsidianProvider`` currently overrides this.
+  /// - Parameter list: The list to scan for sections.
+  func sections(in list: TaskList) async throws -> [String]
+
   /// Returns a stream that emits an updated task array whenever the provider's data changes.
   ///
   /// Return `nil` if the provider does not support live updates.
@@ -63,6 +72,7 @@ extension TaskProvider {
   var isAuthorized: Bool { true }
   var displayOrder: Int { Int.max }
   var tint: ProviderTint { .gray }
+  func sections(in list: TaskList) async throws -> [String] { [] }
 }
 
 /// A `TaskProvider` that supports toggling task completion state in the source system.
@@ -87,6 +97,10 @@ extension ClosableTaskProvider {
   func completedTasks() async throws -> [TaskItem] { [] }
 }
 
+extension WritableTaskProvider {
+  var supportsDueTime: Bool { true }
+}
+
 /// A `ClosableTaskProvider` that also supports creating and updating tasks, and choosing a
 /// default target list from among the provider's existing lists.
 ///
@@ -99,6 +113,13 @@ protocol WritableTaskProvider: ClosableTaskProvider {
 
   /// The `ContentFormat` this provider creates new tasks with.
   var contentFormat: ContentFormat { get }
+
+  /// Whether this provider persists `TaskDraft.dueDateIncludesTime`/`TaskItem.dueDateIncludesTime`.
+  ///
+  /// `true` by default. Providers whose native format has no time-of-day convention (e.g.
+  /// Obsidian's `📅 YYYY-MM-DD`, which always writes date-only) override this to `false` so the
+  /// Add Task dialog doesn't offer a "due time" affordance that would silently be dropped.
+  var supportsDueTime: Bool { get }
 
   /// Creates a new task from `draft` and returns the resulting item.
   ///

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -15,8 +15,16 @@ struct AdHocTaskParams {
   let priority: TaskPriority
   /// Parsed due date, or `nil` if no `due` param was supplied.
   let dueDate: Date?
+  /// Whether `dueDate` carries a meaningful time-of-day (the `due` param included one), or is
+  /// date-only.
+  let dueDateIncludesTime: Bool
   /// Raw list name from the URL, or `nil` if the param was absent.
   let listName: String?
+  /// Raw section (sub-grouping within the list) from the URL, or `nil` if the param was absent.
+  ///
+  /// Passed straight through to ``TaskDraft/section`` — unlike `listName`, no name-to-ID
+  /// resolution is needed since a section is already a plain string.
+  let section: String?
   /// Raw provider ID from the URL, or `nil` if the param was absent.
   ///
   /// When set and the named provider is an enabled ``WritableTaskProvider``, ad-hoc task
@@ -146,6 +154,8 @@ final class URLSchemeHandler {
     draft.title = adHocParams.title
     draft.priority = adHocParams.priority
     draft.dueDate = adHocParams.dueDate
+    draft.dueDateIncludesTime = adHocParams.dueDateIncludesTime
+    draft.section = adHocParams.section
     if let name = adHocParams.listName {
       let lists: [TaskList]
       if let cached = registry.providerLists[writable.id] {
@@ -245,11 +255,14 @@ final class URLSchemeHandler {
   }
 
   private func buildAdHocParams(from params: [String: String], title: String) -> AdHocTaskParams {
-    AdHocTaskParams(
+    let due = params["due"].flatMap(parseDueDate(_:))
+    return AdHocTaskParams(
       title: title,
       priority: params["priority"].flatMap(TaskPriority.init(urlParam:)) ?? .none,
-      dueDate: params["due"].flatMap(parseDate(_:)),
+      dueDate: due?.date,
+      dueDateIncludesTime: due?.includesTime ?? false,
       listName: params["list"],
+      section: params["section"],
       providerID: params["provider"]
     )
   }
@@ -266,10 +279,40 @@ final class URLSchemeHandler {
     }
   }
 
-  private func parseDate(_ string: String) -> Date? {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withFullDate, .withDashSeparatorInDate]
-    return formatter.date(from: string)
+  /// Parses a `due` param of the form `YYYY-MM-DD` or `YYYY-MM-DD HH:MM` (the space arrives
+  /// decoded from a `+` or `%20` in the URL query), returning the date plus whether a time was
+  /// given. Built via `Calendar.current` rather than `ISO8601DateFormatter`, which parses
+  /// date-only strings as UTC midnight — that lands on the *previous* local day west of UTC
+  /// (e.g. `"2026-08-10"` became 2026-08-09 in a US timezone). Matches ``AddTaskView``'s
+  /// date-only path, which builds the date the same way for the same reason.
+  private func parseDueDate(_ string: String) -> (date: Date, includesTime: Bool)? {
+    let parts = string.trimmingCharacters(in: .whitespaces).split(separator: " ", maxSplits: 1)
+    guard var components = parts.first.flatMap(Self.dateComponents(_:)) else { return nil }
+    guard parts.count == 2 else {
+      return Calendar.current.date(from: components).map { ($0, false) }
+    }
+    guard let (hour, minute) = Self.timeComponents(String(parts[1])) else { return nil }
+    components.hour = hour
+    components.minute = minute
+    return Calendar.current.date(from: components).map { ($0, true) }
+  }
+
+  /// Parses a `YYYY-MM-DD` substring into year/month/day `DateComponents`.
+  private nonisolated static func dateComponents(_ substring: Substring) -> DateComponents? {
+    let parts = substring.split(separator: "-").compactMap { Int($0) }
+    guard parts.count == 3 else { return nil }
+    var components = DateComponents()
+    components.year = parts[0]
+    components.month = parts[1]
+    components.day = parts[2]
+    return components
+  }
+
+  /// Parses an `HH:MM` string into hour/minute.
+  private nonisolated static func timeComponents(_ string: String) -> (hour: Int, minute: Int)? {
+    let parts = string.split(separator: ":").compactMap { Int($0) }
+    guard parts.count == 2 else { return nil }
+    return (parts[0], parts[1])
   }
 }
 

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -95,7 +95,7 @@ struct SettingsView: View {
 
       Section("Tasks") {
         Picker("Default writable provider", selection: $settings.defaultWritableProviderID) {
-          Text("Automatic").tag(ProviderID?.none)
+          Label("Automatic", systemImage: "wand.and.stars").tag(ProviderID?.none)
           ForEach(writableProviderEntries) { entry in
             Label(entry.displayName, systemImage: entry.icon).tag(ProviderID?.some(entry.id))
           }

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -26,7 +26,10 @@ struct AddTaskView: View {
   @State private var notes = ""
   @State private var priority: TaskPriority = .none
   @State private var selectedListID: String = ""
+  @State private var sections: [String] = []
+  @State private var selectedSection: String?
   @State private var hasDueDate = false
+  @State private var hasDueTime = false
   @State private var dueDate = Date()
   @State private var showNotes = false
   @State private var taskLists: [TaskList] = []
@@ -42,6 +45,10 @@ struct AddTaskView: View {
   }
 
   private var isMarkdownCapable: Bool { provider.contentFormat == .markdown }
+
+  /// Width reserved for row labels ("List", "Priority", "Due date", …) so the due-date row —
+  /// kept outside the `Grid` above — still lines up with the Grid's own label column.
+  private static let labelColumnWidth: CGFloat = 60
 
   var body: some View {
     VStack(alignment: .leading, spacing: .sectionGap) {
@@ -73,6 +80,21 @@ struct AddTaskView: View {
           .frame(maxWidth: .infinity, alignment: .leading)
         }
 
+        if !sections.isEmpty {
+          GridRow {
+            Text("Section")
+              .foregroundStyle(.secondary)
+            Picker("Section", selection: $selectedSection) {
+              ForEach(sections, id: \.self) { section in
+                Text(section).tag(String?.some(section))
+              }
+            }
+            .labelsHidden()
+            .accessibilityLabel("Section")
+            .frame(maxWidth: .infinity, alignment: .leading)
+          }
+        }
+
         GridRow {
           Text("Priority")
             .foregroundStyle(.secondary)
@@ -90,20 +112,20 @@ struct AddTaskView: View {
           .pickerStyle(.menu)
           .frame(maxWidth: .infinity, alignment: .leading)
         }
+      }
 
-        GridRow {
-          Text("Due date")
-            .foregroundStyle(.secondary)
-          HStack {
-            Toggle("Has due date", isOn: $hasDueDate)
-              .labelsHidden()
-              .accessibilityLabel("Has due date")
-              .accessibilityHint("Enables the due date picker")
-            if hasDueDate {
-              DatePicker("Due date", selection: $dueDate, displayedComponents: .date)
-                .labelsHidden()
-                .accessibilityLabel("Due date")
-            }
+      // Kept out of the Grid above: the date/time chip row's width varies as chips are
+      // added and removed, and Grid shares column widths across all its rows — inside the
+      // Grid, that variation was dragging the List/Priority pickers wider too whenever a
+      // chip appeared, visibly shifting the whole form.
+      HStack(spacing: 12) {
+        Text("Due date")
+          .foregroundStyle(.secondary)
+          .frame(width: Self.labelColumnWidth, alignment: .leading)
+        HStack(spacing: 8) {
+          dateChip
+          if hasDueDate, provider.supportsDueTime {
+            timeChip
           }
         }
       }
@@ -125,7 +147,10 @@ struct AddTaskView: View {
       }
     }
     .padding()
-    .frame(width: 360)
+    // Wide enough to fit both due-date chips at once (label + date chip + time chip) without
+    // ever needing to grow — a fixed width that had to expand when the time chip appeared was
+    // what made the form visibly shift.
+    .frame(width: 420)
     .onAppear {
       isTitleFocused = true
       if let task = taskToEdit {
@@ -133,6 +158,7 @@ struct AddTaskView: View {
         notes = task.notes ?? ""
         priority = task.priority
         hasDueDate = task.dueDate != nil
+        hasDueTime = task.dueDateIncludesTime
         if let due = task.dueDate { dueDate = due }
         showNotes = !(task.notes ?? "").isEmpty
         selectedListID = task.list?.id ?? ""
@@ -146,6 +172,111 @@ struct AddTaskView: View {
         selectedListID = provider.defaultListID ?? first.id
       }
     }
+    .task(id: selectedListID) {
+      guard !selectedListID.isEmpty else {
+        sections = []
+        selectedSection = nil
+        return
+      }
+      let list = TaskList(id: selectedListID, providerID: provider.id, name: "")
+      sections = (try? await provider.sections(in: list)) ?? []
+      // No "None" option: once a file has at least one heading, a task inserted anywhere below
+      // it reads back as belonging to that heading anyway (Obsidian has no way to mark a task as
+      // deliberately section-less past that point), so the picker only offers real targets.
+      let editingSection = (taskToEdit?.list?.id == selectedListID ? taskToEdit?.section : nil)
+      if let editingSection, sections.contains(editingSection) {
+        selectedSection = editingSection
+      } else {
+        selectedSection = sections.first
+      }
+    }
+  }
+
+  // MARK: - Due date / time chips
+
+  /// A capsule showing the selected due date with a clear button, or an "Add Date" button when
+  /// no due date is set — mirroring Reminders.app's date-chip affordance.
+  @ViewBuilder
+  private var dateChip: some View {
+    if hasDueDate {
+      HStack(spacing: 4) {
+        Image(systemName: "calendar")
+        DatePicker("Due date", selection: $dueDate, displayedComponents: .date)
+          .labelsHidden()
+          .datePickerStyle(.compact)
+          .fixedSize()
+        Button {
+          hasDueDate = false
+          hasDueTime = false
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove due date")
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 4)
+      .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+    } else {
+      Button {
+        hasDueDate = true
+        dueDate = Date()
+      } label: {
+        Label("Add Date", systemImage: "calendar")
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+    }
+  }
+
+  /// A capsule showing the selected due time with a clear button, or an "Add Time" button when
+  /// no due time is set. Adding a time seeds it from the current wall-clock time rather than
+  /// whatever time-of-day `dueDate` already happens to carry (e.g. midnight from a date-only
+  /// value), so the picker opens on a meaningful default.
+  @ViewBuilder
+  private var timeChip: some View {
+    if hasDueTime {
+      HStack(spacing: 4) {
+        Image(systemName: "clock")
+        DatePicker("Due time", selection: $dueDate, displayedComponents: .hourAndMinute)
+          .labelsHidden()
+          .datePickerStyle(.compact)
+          .fixedSize()
+        Button {
+          hasDueTime = false
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove due time")
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 4)
+      .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+    } else {
+      Button {
+        hasDueTime = true
+        dueDate = Self.mergingCurrentTime(into: dueDate)
+      } label: {
+        Label("Add Time", systemImage: "clock")
+      }
+      .buttonStyle(.bordered)
+      .controlSize(.small)
+    }
+  }
+
+  /// Returns `date` with its hour/minute replaced by the current wall-clock time.
+  private static func mergingCurrentTime(into date: Date) -> Date {
+    let calendar = Calendar.current
+    let nowComponents = calendar.dateComponents([.hour, .minute], from: Date())
+    return calendar.date(
+      bySettingHour: nowComponents.hour ?? 0,
+      minute: nowComponents.minute ?? 0,
+      second: 0,
+      of: date
+    ) ?? date
   }
 
   // MARK: - Private
@@ -155,8 +286,15 @@ struct AddTaskView: View {
     draft.title = title.trimmingCharacters(in: .whitespaces)
     draft.notes = notes
     draft.priority = priority
-    draft.dueDate = hasDueDate ? dueDate : nil
+    if hasDueDate {
+      draft.dueDate = hasDueTime ? dueDate : Calendar.current.startOfDay(for: dueDate)
+      draft.dueDateIncludesTime = hasDueTime
+    } else {
+      draft.dueDate = nil
+      draft.dueDateIncludesTime = false
+    }
     draft.listID = selectedListID.isEmpty ? nil : selectedListID
+    draft.section = selectedSection
     draft.format = provider.contentFormat
     // Dismiss only after the write completes — dismissing first (as this used to) races the
     // sheet's `isAddingTask`-driven refresh against the provider write: for an in-process

--- a/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskCardView.swift
@@ -81,9 +81,14 @@ struct TaskCardView: View {
   @ViewBuilder
   private var metadata: some View {
     if let due = presenter.dueDate {
-      Text(due, format: .dateTime.month(.abbreviated).day().year())
-        .font(.taskMetadata)
-        .foregroundStyle(presenter.dueIsUrgent ? Color.dueUrgent : Color.secondary)
+      Text(
+        due,
+        format: presenter.dueDateIncludesTime
+          ? .dateTime.month(.abbreviated).day().year().hour().minute()
+          : .dateTime.month(.abbreviated).day().year()
+      )
+      .font(.taskMetadata)
+      .foregroundStyle(presenter.dueIsUrgent ? Color.dueUrgent : Color.secondary)
     } else if presenter.isCompleted {
       Text(presenter.completedSubtitle)
         .font(.taskMetadata)

--- a/app/Taskmato/Views/Tasks/Components/TaskItemPresenter.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskItemPresenter.swift
@@ -74,6 +74,9 @@ struct TaskItemPresenter {
   /// completed subtitle instead.
   var dueDate: Date? { isCompleted ? nil : task.dueDate }
 
+  /// Whether ``dueDate`` carries a meaningful time-of-day, or is date-only.
+  var dueDateIncludesTime: Bool { isCompleted ? false : task.dueDateIncludesTime }
+
   /// `true` when the due date is today or already past.
   var dueIsUrgent: Bool { task.dueDate?.isUrgentDueDate ?? false }
 

--- a/app/Taskmato/Views/Tasks/Components/TaskRowView.swift
+++ b/app/Taskmato/Views/Tasks/Components/TaskRowView.swift
@@ -59,9 +59,14 @@ struct TaskRowView: View {
   @ViewBuilder
   private var metadata: some View {
     if let due = presenter.dueDate {
-      Text(due, format: .dateTime.month(.abbreviated).day())
-        .font(.taskMetadata)
-        .foregroundStyle(presenter.dueIsUrgent ? Color.dueUrgent : Color.secondary)
+      Text(
+        due,
+        format: presenter.dueDateIncludesTime
+          ? .dateTime.month(.abbreviated).day().hour().minute()
+          : .dateTime.month(.abbreviated).day()
+      )
+      .font(.taskMetadata)
+      .foregroundStyle(presenter.dueIsUrgent ? Color.dueUrgent : Color.secondary)
     } else if presenter.isCompleted {
       Text(presenter.completedSubtitle)
         .font(.taskMetadata)

--- a/app/TaskmatoTests/LocalProviderTests.swift
+++ b/app/TaskmatoTests/LocalProviderTests.swift
@@ -186,6 +186,27 @@ struct LocalProviderTests {
     #expect(createdAt <= after)
   }
 
+  @Test func addTaskPreservesDueDateIncludesTimeFlag() async throws {
+    let provider = await makeProvider()
+    var draft = TaskDraft()
+    draft.title = "Meeting"
+    draft.dueDate = Date()
+    draft.dueDateIncludesTime = true
+    try await provider.addTask(draft)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks.first?.dueDateIncludesTime == true)
+  }
+
+  @Test func addTaskDefaultsDueDateIncludesTimeToFalse() async throws {
+    let provider = await makeProvider()
+    var draft = TaskDraft()
+    draft.title = "All day"
+    draft.dueDate = Date()
+    try await provider.addTask(draft)
+    let tasks = try await provider.tasks(in: nil)
+    #expect(tasks.first?.dueDateIncludesTime == false)
+  }
+
   @Test func addTaskUsesDefaultListWhenNoDraftListID() async throws {
     let provider = await makeProvider()
     let defaultID = provider.defaultListID!

--- a/app/TaskmatoTests/ObsidianProviderWritableTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderWritableTests.swift
@@ -1,0 +1,336 @@
+//
+//  ObsidianProviderWritableTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+// MARK: - Helpers
+
+@MainActor
+private func makeVault() throws -> URL {
+  let dir = FileManager.default.temporaryDirectory
+    .appendingPathComponent(UUID().uuidString)
+  try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+  return dir
+}
+
+@MainActor
+private func write(_ content: String, at relativePath: String, in vault: URL) throws {
+  let dest = vault.appending(path: relativePath)
+  let parent = dest.deletingLastPathComponent()
+  try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+  try Data(content.utf8).write(to: dest, options: [])
+}
+
+@MainActor
+private func read(_ relativePath: String, in vault: URL) throws -> String {
+  try String(contentsOf: vault.appending(path: relativePath), encoding: .utf8)
+}
+
+@MainActor
+private func makeProvider(vaultURL: URL?, defaultListID: String? = nil) -> ObsidianProvider {
+  ObsidianProvider(
+    store: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!),
+    vaultURL: vaultURL,
+    defaultListID: defaultListID
+  )
+}
+
+// MARK: - Writable tests
+
+@Suite("ObsidianProvider — writable")
+@MainActor
+struct ObsidianProviderWritableTests {
+
+  // MARK: contentFormat
+
+  @Test func contentFormatIsMarkdown() {
+    let provider = makeProvider(vaultURL: nil)
+    #expect(provider.contentFormat == .markdown)
+  }
+
+  // MARK: defaultListID
+
+  @Test func defaultListIDNilWhenUnset() {
+    let provider = makeProvider(vaultURL: nil)
+    #expect(provider.defaultListID == nil)
+  }
+
+  @Test func defaultListIDReflectsOverrideAfterSetDefaultList() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Task", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    try await provider.setDefaultList("tasks.md")
+    #expect(provider.defaultListID == "tasks.md")
+  }
+
+  @Test func setDefaultListThrowsForUnknownFile() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    let provider = makeProvider(vaultURL: vault)
+    await #expect(throws: ObsidianProviderError.self) {
+      try await provider.setDefaultList("nonexistent.md")
+    }
+  }
+
+  // MARK: addTask
+
+  @Test func addTaskTargetsDraftListIDWhenSet() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Existing", at: "work.md", in: vault)
+    try write("- [ ] Existing", at: "personal.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.listID = "personal.md"
+    let item = try await provider.addTask(draft)
+    #expect(item.list?.id == "personal.md")
+    let content = try read("personal.md", in: vault)
+    #expect(content.contains("- [ ] Buy milk"))
+  }
+
+  @Test func addTaskFallsBackToDefaultListID() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Existing", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    let item = try await provider.addTask(draft)
+    #expect(item.list?.id == "tasks.md")
+  }
+
+  @Test func addTaskThrowsWhenNoListResolves() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    let provider = makeProvider(vaultURL: vault)
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    await #expect(throws: ObsidianProviderError.self) {
+      try await provider.addTask(draft)
+    }
+  }
+
+  @Test func addTaskMapsTitlePriorityAndDueDate() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Existing", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.priority = .high
+    draft.dueDate = Calendar.current.date(from: DateComponents(year: 2026, month: 6, day: 15))
+    let item = try await provider.addTask(draft)
+    #expect(item.title == "Buy milk")
+    #expect(item.priority == .high)
+    var cal = Calendar(identifier: .gregorian)
+    cal.timeZone = TimeZone(identifier: "UTC")!
+    let comps = cal.dateComponents([.year, .month, .day], from: item.dueDate!)
+    #expect(comps.year == 2026)
+    #expect(comps.month == 6)
+    #expect(comps.day == 15)
+  }
+
+  @Test func addTaskWithNotesWritesIndentedContinuationLines() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Existing", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.notes = "2%\nOne gallon"
+    let item = try await provider.addTask(draft)
+    #expect(item.notes == "2%\nOne gallon")
+    let content = try read("tasks.md", in: vault)
+    #expect(content.contains("- [ ] Buy milk\n    2%\n    One gallon"))
+  }
+
+  @Test func addTaskWithNilSectionAppendsAtEndOfFile() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write(
+      """
+      ## Section A
+      - [ ] First
+
+      ## Section B
+      - [ ] Second
+      """, at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "Top level"
+    _ = try await provider.addTask(draft)
+    let content = try read("tasks.md", in: vault)
+    #expect(content.hasSuffix("- [ ] Top level"))
+  }
+
+  @Test func addTaskToExistingSectionAppendsAfterLastLineInBlock() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write(
+      """
+      ## Section A
+      - [ ] First
+      - [ ] Second
+
+      ## Section B
+      - [ ] Third
+      """, at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "New task"
+    draft.section = "Section A"
+    let item = try await provider.addTask(draft)
+    #expect(item.section == "Section A")
+    let content = try read("tasks.md", in: vault)
+    let expected = """
+      ## Section A
+      - [ ] First
+      - [ ] Second
+      - [ ] New task
+
+      ## Section B
+      - [ ] Third
+      """
+    #expect(content == expected)
+  }
+
+  @Test func addTaskToSectionAtEndOfFileInsertsAfterHeading() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("## Empty Section", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "First in section"
+    draft.section = "Empty Section"
+    _ = try await provider.addTask(draft)
+    let content = try read("tasks.md", in: vault)
+    #expect(content == "## Empty Section\n- [ ] First in section")
+  }
+
+  @Test func addTaskThrowsSectionNotFoundForUnknownHeading() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Existing", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "New task"
+    draft.section = "Nonexistent"
+    await #expect(throws: ObsidianProviderError.self) {
+      try await provider.addTask(draft)
+    }
+  }
+
+  // MARK: updateTask
+
+  @Test func updateTaskInPlaceRewritesLineWithoutMoving() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Original", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:1")
+    var draft = TaskDraft()
+    draft.title = "Updated"
+    try await provider.updateTask(ref, draft: draft)
+    let content = try read("tasks.md", in: vault)
+    #expect(content == "- [ ] Updated")
+  }
+
+  @Test func updateTaskMovesToADifferentSectionInSameFile() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write(
+      """
+      ## Section A
+      - [ ] Move me
+
+      ## Section B
+      - [ ] Existing
+      """, at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:2")
+    var draft = TaskDraft()
+    draft.title = "Move me"
+    draft.section = "Section B"
+    try await provider.updateTask(ref, draft: draft)
+    let content = try read("tasks.md", in: vault)
+    let expected = """
+      ## Section A
+
+      ## Section B
+      - [ ] Existing
+      - [ ] Move me
+      """
+    #expect(content == expected)
+  }
+
+  @Test func updateTaskMovesToADifferentFile() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Move me", at: "source.md", in: vault)
+    try write("- [ ] Existing", at: "dest.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "source.md:1")
+    var draft = TaskDraft()
+    draft.title = "Move me"
+    draft.listID = "dest.md"
+    try await provider.updateTask(ref, draft: draft)
+    #expect(try read("source.md", in: vault).isEmpty)
+    #expect(try read("dest.md", in: vault) == "- [ ] Existing\n- [ ] Move me")
+  }
+
+  @Test func updateTaskThrowsForStaleRef() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Original", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:5")
+    var draft = TaskDraft()
+    draft.title = "Updated"
+    await #expect(throws: ObsidianProviderError.self) {
+      try await provider.updateTask(ref, draft: draft)
+    }
+  }
+
+  // MARK: deleteTask
+
+  @Test func deleteTaskRemovesLine() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] First\n- [ ] Second", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:1")
+    try await provider.deleteTask(ref)
+    let content = try read("tasks.md", in: vault)
+    #expect(content == "- [ ] Second")
+  }
+
+  @Test func deleteTaskRemovesIndentedNoteLinesToo() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write(
+      "- [ ] First\n    Note line\n- [ ] Second", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:1")
+    try await provider.deleteTask(ref)
+    let content = try read("tasks.md", in: vault)
+    #expect(content == "- [ ] Second")
+  }
+
+  @Test func deleteTaskThrowsForUnknownRef() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Task", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:99")
+    await #expect(throws: ObsidianProviderError.self) {
+      try await provider.deleteTask(ref)
+    }
+  }
+}

--- a/app/TaskmatoTests/ObsidianTaskLineFormatterTests.swift
+++ b/app/TaskmatoTests/ObsidianTaskLineFormatterTests.swift
@@ -1,0 +1,146 @@
+//
+//  ObsidianTaskLineFormatterTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+@Suite("ObsidianTaskLineFormatter")
+struct ObsidianTaskLineFormatterTests {
+
+  private let formatter = ObsidianTaskLineFormatter()
+  private let parser = ObsidianTaskParser()
+  private let dummyList = TaskList(id: "tasks.md", providerID: "obsidian", name: "tasks")
+
+  private func date(_ string: String) -> Date {
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withFullDate]
+    return iso.date(from: string)!
+  }
+
+  private func roundTrip(_ line: String) -> TaskItem {
+    let items = parser.parse(
+      content: line,
+      providerID: "obsidian",
+      fileRelativePath: "tasks.md",
+      vaultName: "MyVault",
+      list: dummyList
+    ).items
+    return items[0]
+  }
+
+  // MARK: - Title only
+
+  @Test func formatsTitleOnly() {
+    let line = formatter.formatLine(title: "Write unit tests")
+    #expect(line == "- [ ] Write unit tests")
+  }
+
+  @Test func formatsCompletedCheckbox() {
+    let line = formatter.formatLine(title: "Done", checkbox: "x")
+    #expect(line == "- [x] Done")
+  }
+
+  @Test func trimsTitleWhitespace() {
+    let line = formatter.formatLine(title: "  Padded  ")
+    #expect(line == "- [ ] Padded")
+  }
+
+  // MARK: - Priority
+
+  @Test(
+    arguments: [
+      (TaskPriority.highest, "🔺"),
+      (TaskPriority.high, "⏫"),
+      (TaskPriority.medium, "🔼"),
+      (TaskPriority.low, "🔽"),
+      (TaskPriority.lowest, "⏬"),
+    ]
+  )
+  func formatsEachPriorityEmoji(priority: TaskPriority, emoji: String) {
+    let line = formatter.formatLine(title: "Task", priority: priority)
+    #expect(line == "- [ ] Task \(emoji)")
+  }
+
+  @Test func omitsEmojiForNonePriority() {
+    let line = formatter.formatLine(title: "Task", priority: .none)
+    #expect(line == "- [ ] Task")
+  }
+
+  // MARK: - Dates
+
+  @Test func formatsDueDate() {
+    let line = formatter.formatLine(title: "Task", dueDate: date("2026-08-08"))
+    #expect(line == "- [ ] Task 📅 2026-08-08")
+  }
+
+  @Test func formatsScheduledDate() {
+    let line = formatter.formatLine(title: "Task", scheduledDate: date("2026-08-08"))
+    #expect(line == "- [ ] Task ⏰ 2026-08-08")
+  }
+
+  @Test func formatsStartDate() {
+    let line = formatter.formatLine(title: "Task", startDate: date("2026-08-08"))
+    #expect(line == "- [ ] Task 🛫 2026-08-08")
+  }
+
+  @Test func formatsAllFieldsInOrder() {
+    let line = formatter.formatLine(
+      title: "Task",
+      priority: .high,
+      startDate: date("2026-08-01"),
+      scheduledDate: date("2026-08-05"),
+      dueDate: date("2026-08-08")
+    )
+    #expect(line == "- [ ] Task ⏫ 🛫 2026-08-01 ⏰ 2026-08-05 📅 2026-08-08")
+  }
+
+  // MARK: - Round-trip through the parser
+
+  @Test func roundTripsTitlePriorityAndDueDate() {
+    let line = formatter.formatLine(
+      title: "Ship it", priority: .medium, dueDate: date("2026-08-08"))
+    let item = roundTrip(line)
+    #expect(item.title == "Ship it")
+    #expect(item.priority == .medium)
+    #expect(item.dueDate == date("2026-08-08"))
+  }
+
+  @Test func roundTripsAllDateFields() {
+    let line = formatter.formatLine(
+      title: "Ship it",
+      startDate: date("2026-08-01"),
+      scheduledDate: date("2026-08-05"),
+      dueDate: date("2026-08-08")
+    )
+    let item = roundTrip(line)
+    #expect(item.startDate == date("2026-08-01"))
+    #expect(item.scheduledDate == date("2026-08-05"))
+    #expect(item.dueDate == date("2026-08-08"))
+  }
+
+  // MARK: - Note lines
+
+  @Test func formatsNoteLinesWithFourSpaceIndent() {
+    let lines = formatter.formatNoteLines("First note\nSecond note")
+    #expect(lines == ["    First note", "    Second note"])
+  }
+
+  @Test func formatsSingleLineNote() {
+    let lines = formatter.formatNoteLines("Just one line")
+    #expect(lines == ["    Just one line"])
+  }
+
+  @Test func returnsEmptyArrayForBlankNotes() {
+    #expect(formatter.formatNoteLines("").isEmpty)
+    #expect(formatter.formatNoteLines("   \n  ").isEmpty)
+  }
+
+  @Test func trimsSurroundingWhitespaceFromNotes() {
+    let lines = formatter.formatNoteLines("\n  Note text  \n")
+    #expect(lines == ["    Note text"])
+  }
+}

--- a/app/TaskmatoTests/RemindersProviderWritableTests.swift
+++ b/app/TaskmatoTests/RemindersProviderWritableTests.swift
@@ -123,6 +123,42 @@ struct RemindersProviderWritableTests {
     #expect(comps.day == 15)
   }
 
+  @Test func addTaskWithDateOnlyDueDateOmitsHourAndMinute() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    store.stubbedCalendars = [work]
+    store.stubbedDefaultCalendar = work
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.dueDate = Calendar.current.date(
+      from: DateComponents(year: 2026, month: 6, day: 15, hour: 9, minute: 30))
+    draft.dueDateIncludesTime = false
+    let item = try await provider.addTask(draft)
+    #expect(store.savedReminders.first?.dueDateComponents?.hour == nil)
+    #expect(store.savedReminders.first?.dueDateComponents?.minute == nil)
+    #expect(item.dueDateIncludesTime == false)
+  }
+
+  @Test func addTaskWithDateAndTimeDueDateIncludesHourAndMinute() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    store.stubbedCalendars = [work]
+    store.stubbedDefaultCalendar = work
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    draft.dueDate = Calendar.current.date(
+      from: DateComponents(year: 2026, month: 6, day: 15, hour: 9, minute: 30))
+    draft.dueDateIncludesTime = true
+    let item = try await provider.addTask(draft)
+    #expect(store.savedReminders.first?.dueDateComponents?.hour == 9)
+    #expect(store.savedReminders.first?.dueDateComponents?.minute == 30)
+    #expect(item.dueDateIncludesTime == true)
+    let comps = Calendar.current.dateComponents(
+      [.year, .month, .day, .hour, .minute], from: item.dueDate!)
+    #expect(comps.hour == 9)
+    #expect(comps.minute == 30)
+  }
+
   @Test(
     arguments: [
       (TaskPriority.none, 0),

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -69,10 +69,11 @@ private final class StubWritableProvider: WritableTaskProvider {
       format: .plainText,
       priority: draft.priority,
       dueDate: draft.dueDate,
+      dueDateIncludesTime: draft.dueDateIncludesTime,
       scheduledDate: nil,
       startDate: nil,
       list: nil,
-      section: nil,
+      section: draft.section,
       sourceURL: nil
     )
   }
@@ -207,10 +208,61 @@ struct URLSchemeHandlerTests {
     #expect(ctx.selectionStore.activeTask?.priority == .high)
   }
 
-  @Test func adHocTaskWithDueDate() async {
+  @Test func adHocTaskWithDueDate() async throws {
     let ctx = makeHandler()
     await ctx.handler.handle(URL(string: "taskmato://start?title=Due+Task&due=2026-12-01")!)
-    #expect(ctx.selectionStore.activeTask?.dueDate != nil)
+    let dueDate = try #require(ctx.selectionStore.activeTask?.dueDate)
+    let comps = Calendar.current.dateComponents([.year, .month, .day], from: dueDate)
+    // Regression: --due must parse as local midnight, not UTC midnight — ISO8601DateFormatter's
+    // UTC parsing landed on the previous local day west of UTC.
+    #expect(comps.year == 2026)
+    #expect(comps.month == 12)
+    #expect(comps.day == 1)
+    #expect(ctx.selectionStore.activeTask?.dueDateIncludesTime == false)
+  }
+
+  @Test func adHocTaskWithDueTimeSetsDueDateIncludesTime() async throws {
+    let ctx = makeHandler()
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Due+Task+With+Time&due=2026-12-01+14:30")!)
+    let dueDate = try #require(ctx.selectionStore.activeTask?.dueDate)
+    let comps = Calendar.current.dateComponents(
+      [.year, .month, .day, .hour, .minute], from: dueDate)
+    #expect(comps.year == 2026)
+    #expect(comps.month == 12)
+    #expect(comps.day == 1)
+    #expect(comps.hour == 14)
+    #expect(comps.minute == 30)
+    #expect(ctx.selectionStore.activeTask?.dueDateIncludesTime == true)
+  }
+
+  @Test func adHocTaskWithMalformedDueTimeYieldsNoDueDate() async {
+    let ctx = makeHandler()
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Bad+Due+Time&due=2026-12-01+not-a-time")!)
+    #expect(ctx.selectionStore.activeTask?.dueDate == nil)
+  }
+
+  @Test func adHocTaskWithSectionPassesSectionThroughToDraft() async throws {
+    let ctx = makeHandler(enableLocalProvider: true)
+    // LocalProvider has no sections concept, so verify via a stub provider that echoes
+    // draft.section back onto the created TaskItem.
+    let stub = StubWritableProvider(id: "sectioned")
+    ctx.registry.register(stub)
+    ctx.registry.enable(stub)
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Sectioned&provider=sectioned&section=Backlog")!)
+    #expect(ctx.selectionStore.activeTask?.section == "Backlog")
+  }
+
+  @Test func adHocTaskWithoutSectionLeavesDraftSectionNil() async throws {
+    let ctx = makeHandler(enableLocalProvider: true)
+    let stub = StubWritableProvider(id: "sectioned")
+    ctx.registry.register(stub)
+    ctx.registry.enable(stub)
+    await ctx.handler.handle(
+      URL(string: "taskmato://start?title=Unsectioned&provider=sectioned")!)
+    #expect(ctx.selectionStore.activeTask?.section == nil)
   }
 
   // MARK: - Ad-hoc: URL param provider override

--- a/docs/architecture/decisions/0011-list-management-protocol-split.md
+++ b/docs/architecture/decisions/0011-list-management-protocol-split.md
@@ -24,6 +24,15 @@ would mean either building that risky surface anyway, or stub-throwing from the 
 exactly what ADR-0001 says the layered hierarchy exists to avoid ("no stub throws... UI
 affordances gated at the type level").
 
+Conforming `ObsidianProvider` to write support ([#328](https://github.com/richwklein/taskmato/issues/328))
+raises the same question. Obsidian "lists" are markdown files (file-as-list, not folder-as-list —
+`TaskList.id` is a vault-relative file path), and a vault file's lifecycle is already owned by a
+mature native surface: Obsidian.app itself, Finder, and third-party sync tools (iCloud Drive,
+Syncthing, git). Building in-app file create/rename/delete from inside a Pomodoro timer app would
+duplicate that surface and add real risk — deleting a note deletes everything in it, not just its
+tasks — for a capability users already have elsewhere. The same reasoning that kept
+`RemindersProvider` off `WritableListProvider` applies directly.
+
 ## Decision
 
 Split `WritableTaskProvider` into two tiers:
@@ -35,20 +44,20 @@ Split `WritableTaskProvider` into two tiers:
   `renameList`, `deleteList`.
 
 `LocalProvider` conforms to `WritableListProvider` (Taskmato is the sole owner of its list
-structure). `RemindersProvider` conforms to `WritableTaskProvider` only — it gets task CRUD and
-default-list selection among the calendars Reminders already exposes, with no in-app list
-creation, rename, or delete.
+structure). `RemindersProvider` and `ObsidianProvider` conform to `WritableTaskProvider` only —
+each gets task CRUD and default-list selection among the lists it already exposes (EventKit
+calendars for Reminders, vault files for Obsidian), with no in-app list creation, rename, or
+delete. For Obsidian, `addTask`/`updateTask` additionally support targeting a specific section
+(a markdown heading within a file) via `TaskDraft.section`/`TaskItem.section` — inserting or
+moving a task within an *existing* heading's task block is task-level content editing, not list
+lifecycle, so it stays in scope for the base tier the same way Reminders' due-date and priority
+edits do.
 
 UI affordances that create, rename, or delete lists (the sidebar's "New list" row, and the
 Rename/Delete context-menu items) gate on `is WritableListProvider`. Affordances scoped to task
 creation and default-list selection (the "+" add-task button, the sidebar star) continue to
 gate on the base `WritableTaskProvider` tier, so they apply uniformly to every writable
-provider, including Reminders.
-
-`ObsidianProvider`'s future write conformance ([#328](https://github.com/richwklein/taskmato/issues/328))
-should re-evaluate against this same question — whether Taskmato should own vault folder
-lifecycle, or whether that too belongs to a tier below `WritableListProvider` — rather than
-assuming full list CRUD by default.
+provider, including Reminders and Obsidian.
 
 ## Consequences
 
@@ -60,8 +69,8 @@ assuming full list CRUD by default.
   provider.
 - Call sites that only need task creation (`ProviderRegistry`'s writable-provider resolution,
   the Settings "Default writable provider" picker, the URL scheme handler, task detail actions)
-  stay on `WritableTaskProvider` and pick up Reminders automatically once it conforms — no UI
-  change required for those surfaces.
+  stay on `WritableTaskProvider` and pick up Reminders and Obsidian automatically once each
+  conforms — no UI change required for those surfaces.
 - Adding a future provider tier below `WritableListProvider` (e.g., a provider that can rename
   but not create/delete lists) would mean a further protocol split; the pattern established here
   extends to that case without disrupting existing conformers.

--- a/scripts/taskmato.sh
+++ b/scripts/taskmato.sh
@@ -5,7 +5,7 @@
 # Usage:
 #   taskmato <title>
 #   taskmato --title <title> [--priority none|lowest|low|medium|high|highest]
-#             [--due YYYY-MM-DD] [--list <name>] [--provider <id>]
+#             [--due "YYYY-MM-DD[ HH:MM]"] [--list <name>] [--section <name>] [--provider <id>]
 #   taskmato --provider <id> --id <native-id>
 #   taskmato --provider <id> --title <title>
 #
@@ -60,8 +60,12 @@ Options:
                           for ad-hoc creation when no matching task is found
   --id <native-id>        Look up task by its native provider ID (requires --provider)
   --priority <level>      Priority: none, lowest, low, medium, high, highest
-  --due <YYYY-MM-DD>      Due date for ad-hoc task creation
+  --due <date[ time]>     Due date for ad-hoc task creation: "YYYY-MM-DD" for date only, or
+                          "YYYY-MM-DD HH:MM" (24-hour, quoted) to also set a due time. Ignored
+                          by providers without a time convention (e.g. Obsidian).
   --list <name>           List name for ad-hoc task creation
+  --section <name>        Section (heading) within the list for ad-hoc task creation
+                          (Obsidian only; ignored by providers without sections)
   -h, --help              Show this help
 EOF
 }
@@ -72,6 +76,7 @@ TITLE=""
 PRIORITY=""
 DUE=""
 LIST=""
+SECTION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -81,6 +86,7 @@ while [[ $# -gt 0 ]]; do
     --priority) PRIORITY="$2"; shift 2 ;;
     --due)      DUE="$2"; shift 2 ;;
     --list)     LIST="$2"; shift 2 ;;
+    --section)  SECTION="$2"; shift 2 ;;
     -h|--help)  usage; exit 0 ;;
     -*)
       echo "Unknown option: $1" >&2
@@ -107,6 +113,7 @@ QUERY=""
 [[ -n "$PRIORITY"  ]] && add_param "priority" "$PRIORITY"
 [[ -n "$DUE"       ]] && add_param "due"      "$DUE"
 [[ -n "$LIST"      ]] && add_param "list"     "$LIST"
+[[ -n "$SECTION"   ]] && add_param "section"  "$SECTION"
 
 if [[ -z "$QUERY" ]]; then
   echo "Error: at least --title or --provider + --id is required." >&2


### PR DESCRIPTION
## Summary

`ObsidianProvider` now conforms to `WritableTaskProvider`: tasks can be created, edited, and deleted directly against vault files, with writes able to target a specific section (markdown heading) as a continuation of that section's existing task list — not just appended at end of file. Along the way this also fixed a due-date/due-time bug (Reminders writes were silently stamping the current wall-clock time onto every due date), a Settings picker display bug, and a due-date UTC-parsing bug in the `taskmato://` URL scheme / CLI wrapper.

## Linked issue

Closes #328

## Approach

- **Section-targeted writes**: `TaskDraft.section`/`TaskItem.section` carry an optional sub-heading. `ObsidianTaskLineFormatter` is a new pure serializer (mirrors `ObsidianTaskParser`'s testable-without-filesystem style). `ObsidianProvider+Writable.swift` holds the section-boundary insertion algorithm — a new task lands as the last item in its target heading's existing block, or at end of file when no section is given.
- **Date vs. date+time**: added `dueDateIncludesTime` to `TaskDraft`/`TaskItem` (and threaded through `LocalTask`/`LocalTaskEntity`/`RemindersProvider`) so a date-only due date no longer gets a phantom due *time* in Reminders. `WritableTaskProvider` gained a `supportsDueTime` capability flag (default `true`; `false` for Obsidian, whose `📅 YYYY-MM-DD` format has no time convention) so the Add Task dialog only offers a time affordance where it'll actually be honored.
- **Add Task dialog**: Reminders.app-style date/time chips replace the old checkbox+DatePicker; a section picker (sourced from a new `TaskProvider.sections(in:)` base-protocol member, default empty) offers only sections that already exist in the target file — no "None" option, since a task inserted anywhere below an existing heading reads back as belonging to it regardless of UI intent.
- **Protocol scope**: `ObsidianProvider` conforms to `WritableTaskProvider` only, not `WritableListProvider` — vault file lifecycle stays owned by Obsidian.app/Finder/sync tools, mirroring the precedent that kept `RemindersProvider` off list lifecycle. ADR-0011 amended in place to record this rather than a new ADR.
- **Settings bug fix**: "Default writable provider" now correctly shows "Automatic" instead of a blank row when unset (a `Text`/`Label` view-type mismatch in the `Picker`'s tags).
- **CLI/URL scheme**: `--section` pass-through for ad-hoc task creation; `--due` now accepts an optional `HH:MM` time; fixed a UTC-vs-local off-by-one where a date-only `--due` landed on the previous local day in timezones west of UTC.

## Out of scope

- Creating a brand-new section from the Add Task dialog (tracked separately in #555) — this PR only lets you target sections that already exist in the file.
- Matching an existing file's ordered-list style (`1. [ ]`) when inserting new tasks — new lines are always unordered for now (tracked in #556).
- The double-click-to-activate-task regression noticed during manual testing (#554) — investigated and confirmed unrelated to this branch (zero diff on the files that implement it).

## Validation

- [x] Lint passes locally (`make lint`)
- [x] Unit tests pass locally (`make test` / targeted `-only-testing:` runs throughout)
- [x] Added or updated tests covering the new behavior
- [x] Manually verified the new behavior (Add Task section targeting, due-date/time chips, `scripts/taskmato.sh` end-to-end against a running build)
- [x] Documentation updated where appropriate (ADR-0011 amended)

## Release / deploy impact

- [x] Safe to label `no-deploy`

## Reviewer notes

Related follow-up issues filed during this work: #554 (double-click regression, unrelated to this branch), #555 (writable section creation), #556 (match existing ordered/unordered list style on insert).