### PR TITLE
[Bug]: New Obsidian tasks always use unordered list style, even in ordered-list files

### DIFF
--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift
@@ -15,6 +15,31 @@ import Foundation
 /// architectural boundary between the two.
 extension ObsidianProvider {
 
+  /// The style to use for a newly written task line.
+  private enum TaskLineStyle {
+    case unordered
+    case ordered(Int)
+
+    nonisolated var orderedNumber: Int? {
+      switch self {
+      case .unordered:
+        return nil
+      case .ordered(let number):
+        return number
+      }
+    }
+  }
+
+  /// The captured state needed to apply an update or move to a task.
+  private struct UpdateTaskContext {
+    let draft: TaskDraft
+    let ref: String
+    let identity: ObsidianTaskIdentity.Components
+    let currentRelPath: String
+    let targetRelPath: String
+    let vaultURL: URL
+  }
+
   // MARK: - TaskProvider
 
   /// Returns every heading in `list`'s file, in document order, regardless of whether it
@@ -61,20 +86,25 @@ extension ObsidianProvider {
       throw ObsidianProviderError.listNotFound("")
     }
     let fileURL = vaultURL.appending(path: relPath)
-    let (taskLine, noteLines) = Self.formatLines(for: draft)
 
-    let insertedLineNumber = try await Task.detached(priority: .userInitiated) { [weak self] in
+    let (insertedLineNumber, taskLine) = try await Task.detached(
+      priority: .userInitiated
+    ) { [weak self] in
       guard let self else { throw ObsidianProviderError.vaultNotConfigured }
       return try self.withVaultAccess(vaultURL) { _ in
         var lines = try String(contentsOf: fileURL, encoding: .utf8)
           .components(separatedBy: "\n")
+        let wasEmptyFile = lines == [""]
         let insertionIndex = try Self.insertionIndex(
           forSection: draft.section, in: lines, list: relPath
         )
+        let style = Self.style(forInsertionAt: insertionIndex, in: lines, section: draft.section)
+        let (taskLine, noteLines) = Self.formatLines(for: draft, orderedNumber: style.orderedNumber)
         lines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
+        if wasEmptyFile { lines.removeLast() }
         let updated = lines.joined(separator: "\n")
         try Data(updated.utf8).write(to: fileURL, options: [])
-        return insertionIndex + 1
+        return (insertionIndex + 1, taskLine)
       }
     }.value
 
@@ -108,45 +138,20 @@ extension ObsidianProvider {
     }
     let currentRelPath = identity.fileRelativePath
     let targetRelPath = draft.listID ?? currentRelPath
-    let (taskLine, noteLines) = Self.formatLines(for: draft)
 
     try await Task.detached(priority: .userInitiated) { [weak self] in
       guard let self else { return }
       try self.withVaultAccess(vaultURL) { _ in
-        let sourceFileURL = vaultURL.appending(path: currentRelPath)
-        var sourceLines = try String(contentsOf: sourceFileURL, encoding: .utf8)
-          .components(separatedBy: "\n")
-        let (taskIndex, noteEndIndex) = try Self.lineRange(
-          for: identity, in: sourceLines, ref: ref.nativeID
+        try Self.writeUpdatedTask(
+          context: UpdateTaskContext(
+            draft: draft,
+            ref: ref.nativeID,
+            identity: identity,
+            currentRelPath: currentRelPath,
+            targetRelPath: targetRelPath,
+            vaultURL: vaultURL
+          )
         )
-        let currentSection = Self.section(ofLineAt: taskIndex, in: sourceLines)
-
-        if targetRelPath == currentRelPath, draft.section == currentSection {
-          sourceLines.replaceSubrange(taskIndex..<noteEndIndex, with: [taskLine] + noteLines)
-          try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
-          return
-        }
-
-        sourceLines.removeSubrange(taskIndex..<noteEndIndex)
-
-        if targetRelPath == currentRelPath {
-          let insertionIndex = try Self.insertionIndex(
-            forSection: draft.section, in: sourceLines, list: targetRelPath
-          )
-          sourceLines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
-          try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
-        } else {
-          try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
-
-          let destFileURL = vaultURL.appending(path: targetRelPath)
-          var destLines = try String(contentsOf: destFileURL, encoding: .utf8)
-            .components(separatedBy: "\n")
-          let insertionIndex = try Self.insertionIndex(
-            forSection: draft.section, in: destLines, list: targetRelPath
-          )
-          destLines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
-          try Data(destLines.joined(separator: "\n").utf8).write(to: destFileURL, options: [])
-        }
       }
     }.value
   }
@@ -179,13 +184,129 @@ extension ObsidianProvider {
   private nonisolated static func formatLines(for draft: TaskDraft) -> (
     taskLine: String, noteLines: [String]
   ) {
+    formatLines(for: draft, orderedNumber: nil)
+  }
+
+  /// Builds the task line and note lines for `draft` via ``ObsidianTaskLineFormatter``.
+  private nonisolated static func formatLines(
+    for draft: TaskDraft,
+    orderedNumber: Int?
+  ) -> (taskLine: String, noteLines: [String]) {
     let formatter = ObsidianTaskLineFormatter()
     let taskLine = formatter.formatLine(
       title: draft.title,
+      orderedNumber: orderedNumber,
       priority: draft.priority,
       dueDate: draft.dueDate
     )
     return (taskLine, formatter.formatNoteLines(draft.notes))
+  }
+
+  /// Returns the style for a new task inserted at `insertionIndex`.
+  ///
+  /// New tasks use the nearest preceding recognized task within the destination section, or the
+  /// nearest preceding recognized task anywhere in the file when `section` is `nil`.
+  private nonisolated static func style(
+    forInsertionAt insertionIndex: Int,
+    in lines: [String],
+    section: String?
+  ) -> TaskLineStyle {
+    var lineIndex = insertionIndex - 1
+    while lineIndex >= 0 {
+      let line = lines[lineIndex]
+      if ObsidianTaskParser.isIncompleteTask(line) || ObsidianTaskParser.isCompletedTask(line) {
+        return style(forInsertedTaskLine: line)
+      }
+      if section != nil {
+        if ObsidianTaskParser.h1(line) != nil || ObsidianTaskParser.subheading(line) != nil {
+          break
+        }
+      }
+      lineIndex -= 1
+    }
+    return .unordered
+  }
+
+  /// Returns the style for rewriting `line` in place.
+  ///
+  /// In-place edits preserve the exact list style and number already present on the line.
+  private nonisolated static func style(forTaskLine line: String) -> TaskLineStyle {
+    guard ObsidianTaskParser.isOrderedTask(line) else { return .unordered }
+    guard let orderedNumber = ObsidianTaskParser.orderedTaskNumber(line) else {
+      return .ordered(1)
+    }
+    return .ordered(orderedNumber)
+  }
+
+  /// Returns the style for a new line following `line`, advancing ordered numbering when needed.
+  private nonisolated static func style(forInsertedTaskLine line: String) -> TaskLineStyle {
+    guard ObsidianTaskParser.isOrderedTask(line) else { return .unordered }
+    guard let orderedNumber = ObsidianTaskParser.orderedTaskNumber(line) else {
+      return .ordered(1)
+    }
+    return .ordered(orderedNumber == Int.max ? 1 : orderedNumber + 1)
+  }
+
+  /// Applies an update or move to the task identified by `ref`.
+  private nonisolated static func writeUpdatedTask(context: UpdateTaskContext) throws {
+    let sourceFileURL = context.vaultURL.appending(path: context.currentRelPath)
+    var sourceLines = try String(contentsOf: sourceFileURL, encoding: .utf8)
+      .components(separatedBy: "\n")
+    let (taskIndex, noteEndIndex) = try Self.lineRange(
+      for: context.identity, in: sourceLines, ref: context.ref
+    )
+    let currentSection = Self.section(ofLineAt: taskIndex, in: sourceLines)
+
+    if context.targetRelPath == context.currentRelPath, context.draft.section == currentSection {
+      let style = Self.style(forTaskLine: sourceLines[taskIndex])
+      let (taskLine, noteLines) = Self.formatLines(
+        for: context.draft,
+        orderedNumber: style.orderedNumber
+      )
+      sourceLines.replaceSubrange(taskIndex..<noteEndIndex, with: [taskLine] + noteLines)
+      try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
+      return
+    }
+
+    sourceLines.removeSubrange(taskIndex..<noteEndIndex)
+
+    if context.targetRelPath == context.currentRelPath {
+      let insertionIndex = try Self.insertionIndex(
+        forSection: context.draft.section, in: sourceLines, list: context.targetRelPath
+      )
+      let style = Self.style(
+        forInsertionAt: insertionIndex,
+        in: sourceLines,
+        section: context.draft.section
+      )
+      let (taskLine, noteLines) = Self.formatLines(
+        for: context.draft,
+        orderedNumber: style.orderedNumber
+      )
+      sourceLines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
+      try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
+      return
+    }
+
+    try Data(sourceLines.joined(separator: "\n").utf8).write(to: sourceFileURL, options: [])
+
+    let destFileURL = context.vaultURL.appending(path: context.targetRelPath)
+    var destLines = try String(contentsOf: destFileURL, encoding: .utf8)
+      .components(separatedBy: "\n")
+    let insertionIndex = try Self.insertionIndex(
+      forSection: context.draft.section, in: destLines, list: context.targetRelPath
+    )
+    let style = Self.style(
+      forInsertionAt: insertionIndex,
+      in: destLines,
+      section: context.draft.section
+    )
+    let (taskLine, noteLines) = Self.formatLines(
+      for: context.draft,
+      orderedNumber: style.orderedNumber
+    )
+    destLines.insert(contentsOf: [taskLine] + noteLines, at: insertionIndex)
+    try Data(destLines.joined(separator: "\n").utf8).write(to: destFileURL, options: [])
   }
 
   // MARK: - Write-side section/line-range helpers

--- a/app/Taskmato/Tasks/Obsidian/ObsidianTaskLineFormatter.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianTaskLineFormatter.swift
@@ -17,6 +17,7 @@ nonisolated struct ObsidianTaskLineFormatter: Sendable {
   /// - Parameters:
   ///   - title: The task title, written verbatim (trimmed).
   ///   - checkbox: The checkbox character (`" "` for incomplete, `"x"` for complete).
+  ///   - orderedNumber: The literal list number to emit for ordered tasks, or `nil` for unordered.
   ///   - priority: Appended as the matching priority emoji, omitted for `.none`.
   ///   - startDate: Appended as `🛫 yyyy-MM-dd`, when present.
   ///   - scheduledDate: Appended as `⏰ yyyy-MM-dd`, when present.
@@ -25,12 +26,14 @@ nonisolated struct ObsidianTaskLineFormatter: Sendable {
   func formatLine(
     title: String,
     checkbox: String = " ",
+    orderedNumber: Int? = nil,
     priority: TaskPriority = .none,
     startDate: Date? = nil,
     scheduledDate: Date? = nil,
     dueDate: Date? = nil
   ) -> String {
-    var line = "- [\(checkbox)] \(title.trimmingCharacters(in: .whitespaces))"
+    let prefix = orderedNumber.map { "\($0)." } ?? "-"
+    var line = "\(prefix) [\(checkbox)] \(title.trimmingCharacters(in: .whitespaces))"
 
     if let emoji = Self.priorityEmoji(for: priority) {
       line += " \(emoji)"

--- a/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianTaskParser.swift
@@ -207,13 +207,47 @@ nonisolated struct ObsidianTaskParser: Sendable {
       || matchesOrderedItem(line, bracket: "[X]")
   }
 
+  /// Returns `true` if `line` is an ordered task list item (`N. [ ] `, `N. [x] `, or `N. [X] `).
+  ///
+  /// Shared with ``ObsidianProvider``'s write-side style detection so both read and write agree
+  /// on what counts as an ordered task line.
+  static func isOrderedTask(_ line: String) -> Bool {
+    orderedTaskPrefixRange(in: line) != nil
+  }
+
+  /// Returns the numeric prefix for an ordered task list item, or `nil` when `line` is unordered.
+  ///
+  /// Shared with ``ObsidianProvider``'s write-side style preservation so both read and write use
+  /// the same ordered-number extraction.
+  static func orderedTaskNumber(_ line: String) -> Int? {
+    guard let numberRange = orderedTaskNumberRange(in: line) else { return nil }
+    return Int(line[numberRange])
+  }
+
   /// Returns `true` when `line` is an ordered list item (`1. <bracket> `) with the given bracket content.
   private static func matchesOrderedItem(_ line: String, bracket: String) -> Bool {
+    guard let prefixRange = orderedTaskPrefixRange(in: line) else { return false }
+    return line[prefixRange.upperBound...].hasPrefix("\(bracket) ")
+  }
+
+  /// Returns the range covering the numeric portion of an ordered-list prefix.
+  private static func orderedTaskNumberRange(in line: String) -> Range<String.Index>? {
     var idx = line.startIndex
     while idx < line.endIndex, line[idx].isNumber {
       idx = line.index(after: idx)
     }
-    return idx > line.startIndex && line[idx...].hasPrefix(". \(bracket) ")
+    guard idx > line.startIndex, idx < line.endIndex, line[idx] == "." else { return nil }
+    let spaceIndex = line.index(after: idx)
+    guard spaceIndex < line.endIndex, line[spaceIndex] == " " else { return nil }
+    return line.startIndex..<idx
+  }
+
+  /// Returns the range covering the ordered-list prefix (`N. `) at the start of `line`.
+  static func orderedTaskPrefixRange(in line: String) -> Range<String.Index>? {
+    guard let numberRange = orderedTaskNumberRange(in: line) else { return nil }
+    let dotIndex = numberRange.upperBound
+    let spaceIndex = line.index(after: dotIndex)
+    return line.startIndex..<line.index(after: spaceIndex)
   }
 
   /// Returns `true` if `line` is indented (a task's note/continuation line).
@@ -423,11 +457,11 @@ nonisolated enum ObsidianTaskIdentity {
     for prefix in ["- [ ] ", "- [x] ", "- [X] "] where line.hasPrefix(prefix) {
       return String(line.dropFirst(prefix.count))
     }
-    var idx = line.startIndex
-    while idx < line.endIndex, line[idx].isNumber { idx = line.index(after: idx) }
-    guard idx > line.startIndex else { return line }
-    let rest = String(line[idx...])
-    for suffix in [". [ ] ", ". [x] ", ". [X] "] where rest.hasPrefix(suffix) {
+    guard let prefixRange = ObsidianTaskParser.orderedTaskPrefixRange(in: line) else {
+      return line
+    }
+    let rest = line[prefixRange.upperBound...]
+    for suffix in ["[ ] ", "[x] ", "[X] "] where rest.hasPrefix(suffix) {
       return String(rest.dropFirst(suffix.count))
     }
     return line

--- a/app/TaskmatoTests/ObsidianProviderWritableTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderWritableTests.swift
@@ -156,18 +156,51 @@ struct ObsidianProviderWritableTests {
     defer { try? FileManager.default.removeItem(at: vault) }
     try write(
       """
-      ## Section A
-      - [ ] First
-
-      ## Section B
-      - [ ] Second
+      1. [ ] First
+      2. [x] Second
       """, at: "tasks.md", in: vault)
     let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
     var draft = TaskDraft()
     draft.title = "Top level"
     _ = try await provider.addTask(draft)
     let content = try read("tasks.md", in: vault)
-    #expect(content.hasSuffix("- [ ] Top level"))
+    #expect(content == "1. [ ] First\n2. [x] Second\n3. [ ] Top level")
+  }
+
+  @Test func addTaskUsesOrderedStyleFromPrecedingCompletedTask() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write(
+      """
+      ## Section A
+      1. [ ] First
+      2. [x] Done
+      """, at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "Next"
+    draft.section = "Section A"
+    _ = try await provider.addTask(draft)
+    let content = try read("tasks.md", in: vault)
+    let expected = """
+      ## Section A
+      1. [ ] First
+      2. [x] Done
+      3. [ ] Next
+      """
+    #expect(content == expected)
+  }
+
+  @Test func addTaskDefaultsToUnorderedWhenNoTaskEvidenceExists() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault, defaultListID: "tasks.md")
+    var draft = TaskDraft()
+    draft.title = "First task"
+    _ = try await provider.addTask(draft)
+    let content = try read("tasks.md", in: vault)
+    #expect(content == "- [ ] First task")
   }
 
   @Test func addTaskToExistingSectionAppendsAfterLastLineInBlock() async throws {
@@ -232,14 +265,14 @@ struct ObsidianProviderWritableTests {
   @Test func updateTaskInPlaceRewritesLineWithoutMoving() async throws {
     let vault = try makeVault()
     defer { try? FileManager.default.removeItem(at: vault) }
-    try write("- [ ] Original", at: "tasks.md", in: vault)
+    try write("7. [ ] Original", at: "tasks.md", in: vault)
     let provider = makeProvider(vaultURL: vault)
     let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:1")
     var draft = TaskDraft()
     draft.title = "Updated"
     try await provider.updateTask(ref, draft: draft)
     let content = try read("tasks.md", in: vault)
-    #expect(content == "- [ ] Updated")
+    #expect(content == "7. [ ] Updated")
   }
 
   @Test func updateTaskMovesToADifferentSectionInSameFile() async throws {
@@ -251,7 +284,7 @@ struct ObsidianProviderWritableTests {
       - [ ] Move me
 
       ## Section B
-      - [ ] Existing
+      4. [x] Existing
       """, at: "tasks.md", in: vault)
     let provider = makeProvider(vaultURL: vault)
     let ref = TaskRef(providerID: "obsidian", nativeID: "tasks.md:2")
@@ -264,8 +297,8 @@ struct ObsidianProviderWritableTests {
       ## Section A
 
       ## Section B
-      - [ ] Existing
-      - [ ] Move me
+      4. [x] Existing
+      5. [ ] Move me
       """
     #expect(content == expected)
   }
@@ -273,8 +306,8 @@ struct ObsidianProviderWritableTests {
   @Test func updateTaskMovesToADifferentFile() async throws {
     let vault = try makeVault()
     defer { try? FileManager.default.removeItem(at: vault) }
-    try write("- [ ] Move me", at: "source.md", in: vault)
-    try write("- [ ] Existing", at: "dest.md", in: vault)
+    try write("1. [ ] Move me", at: "source.md", in: vault)
+    try write("9. [x] Existing", at: "dest.md", in: vault)
     let provider = makeProvider(vaultURL: vault)
     let ref = TaskRef(providerID: "obsidian", nativeID: "source.md:1")
     var draft = TaskDraft()
@@ -282,7 +315,7 @@ struct ObsidianProviderWritableTests {
     draft.listID = "dest.md"
     try await provider.updateTask(ref, draft: draft)
     #expect(try read("source.md", in: vault).isEmpty)
-    #expect(try read("dest.md", in: vault) == "- [ ] Existing\n- [ ] Move me")
+    #expect(try read("dest.md", in: vault) == "9. [x] Existing\n10. [ ] Move me")
   }
 
   @Test func updateTaskThrowsForStaleRef() async throws {

--- a/app/TaskmatoTests/ObsidianTaskLineFormatterTests.swift
+++ b/app/TaskmatoTests/ObsidianTaskLineFormatterTests.swift
@@ -44,6 +44,11 @@ struct ObsidianTaskLineFormatterTests {
     #expect(line == "- [x] Done")
   }
 
+  @Test func formatsOrderedTaskWhenNumberProvided() {
+    let line = formatter.formatLine(title: "Write unit tests", orderedNumber: 3)
+    #expect(line == "3. [ ] Write unit tests")
+  }
+
   @Test func trimsTitleWhitespace() {
     let line = formatter.formatLine(title: "  Padded  ")
     #expect(line == "- [ ] Padded")

--- a/app/TaskmatoTests/ObsidianTaskParserOrderedListTests.swift
+++ b/app/TaskmatoTests/ObsidianTaskParserOrderedListTests.swift
@@ -82,4 +82,11 @@ struct ObsidianTaskParserOrderedListTests {
     #expect(tasks[0].section == "Goals")
     #expect(tasks[1].section == "Goals")
   }
+
+  @Test func detectsOrderedTaskPrefixAndNumber() {
+    #expect(ObsidianTaskParser.isOrderedTask("12. [x] Done"))
+    #expect(ObsidianTaskParser.orderedTaskNumber("12. [x] Done") == 12)
+    #expect(!ObsidianTaskParser.isOrderedTask("- [ ] Unordered"))
+    #expect(ObsidianTaskParser.orderedTaskNumber("- [ ] Unordered") == nil)
+  }
 }


### PR DESCRIPTION
## Summary

Fix Obsidian task writes so new and moved tasks preserve the ordered or unordered Markdown list style used at their destination.

## Linked issue

Closes #556

## Root cause

ObsidianTaskLineFormatter always emitted unordered task markers, while the parser and checkbox rewrite path already supported ordered task syntax.

## Fix

- Detect the nearest preceding recognized task in the destination section or file.
- Increment ordered list numbers for new and moved tasks.
- Preserve exact list style for in-place edits.
- Default to unordered for empty sections and files.
- Add shared ordered-task parsing helpers and regression tests.

## Validation

- [x] Lint passes locally (SwiftLint reports 0 violations; the make wrapper intermittently hits a sandbox cache-write permission error)
- [x] Unit tests pass locally
- [x] Added or updated a regression test
- [x] Manually verified the taskmato.sh URL creation path

## Release / deploy impact

- [x] Safe to label no-deploy
- [ ] Breaking change

## Reviewer notes

Full make test passes. No entitlements, persistence, or protocol changes are included.