### PR TITLE
fix(tasks): restore list double-click focus

### DIFF
--- a/app/Taskmato/Views/Tasks/TaskDetailCompletedViews.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailCompletedViews.swift
@@ -15,11 +15,8 @@ extension TaskDetailView {
       kind: completedKind(for: task),
       lineage: lineage(for: task)
     )
+    .tag(task.id)
     .listRowBackground(selectionBackground(for: task))
-    .onTapGesture {
-      selection = task.id
-      focusTaskContent()
-    }
     .accessibilityAddTraits(selection == task.id ? .isSelected : [])
     .contextMenu { completedTaskContextMenu(for: task) }
   }

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -224,6 +224,11 @@ struct TaskDetailView: View {
         isTaskContentFocused = false
         Task { await refresh() }
       }
+      .onChange(of: selection) { _, newSelection in
+        // Native List selection changes after the table handles the click. Reclaim first
+        // responder status after that handoff so Return and task commands keep working.
+        if newSelection != nil { focusTaskContent() }
+      }
       .onChange(of: isSearchFocused) { _, focused in
         if focused { isTaskContentFocused = false }
       }
@@ -307,7 +312,7 @@ struct TaskDetailView: View {
           to:
             attachTaskKeyboardResponder(
               to:
-                List {
+                List(selection: $selection) {
                   SwiftUI.ForEach(sections) { section in
                     listSection(for: section)
                   }
@@ -337,11 +342,8 @@ struct TaskDetailView: View {
           kind: activeKind(for: task),
           lineage: lineage(for: task)
         )
+        .tag(task.id)
         .listRowBackground(selectionBackground(for: task))
-        .onTapGesture {
-          selection = task.id
-          focusTaskContent()
-        }
         .accessibilityAddTraits(selection == task.id ? .isSelected : [])
         .contextMenu { taskContextMenu(for: task) }
       }


### PR DESCRIPTION
## Summary

Restore task-row activation and keyboard focus in the Tasks list. Double-click now activates a task, and Return continues to activate the focused task after a single click.

## Linked issue

Closes #554

## Root cause

The list’s native `NSTableView` selection was disconnected from the view-local task selection state. Restoring native `List(selection:)` selection made double-click activation reliable, but the table then took first-responder status after clicks, leaving the task keyboard responder unfocused.

## Fix

Bind the list to the existing task selection state, tag active and completed rows with their task references, remove the competing row-level selection gestures, and reclaim task-content focus whenever native selection changes.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [ ] Added or updated a regression test
- [x] Manually verified the original bug no longer reproduces

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

The full `make test` run compiled successfully; one existing UI smoke test intermittently failed during app teardown. The isolated `TaskmatoTests` target passed.