### PR TITLE
feat(tasks): clarify default task destinations

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -25,6 +25,7 @@ struct AppComposition {
   let selectionStore: TaskSelectionStore
   let registry: ProviderRegistry
   let queryService: TaskQueryService
+  let destinationResolver: TaskDestinationResolver
   let sidebarSelection: SelectionStore
   let notifications: NotificationService
   let obsidianProvider: ObsidianProvider
@@ -58,6 +59,7 @@ struct AppComposition {
       [obsidianProvider, localProvider, remindersProvider], into: registry,
       fallback: localProvider)
     let queryService = TaskQueryService(registry: registry, sorter: TaskSorter())
+    let destinationResolver = TaskDestinationResolver(registry: registry, settings: settings)
     let sidebarSelection = SelectionStore(registry: registry, store: settingsStore)
     let nav = MainNavigation(
       settings: settings, selectionStore: sidebarSelection, statsViewModel: statsViewModel,
@@ -68,22 +70,16 @@ struct AppComposition {
     let urlHandler = URLSchemeHandler(
       registry: registry, queryService: queryService, selectionStore: selectionStore,
       engine: engine, settings: settings,
-      nav: nav, errorPresenter: errorPresenter
+      nav: nav, errorPresenter: errorPresenter, destinationResolver: destinationResolver
     )
-    let (phaseOrchestrator, focusAttribution) = Self.makePhaseOrchestrator(
-      engine: engine, store: store, settings: settings, selectionStore: selectionStore,
-      notifications: notifications)
-    Self.wireFocusHandoff(
-      engine: engine, settings: settings, nav: nav, selectionStore: selectionStore,
-      attribution: focusAttribution)
-    let activeTaskReconciliation = Self.wireActiveTaskReconciliation(
-      registry: registry, selectionStore: selectionStore,
-      runtime: (engine: engine, attribution: focusAttribution),
-      navigation: (sidebarSelection: sidebarSelection, nav: nav),
-      errorPresenter: errorPresenter)
-    self.activeTaskLiveObserver = activeTaskReconciliation.liveObserver
-    self.activeTaskReconciler = activeTaskReconciliation.reconciler
-    self.focusAttribution = focusAttribution
+    let runtime = Self.makeRuntime(
+      RuntimeInputs(
+        engine: engine, store: store, settings: settings, selectionStore: selectionStore,
+        registry: registry, sidebarSelection: sidebarSelection, nav: nav,
+        notifications: notifications, errorPresenter: errorPresenter))
+    self.activeTaskLiveObserver = runtime.activeTaskReconciliation.liveObserver
+    self.activeTaskReconciler = runtime.activeTaskReconciliation.reconciler
+    self.focusAttribution = runtime.focusAttribution
     self.engine = engine
     self.settings = settings
     self.timerPresenter = TimerPresenter(engine: engine, settings: settings)
@@ -92,6 +88,7 @@ struct AppComposition {
     self.selectionStore = selectionStore
     self.registry = registry
     self.queryService = queryService
+    self.destinationResolver = destinationResolver
     self.sidebarSelection = sidebarSelection
     self.notifications = notifications
     self.obsidianProvider = obsidianProvider
@@ -100,7 +97,7 @@ struct AppComposition {
     self.urlHandler = urlHandler
     self.nav = nav
     self.errorPresenter = errorPresenter
-    self.phaseOrchestrator = phaseOrchestrator
+    self.phaseOrchestrator = runtime.phaseOrchestrator
   }
 
   /// Opens the SwiftData session store, trapping if it cannot be created.
@@ -206,6 +203,44 @@ struct AppComposition {
       selectionStore: selectionStore, notifications: notifications, attribution: attribution)
     Task { await orchestrator.run() }
     return (orchestrator, attribution)
+  }
+
+  /// Builds the phase and active-task runtime services that share registry and navigation wiring.
+  private static func makeRuntime(_ inputs: RuntimeInputs) -> RuntimeServices {
+    let (phaseOrchestrator, focusAttribution) = Self.makePhaseOrchestrator(
+      engine: inputs.engine, store: inputs.store, settings: inputs.settings,
+      selectionStore: inputs.selectionStore, notifications: inputs.notifications)
+    Self.wireFocusHandoff(
+      engine: inputs.engine, settings: inputs.settings, nav: inputs.nav,
+      selectionStore: inputs.selectionStore,
+      attribution: focusAttribution)
+    let activeTaskReconciliation = Self.wireActiveTaskReconciliation(
+      registry: inputs.registry, selectionStore: inputs.selectionStore,
+      runtime: (engine: inputs.engine, attribution: focusAttribution),
+      navigation: (sidebarSelection: inputs.sidebarSelection, nav: inputs.nav),
+      errorPresenter: inputs.errorPresenter)
+    return RuntimeServices(
+      phaseOrchestrator: phaseOrchestrator, focusAttribution: focusAttribution,
+      activeTaskReconciliation: activeTaskReconciliation)
+  }
+
+  private struct RuntimeInputs {
+    let engine: SessionEngine
+    let store: SessionStore
+    let settings: AppSettings
+    let selectionStore: TaskSelectionStore
+    let registry: ProviderRegistry
+    let sidebarSelection: SelectionStore
+    let nav: MainNavigation
+    let notifications: NotificationService
+    let errorPresenter: ErrorPresenter
+  }
+
+  private struct RuntimeServices {
+    let phaseOrchestrator: PhaseOrchestrator
+    let focusAttribution: FocusAttribution
+    let activeTaskReconciliation:
+      (reconciler: ActiveTaskReconciler, liveObserver: ActiveTaskLiveObserver)
   }
 
   /// Wires the two focus-handoff callbacks onto `selectionStore` (D4/D9 of design doc 0010): a

--- a/app/Taskmato/TaskmatoApp.swift
+++ b/app/Taskmato/TaskmatoApp.swift
@@ -49,6 +49,7 @@ struct TaskmatoApp: App {
         selectionStore: composition.selectionStore,
         registry: composition.registry,
         queryService: composition.queryService,
+        destinationResolver: composition.destinationResolver,
         sidebarSelection: composition.sidebarSelection,
         nav: composition.nav,
         errorPresenter: composition.errorPresenter

--- a/app/Taskmato/Tasks/ConfigurableTaskProvider.swift
+++ b/app/Taskmato/Tasks/ConfigurableTaskProvider.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-/// A `TaskProvider` that exposes a user-facing setup sheet.
+/// A `TaskProvider` that exposes a user-facing setup or settings sheet.
 ///
 /// Conform to this protocol to opt in to the "Configure…" context-menu action in
 /// the provider sidebar. The provider produces its own configuration view, so no
@@ -20,7 +20,7 @@ protocol ConfigurableTaskProvider: TaskProvider {
   /// immediately presents ``configurationView()``.
   var needsConfiguration: Bool { get }
 
-  /// Produces the view displayed inside the modal configuration sheet.
+  /// Produces the view displayed inside the modal configuration or settings sheet.
   @MainActor
   func configurationView() -> AnyView
 }

--- a/app/Taskmato/Tasks/Local/LocalProvider.swift
+++ b/app/Taskmato/Tasks/Local/LocalProvider.swift
@@ -149,9 +149,13 @@ final class LocalProvider: WritableListProvider {
   /// If `draft.listID` is `nil`, the task is assigned to the provider's default list.
   @discardableResult
   func addTask(_ draft: TaskDraft) async throws -> TaskItem {
+    await ready()
     var resolved = draft
     if resolved.listID == nil {
       resolved.listID = defaultListID ?? taskLists.first?.id.uuidString
+    }
+    guard resolved.listID != nil else {
+      throw LocalProviderError.noListAvailable
     }
     let newTask = LocalTask(from: resolved)
     allTasks.append(newTask)
@@ -292,6 +296,9 @@ enum LocalProviderError: LocalizedError {
   /// No list matching the given ID exists in the store.
   case listNotFound(String)
 
+  /// The store has no list available for a new task.
+  case noListAvailable
+
   /// The list cannot be deleted because it is the current default list.
   case cannotDeleteDefaultList(String)
 
@@ -301,6 +308,8 @@ enum LocalProviderError: LocalizedError {
       return "Could not find task \"\(nativeID)\"."
     case .listNotFound(let listID):
       return "Could not find list \"\(listID)\"."
+    case .noListAvailable:
+      return "No local task list is available. Create a list before adding a task."
     case .cannotDeleteDefaultList(let listID):
       return "Cannot delete the default list \"\(listID)\". Promote another list first."
     }

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Errors.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Errors.swift
@@ -46,6 +46,8 @@ enum ObsidianProviderError: LocalizedError {
   case ambiguousTaskRef(String)
   /// No file matches the given vault-relative list ID.
   case listNotFound(String)
+  /// No matching markdown file is available for a new task.
+  case noListAvailable
   /// No heading matching the given section text was found in the target file.
   case sectionNotFound(list: String, section: String)
 
@@ -61,6 +63,9 @@ enum ObsidianProviderError: LocalizedError {
       return "Could not uniquely locate task \"\(id)\" in the vault."
     case .listNotFound(let id):
       return "Could not locate list \"\(id)\" in the vault."
+    case .noListAvailable:
+      return
+        "No matching Obsidian files are available. Configure a file pattern before adding a task."
     case .sectionNotFound(let list, let section):
       return "Could not locate section \"\(section)\" in \"\(list)\"."
     }

--- a/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift
+++ b/app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift
@@ -76,14 +76,31 @@ extension ObsidianProvider {
   ///
   /// When `draft.section` is given, the line is inserted as the last item in that heading's
   /// existing task block (a continuation of that section's list), rather than at the end of the
-  /// file. Targets `draft.listID` if set, otherwise ``defaultListID``.
+  /// file. Targets `draft.listID` if set, otherwise the configured default or first matching file.
   @discardableResult
   func addTask(_ draft: TaskDraft) async throws -> TaskItem {
     guard let vaultURL else {
       throw ObsidianProviderError.vaultNotConfigured
     }
-    guard let relPath = draft.listID ?? defaultListID else {
-      throw ObsidianProviderError.listNotFound("")
+    let availableLists = try await lists()
+    let relPath: String
+    if let explicitListID = draft.listID {
+      guard availableLists.contains(where: { $0.id == explicitListID }) else {
+        throw ObsidianProviderError.listNotFound(explicitListID)
+      }
+      relPath = explicitListID
+    } else if let defaultListID {
+      if availableLists.contains(where: { $0.id == defaultListID }) {
+        relPath = defaultListID
+      } else if let firstList = availableLists.first {
+        relPath = firstList.id
+      } else {
+        throw ObsidianProviderError.noListAvailable
+      }
+    } else if let firstList = availableLists.first {
+      relPath = firstList.id
+    } else {
+      throw ObsidianProviderError.noListAvailable
     }
     let fileURL = vaultURL.appending(path: relPath)
 

--- a/app/Taskmato/Tasks/Registry/TaskDestinationResolver.swift
+++ b/app/Taskmato/Tasks/Registry/TaskDestinationResolver.swift
@@ -1,0 +1,140 @@
+//
+//  TaskDestinationResolver.swift
+//  Taskmato
+//
+
+import Foundation
+
+/// The provider and list selected for a newly created task.
+struct TaskDestination {
+
+  /// The enabled writable provider that will receive the task.
+  let provider: any WritableTaskProvider
+
+  /// The provider-local list ID that will receive the task.
+  let listID: String
+}
+
+/// Errors raised when Taskmato cannot resolve a writable task destination.
+enum TaskDestinationResolutionError: LocalizedError, Equatable {
+
+  /// No enabled provider can create tasks.
+  case noWritableProvider
+
+  /// The selected provider has no currently available list.
+  case noAvailableList(providerID: ProviderID, providerName: String)
+
+  var errorDescription: String? {
+    switch self {
+    case .noWritableProvider:
+      return "No writable task provider is enabled. Enable a provider before creating a task."
+    case .noAvailableList(_, let providerName):
+      return
+        "\(providerName) has no available lists. Configure a list before creating a task, "
+        + "or pass --list to choose one."
+    }
+  }
+}
+
+/// Resolves the provider and list for every app-created task.
+@MainActor
+final class TaskDestinationResolver {
+
+  private let registry: ProviderRegistry
+  private let settings: AppSettings
+
+  /// - Parameters:
+  ///   - registry: The registry supplying enabled providers and current sidebar context.
+  ///   - settings: The settings supplying the preferred writable provider.
+  init(registry: ProviderRegistry, settings: AppSettings) {
+    self.registry = registry
+    self.settings = settings
+  }
+
+  /// Returns the writable provider selected by the provider precedence rules.
+  /// - Parameters:
+  ///   - providerID: An optional explicitly requested provider.
+  ///   - sidebarSelection: The current sidebar selection for interactive routes.
+  /// - Returns: An enabled writable provider, or `nil` when none is available.
+  func provider(
+    providerID: ProviderID? = nil, sidebarSelection: SidebarSelection? = nil
+  ) -> (any WritableTaskProvider)? {
+    resolveProvider(providerID: providerID, sidebarSelection: sidebarSelection)
+  }
+
+  /// Resolves a destination using the shared provider and list precedence rules.
+  ///
+  /// An invalid explicit provider falls through to the interactive sidebar context, the
+  /// settings preference, and provider order. An explicit list ID is strict and must still
+  /// exist; an unmatched list name is treated as absent so URL and CLI callers retain the
+  /// approved default-list fallback.
+  /// - Parameters:
+  ///   - providerID: An optional provider requested by a URL or other route.
+  ///   - listID: An optional already-resolved list ID from a UI action.
+  ///   - listName: An optional human-readable list name from a URL or CLI invocation.
+  ///   - sidebarSelection: The current sidebar selection for interactive routes.
+  /// - Returns: A provider plus a currently available list ID.
+  /// - Throws: ``TaskDestinationResolutionError`` when no writable provider or list exists.
+  func resolve(
+    providerID: ProviderID? = nil,
+    listID: String? = nil,
+    listName: String? = nil,
+    sidebarSelection: SidebarSelection? = nil
+  ) async throws -> TaskDestination {
+    let provider = resolveProvider(providerID: providerID, sidebarSelection: sidebarSelection)
+    guard let provider else {
+      throw TaskDestinationResolutionError.noWritableProvider
+    }
+
+    let lists = try await provider.lists()
+    let namedListID = listName.flatMap { name in
+      lists.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }?.id
+    }
+
+    if let listID {
+      guard lists.contains(where: { $0.id == listID }) else {
+        throw TaskDestinationResolutionError.noAvailableList(
+          providerID: provider.id, providerName: provider.displayName)
+      }
+      return TaskDestination(provider: provider, listID: listID)
+    }
+
+    if let namedListID {
+      return TaskDestination(provider: provider, listID: namedListID)
+    }
+
+    if let sidebarListID = sidebarSelection?.listID(matching: provider.id) {
+      if lists.contains(where: { $0.id == sidebarListID }) {
+        return TaskDestination(provider: provider, listID: sidebarListID)
+      }
+    }
+
+    if let defaultListID = provider.defaultListID {
+      if lists.contains(where: { $0.id == defaultListID }) {
+        return TaskDestination(provider: provider, listID: defaultListID)
+      }
+    }
+
+    guard let firstList = lists.first else {
+      throw TaskDestinationResolutionError.noAvailableList(
+        providerID: provider.id, providerName: provider.displayName)
+    }
+    return TaskDestination(provider: provider, listID: firstList.id)
+  }
+
+  private func resolveProvider(
+    providerID: ProviderID?, sidebarSelection: SidebarSelection?
+  ) -> (any WritableTaskProvider)? {
+    if let providerID, let provider = registry.enabledWritableProvider(id: providerID) {
+      return provider
+    }
+
+    if case .list(let selectedList) = sidebarSelection {
+      if let provider = registry.enabledWritableProvider(id: selectedList.providerID) {
+        return provider
+      }
+    }
+
+    return registry.resolveDefaultWritableProvider(preferredID: settings.defaultWritableProviderID)
+  }
+}

--- a/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
+++ b/app/Taskmato/Tasks/Reminders/RemindersProvider.swift
@@ -225,14 +225,29 @@ final class RemindersProvider: WritableTaskProvider {
 
   /// Creates a new reminder from `draft` and returns the resulting item.
   ///
-  /// Targets `draft.listID` if set, otherwise ``defaultListID``.
+  /// Targets `draft.listID` if set, otherwise the valid system default or first visible list.
   @discardableResult
   func addTask(_ draft: TaskDraft) async throws -> TaskItem {
-    let calendarID = draft.listID ?? defaultListID
+    let availableLists = try await lists()
+    let calendarID: String?
+    if let explicitListID = draft.listID {
+      calendarID = explicitListID
+    } else if let defaultListID {
+      if availableLists.contains(where: { $0.id == defaultListID }) {
+        calendarID = defaultListID
+      } else {
+        calendarID = availableLists.first?.id
+      }
+    } else {
+      calendarID = availableLists.first?.id
+    }
     guard let calendarID,
       let calendar = store.calendars(for: .reminder)
         .first(where: { $0.calendarIdentifier == calendarID })
     else {
+      if draft.listID == nil {
+        throw RemindersProviderError.noListAvailable
+      }
       throw RemindersProviderError.listNotFound(calendarID ?? "")
     }
     let reminder = store.newReminder()
@@ -359,6 +374,9 @@ enum RemindersProviderError: LocalizedError, Equatable {
   /// No calendar with the given identifier is among the provider's current lists.
   case listNotFound(String)
 
+  /// No visible reminder list is available for a new task.
+  case noListAvailable
+
   var errorDescription: String? {
     switch self {
     case .accessDenied:
@@ -375,6 +393,8 @@ enum RemindersProviderError: LocalizedError, Equatable {
       return "Could not find reminder \"\(id)\"."
     case .listNotFound(let id):
       return "Could not find Reminders list \"\(id)\"."
+    case .noListAvailable:
+      return "No Reminders list is available. Configure or create a list before adding a task."
     }
   }
 }

--- a/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
+++ b/app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift
@@ -65,6 +65,7 @@ final class URLSchemeHandler {
   private let settings: AppSettings
   private let nav: MainNavigation
   private let errorPresenter: ErrorPresenter
+  private let destinationResolver: TaskDestinationResolver
 
   init(
     registry: ProviderRegistry,
@@ -73,7 +74,8 @@ final class URLSchemeHandler {
     engine: SessionEngine,
     settings: AppSettings,
     nav: MainNavigation,
-    errorPresenter: ErrorPresenter
+    errorPresenter: ErrorPresenter,
+    destinationResolver: TaskDestinationResolver
   ) {
     self.registry = registry
     self.queryService = queryService
@@ -82,6 +84,7 @@ final class URLSchemeHandler {
     self.settings = settings
     self.nav = nav
     self.errorPresenter = errorPresenter
+    self.destinationResolver = destinationResolver
   }
 
   /// Handles the given URL, selecting the resolved task and starting a focus session if
@@ -133,20 +136,13 @@ final class URLSchemeHandler {
   /// Returns `nil` after surfacing an error on the window-root banner when no enabled writable
   /// provider is available or the write fails; the caller then starts no session.
   func makeAdHocTask(from adHocParams: AdHocTaskParams) async -> TaskItem? {
-    // Level 1: URL param targets a specific provider (strict — no implicit fallback within level).
-    let urlTargeted = adHocParams.providerID
-      .map(ProviderID.init(_:))
-      .flatMap(registry.enabledWritableProvider(id:))
-    // Level 2 & 3: settings default, then first enabled writable provider.
-    let writable =
-      urlTargeted
-      ?? registry.resolveDefaultWritableProvider(preferredID: settings.defaultWritableProviderID)
-
-    guard let writable else {
-      errorPresenter.present(
-        TransientError(
-          title: AppLabels.Error.adhocCreateFailed,
-          detail: "No writable task list is available."))
+    let destination: TaskDestination
+    do {
+      destination = try await destinationResolver.resolve(
+        providerID: adHocParams.providerID.map(ProviderID.init(_:)),
+        listName: adHocParams.listName)
+    } catch {
+      errorPresenter.present(title: AppLabels.Error.adhocCreateFailed, error: error)
       return nil
     }
 
@@ -156,19 +152,9 @@ final class URLSchemeHandler {
     draft.dueDate = adHocParams.dueDate
     draft.dueDateIncludesTime = adHocParams.dueDateIncludesTime
     draft.section = adHocParams.section
-    if let name = adHocParams.listName {
-      let lists: [TaskList]
-      if let cached = registry.providerLists[writable.id] {
-        lists = cached
-      } else {
-        lists = (try? await writable.lists()) ?? []
-      }
-      draft.listID =
-        lists.first { $0.name.localizedCaseInsensitiveCompare(name) == .orderedSame }?.id
-        ?? writable.defaultListID
-    }
+    draft.listID = destination.listID
     do {
-      return try await writable.addTask(draft)
+      return try await destination.provider.addTask(draft)
     } catch {
       errorPresenter.present(title: AppLabels.Error.adhocCreateFailed, error: error)
       return nil

--- a/app/Taskmato/Views/App/AppSidebarView.swift
+++ b/app/Taskmato/Views/App/AppSidebarView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 ///
 /// A single `List` bound to ``MainNavigation/destination`` holds every destination: the
 /// pinned Timer and Today rows, one collapsible ``Section`` per enabled provider (list rows,
-/// inline rename, star-default, and a "New list" row for writable providers), and a
+/// inline rename, and a "New list" row for writable providers), and a
 /// collapsible Stats section of scope rows. Section expansion is persisted via
 /// ``AppSettings/collapsedSidebarSections``; enabling or configuring a provider re-expands
 /// its section. When no provider is enabled, the provider area is replaced by an add hint.
@@ -18,6 +18,7 @@ struct AppSidebarView: View {
   @Bindable var nav: MainNavigation
   var presenter: TimerPresenter
   var registry: ProviderRegistry
+  var destinationResolver: TaskDestinationResolver
   var settings: AppSettings
   var errorPresenter: ErrorPresenter
   /// Called after a task is successfully added from the list context-menu "Add Task…" item.
@@ -103,6 +104,7 @@ struct AppSidebarView: View {
       if let target = addTaskTarget {
         AddTaskView(
           provider: target.provider,
+          destinationResolver: destinationResolver,
           isPresented: $isAddingTask,
           errorPresenter: errorPresenter,
           initialListID: target.listID
@@ -189,35 +191,12 @@ struct AppSidebarView: View {
 
   @ViewBuilder
   private func listRow(_ list: TaskList, provider: any TaskProvider) -> some View {
-    let writable = provider as? (any WritableTaskProvider)
-    let isDefaultList = isDefault(list.id, for: provider)
-
     HStack(spacing: .iconLabel) {
       Image(systemName: "list.bullet")
         .imageScale(.small)
         .foregroundStyle(.secondary)
 
       listNameField(list: list, provider: provider)
-
-      Spacer()
-
-      if writable != nil {
-        Button {
-          let id = list.id
-          Task {
-            await errorPresenter.attempt(AppLabels.Error.setDefaultFailed) {
-              try await writable?.setDefaultList(id)
-            }
-          }
-        } label: {
-          Image(systemName: isDefaultList ? "star.fill" : "star")
-            .imageScale(.small)
-        }
-        .buttonStyle(.borderless)
-        .foregroundStyle(isDefaultList ? Color.favoriteStar : Color.secondary)
-        .help(isDefaultList ? "Default list" : "Set as default list")
-        .accessibilityLabel(isDefaultList ? "Default list" : "Set as default list")
-      }
     }
   }
 
@@ -260,7 +239,8 @@ struct AppSidebarView: View {
       }
     } label: {
       Label(
-        AppLabels.Sidebar.setDefault.title, systemImage: AppLabels.Sidebar.setDefault.systemImage)
+        "Set as Default List for \(provider.displayName)",
+        systemImage: AppLabels.Sidebar.setDefault.systemImage)
     }
     .disabled(isDefaultList)
 
@@ -515,11 +495,12 @@ private struct SidebarTimerRow: View {
     let registry = ProviderRegistry()
     let settings = AppSettings()
     let selectionStore = SelectionStore(registry: registry)
-    return AppSidebarView(
+    AppSidebarView(
       nav: MainNavigation(
         settings: settings, selectionStore: selectionStore, statsViewModel: .preview),
       presenter: TimerPresenter(engine: SessionEngine(), settings: settings),
       registry: registry,
+      destinationResolver: TaskDestinationResolver(registry: registry, settings: settings),
       settings: settings,
       errorPresenter: ErrorPresenter()
     )

--- a/app/Taskmato/Views/App/ErrorBannerView.swift
+++ b/app/Taskmato/Views/App/ErrorBannerView.swift
@@ -69,13 +69,7 @@ extension ErrorSeverity {
 
 #if DEBUG
   #Preview {
-    let presenter = ErrorPresenter()
-    presenter.present(
-      TransientError(
-        title: "Couldn't complete task",
-        detail: "Reminders access has been revoked in System Settings.",
-        severity: .error))
-    return ErrorBannerView(presenter: presenter)
+    ErrorBannerView(presenter: ErrorPresenter())
       .frame(width: 420)
   }
 #endif

--- a/app/Taskmato/Views/App/MainWindowView.swift
+++ b/app/Taskmato/Views/App/MainWindowView.swift
@@ -21,6 +21,7 @@ struct MainWindowView: View {
   var selectionStore: TaskSelectionStore
   var registry: ProviderRegistry
   var queryService: TaskQueryService
+  var destinationResolver: TaskDestinationResolver
   var sidebarSelection: SelectionStore
   var nav: MainNavigation
   var errorPresenter: ErrorPresenter
@@ -46,6 +47,7 @@ struct MainWindowView: View {
         nav: nav,
         presenter: presenter,
         registry: registry,
+        destinationResolver: destinationResolver,
         settings: settings,
         errorPresenter: errorPresenter,
         onTaskAdded: { taskAddedToken += 1 }
@@ -102,6 +104,7 @@ struct MainWindowView: View {
         selectionStore: selectionStore,
         registry: registry,
         queryService: queryService,
+        destinationResolver: destinationResolver,
         sidebarSelection: sidebarSelection,
         nav: nav,
         settings: settings,
@@ -136,7 +139,7 @@ struct MainWindowView: View {
     let settings = AppSettings()
     let registry = ProviderRegistry()
     let selectionStore = SelectionStore(registry: registry)
-    return MainWindowView(
+    MainWindowView(
       presenter: TimerPresenter(engine: engine, settings: settings),
       engine: engine,
       settings: settings,
@@ -144,6 +147,7 @@ struct MainWindowView: View {
       selectionStore: TaskSelectionStore(),
       registry: registry,
       queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
+      destinationResolver: TaskDestinationResolver(registry: registry, settings: settings),
       sidebarSelection: selectionStore,
       nav: MainNavigation(
         settings: settings, selectionStore: selectionStore, statsViewModel: .preview),

--- a/app/Taskmato/Views/Settings/Components/ProviderDefaultListSettings.swift
+++ b/app/Taskmato/Views/Settings/Components/ProviderDefaultListSettings.swift
@@ -1,0 +1,88 @@
+//
+//  ProviderDefaultListSettings.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// A provider-scoped control for choosing the list used by new tasks.
+struct ProviderDefaultListSettings: View {
+
+  let provider: any WritableTaskProvider
+
+  @State private var lists: [TaskList] = []
+  @State private var selectedListID = ""
+  @State private var isLoading = true
+  @State private var errorMessage: String?
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: .contentGap) {
+      Text("Task creation")
+        .font(.headline)
+
+      Text(
+        "This list is used when a new task does not specify a list. "
+          + "Lists chosen in the sidebar or supplied by a URL or command take precedence."
+      )
+      .font(.caption)
+      .foregroundStyle(.secondary)
+
+      HStack(alignment: .firstTextBaseline, spacing: .contentGap) {
+        Text("Default list")
+          .frame(width: 92, alignment: .trailing)
+
+        if lists.isEmpty, !isLoading {
+          Text("No lists available")
+            .foregroundStyle(.secondary)
+        } else {
+          Picker("Default list", selection: $selectedListID) {
+            ForEach(lists) { list in
+              Text(list.name).tag(list.id)
+            }
+          }
+          .labelsHidden()
+          .disabled(isLoading)
+        }
+      }
+
+      if let errorMessage {
+        Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+          .font(.caption)
+          .foregroundStyle(Color.statusError)
+          .padding(.leading, 92 + .contentGap)
+      }
+    }
+    .task { await loadLists() }
+    .onChange(of: selectedListID) { _, newValue in
+      guard !isLoading, !newValue.isEmpty else { return }
+      Task { await saveDefaultList(newValue) }
+    }
+  }
+
+  private func loadLists() async {
+    defer { isLoading = false }
+    do {
+      lists = try await provider.lists()
+      if let defaultListID = provider.defaultListID {
+        if lists.contains(where: { $0.id == defaultListID }) {
+          selectedListID = defaultListID
+        } else {
+          selectedListID = lists.first?.id ?? ""
+        }
+      } else {
+        selectedListID = lists.first?.id ?? ""
+      }
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+
+  private func saveDefaultList(_ listID: String) async {
+    do {
+      try await provider.setDefaultList(listID)
+      errorMessage = nil
+    } catch {
+      errorMessage = error.localizedDescription
+    }
+  }
+}

--- a/app/Taskmato/Views/Settings/Local/LocalProvider+Configuration.swift
+++ b/app/Taskmato/Views/Settings/Local/LocalProvider+Configuration.swift
@@ -1,0 +1,14 @@
+//
+//  LocalProvider+Configuration.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+extension LocalProvider: ConfigurableTaskProvider {
+  var needsConfiguration: Bool { false }
+
+  func configurationView() -> AnyView {
+    AnyView(LocalSettingsSheet(provider: self))
+  }
+}

--- a/app/Taskmato/Views/Settings/Local/LocalSettingsSheet.swift
+++ b/app/Taskmato/Views/Settings/Local/LocalSettingsSheet.swift
@@ -1,0 +1,33 @@
+//
+//  LocalSettingsSheet.swift
+//  Taskmato
+//
+
+import SwiftUI
+
+/// Configuration sheet for the built-in Local provider.
+struct LocalSettingsSheet: View {
+
+  let provider: LocalProvider
+  @Environment(\.dismiss) private var dismiss
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: .groupGap) {
+      Text("Configure \(provider.displayName)")
+        .font(.sheetTitle)
+
+      Text("Local tasks are stored on this Mac.")
+        .foregroundStyle(.secondary)
+
+      ProviderDefaultListSettings(provider: provider)
+
+      HStack {
+        Spacer()
+        Button("Done") { dismiss() }
+          .keyboardShortcut(.defaultAction)
+      }
+    }
+    .padding(.screenPadding)
+    .frame(minWidth: 360)
+  }
+}

--- a/app/Taskmato/Views/Settings/Obsidian/ObsidianSetupSheet.swift
+++ b/app/Taskmato/Views/Settings/Obsidian/ObsidianSetupSheet.swift
@@ -125,6 +125,8 @@ struct ObsidianSetupSheet: View {
             provider.clearVault()
           }
         }
+
+        ProviderDefaultListSettings(provider: provider)
       } else {
         Text("No vault selected.")
           .foregroundStyle(.secondary)

--- a/app/Taskmato/Views/Settings/Reminders/RemindersSetupSheet.swift
+++ b/app/Taskmato/Views/Settings/Reminders/RemindersSetupSheet.swift
@@ -88,29 +88,33 @@ struct RemindersSetupSheet: View {
 
   @ViewBuilder
   private var authorizedView: some View {
-    RemindersSettingsFieldRow("List patterns") {
-      VStack(alignment: .leading, spacing: .iconLabel) {
-        TextField("e.g. Work*, *Personal*", text: $patternText)
-          .autocorrectionDisabled()
-          .focused($isPatternFocused)
-          .onSubmit { commitPatterns() }
-          .onChange(of: isPatternFocused) { _, focused in
-            if !focused { commitPatterns() }
-          }
+    VStack(alignment: .leading, spacing: .sectionGap) {
+      RemindersSettingsFieldRow("List patterns") {
+        VStack(alignment: .leading, spacing: .iconLabel) {
+          TextField("e.g. Work*, *Personal*", text: $patternText)
+            .autocorrectionDisabled()
+            .focused($isPatternFocused)
+            .onSubmit { commitPatterns() }
+            .onChange(of: isPatternFocused) { _, focused in
+              if !focused { commitPatterns() }
+            }
 
-        if showsListPatternWarning {
-          Label(
-            "No reminder lists match this pattern.",
-            systemImage: "exclamationmark.triangle.fill"
-          )
-          .font(.caption)
-          .foregroundStyle(Color.statusWarning)
-        } else {
-          Text(listSummaryText)
+          if showsListPatternWarning {
+            Label(
+              "No reminder lists match this pattern.",
+              systemImage: "exclamationmark.triangle.fill"
+            )
             .font(.caption)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(Color.statusWarning)
+          } else {
+            Text(listSummaryText)
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
         }
       }
+
+      ProviderDefaultListSettings(provider: provider)
     }
   }
 

--- a/app/Taskmato/Views/Settings/SettingsView.swift
+++ b/app/Taskmato/Views/Settings/SettingsView.swift
@@ -101,7 +101,8 @@ struct SettingsView: View {
           }
         }
         Text(
-          "The provider used when creating ad-hoc tasks from the command line or the Add Task sheet."
+          "Used when the current sidebar context has no writable provider, and by URL or CLI "
+            + "creation when no provider is specified."
         )
         .font(.caption)
         .foregroundStyle(.secondary)

--- a/app/Taskmato/Views/Tasks/AddTaskView.swift
+++ b/app/Taskmato/Views/Tasks/AddTaskView.swift
@@ -16,6 +16,7 @@ import SwiftUI
 struct AddTaskView: View {
 
   var provider: any WritableTaskProvider
+  var destinationResolver: TaskDestinationResolver
   @Binding var isPresented: Bool
   var errorPresenter: ErrorPresenter
   var taskToEdit: TaskItem?
@@ -54,6 +55,12 @@ struct AddTaskView: View {
     VStack(alignment: .leading, spacing: .sectionGap) {
       Text(sheetTitle)
         .font(.sheetTitle)
+
+      if !isEditing {
+        Text("Adding to \(provider.displayName)")
+          .font(.callout)
+          .foregroundStyle(.secondary)
+      }
 
       TextField("Task title", text: $title)
         .textFieldStyle(.roundedBorder)
@@ -169,7 +176,15 @@ struct AddTaskView: View {
     .task {
       taskLists = (try? await provider.lists()) ?? []
       if taskToEdit == nil, selectedListID.isEmpty, let first = taskLists.first {
-        selectedListID = provider.defaultListID ?? first.id
+        if let defaultID = provider.defaultListID {
+          if taskLists.contains(where: { $0.id == defaultID }) {
+            selectedListID = defaultID
+          } else {
+            selectedListID = first.id
+          }
+        } else {
+          selectedListID = first.id
+        }
       }
     }
     .task(id: selectedListID) {
@@ -311,7 +326,11 @@ struct AddTaskView: View {
     } else {
       Task {
         await errorPresenter.attempt(AppLabels.Error.addFailed) {
-          try await provider.addTask(draft)
+          let destination = try await destinationResolver.resolve(
+            providerID: provider.id, listID: draft.listID)
+          var routedDraft = draft
+          routedDraft.listID = destination.listID
+          try await destination.provider.addTask(routedDraft)
         }
         isPresented = false
       }

--- a/app/Taskmato/Views/Tasks/TaskDetailSelection.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailSelection.swift
@@ -170,11 +170,10 @@ extension TaskDetailView {
   /// Returns the writable provider that paste should target without redirecting a read-only list
   /// selection to the default local provider.
   var pasteProvider: (any WritableTaskProvider)? {
-    guard case .list(let sel) = sidebarSelection.selection else {
-      return registry.resolveDefaultWritableProvider(
-        preferredID: settings.defaultWritableProviderID)
+    guard case .list = sidebarSelection.selection else {
+      return destinationResolver.provider()
     }
-    return registry.enabledWritableProvider(id: sel.providerID)
+    return destinationResolver.provider(sidebarSelection: sidebarSelection.selection)
   }
 
   /// The selected list ID to use for paste, only when that list belongs to ``pasteProvider``.
@@ -262,7 +261,11 @@ extension TaskDetailView {
   private func performPaste(_ draft: TaskDraft, provider: any WritableTaskProvider) {
     Task {
       await errorPresenter.attempt(AppLabels.Error.addFailed) {
-        try await provider.addTask(draft)
+        let destination = try await destinationResolver.resolve(
+          providerID: provider.id, listID: draft.listID)
+        var routedDraft = draft
+        routedDraft.listID = destination.listID
+        try await destination.provider.addTask(routedDraft)
       }
       await refresh()
     }

--- a/app/Taskmato/Views/Tasks/TaskDetailView.swift
+++ b/app/Taskmato/Views/Tasks/TaskDetailView.swift
@@ -19,6 +19,7 @@ struct TaskDetailView: View {
   var selectionStore: TaskSelectionStore
   var registry: ProviderRegistry
   var queryService: TaskQueryService
+  var destinationResolver: TaskDestinationResolver
   var sidebarSelection: SelectionStore
   var nav: MainNavigation
   @Bindable var settings: AppSettings
@@ -34,6 +35,7 @@ struct TaskDetailView: View {
   @State var sections: [TaskSection] = []
   @State private var isLoading: Bool = false
   @State private var isAddingTask = false
+  @State private var newTaskDestination: TaskDestination?
   /// Not `private`: `TaskDetailContextMenu.swift`'s "Edit…" item sets this.
   @State var isEditingTask = false
   /// Not `private`: `TaskDetailContextMenu.swift`'s "Edit…" item sets this.
@@ -64,26 +66,10 @@ struct TaskDetailView: View {
   /// `private`: `TaskDetailActions.swift`'s `copyToPasteboard(_:to:)` builds payloads with it.
   let clipboardService = TaskClipboardService()
 
-  /// Returns the writable provider for the current sidebar selection, falling back to the
-  /// default writable provider (from settings, then first enabled in registration order). Not
-  /// `private`: `TaskDetailSelection.swift` uses this to resolve the paste target.
+  /// Returns the writable provider for the current sidebar selection using the shared resolver.
+  /// Not `private`: `TaskDetailSelection.swift` uses this to resolve the paste target.
   var writableProvider: (any WritableTaskProvider)? {
-    guard case .list(let sel) = sidebarSelection.selection,
-      let provider = registry.providers.first(where: {
-        $0.id == sel.providerID && registry.isEnabled($0.id)
-      }),
-      let writable = provider as? (any WritableTaskProvider)
-    else {
-      return registry.resolveDefaultWritableProvider(
-        preferredID: settings.defaultWritableProviderID)
-    }
-    return writable
-  }
-
-  /// The currently selected list to pre-select when creating a task from this detail surface.
-  var selectedListIDForNewTask: String? {
-    guard let provider = writableProvider else { return nil }
-    return sidebarSelection.selection?.listID(matching: provider.id)
+    destinationResolver.provider(sidebarSelection: sidebarSelection.selection)
   }
 
   private var hasClosableProvider: Bool {
@@ -118,15 +104,16 @@ struct TaskDetailView: View {
       .sheet(isPresented: $isAddingTask) {
         if let provider = writableProvider {
           AddTaskView(
-            provider: provider, isPresented: $isAddingTask, errorPresenter: errorPresenter,
-            initialListID: selectedListIDForNewTask)
+            provider: provider, destinationResolver: destinationResolver,
+            isPresented: $isAddingTask, errorPresenter: errorPresenter,
+            initialListID: newTaskDestination?.listID)
         }
       }
       .sheet(isPresented: $isEditingTask) {
         if let task = taskToEdit, let provider = registry.writableProvider(for: task.id) {
           AddTaskView(
-            provider: provider, isPresented: $isEditingTask, errorPresenter: errorPresenter,
-            taskToEdit: task)
+            provider: provider, destinationResolver: destinationResolver,
+            isPresented: $isEditingTask, errorPresenter: errorPresenter, taskToEdit: task)
         }
       }
       .toolbar {
@@ -135,7 +122,7 @@ struct TaskDetailView: View {
         if writableProvider != nil {
           ToolbarItem(placement: .automatic) {
             Button {
-              isAddingTask = true
+              Task { await prepareNewTask() }
             } label: {
               Label(AppLabels.Task.add.title, systemImage: AppLabels.Task.add.systemImage)
             }
@@ -178,7 +165,10 @@ struct TaskDetailView: View {
       }
       .focusedSceneValue(\.taskViewActive, true)
       .focusedSceneValue(\.focusSearch, { isSearchFocused = true })
-      .focusedSceneValue(\.addTask, writableProvider != nil ? { isAddingTask = true } : nil)
+      .focusedSceneValue(
+        \.addTask,
+        writableProvider != nil ? { Task { await prepareNewTask() } } : nil
+      )
       .focusedSceneValue(
         \.toggleCompleted,
         hasClosableProvider
@@ -195,6 +185,16 @@ struct TaskDetailView: View {
         \.toggleCompletedIcon,
         hasClosableProvider ? completedToggleSpec.systemImage : nil
       )
+  }
+
+  private func prepareNewTask() async {
+    do {
+      newTaskDestination = try await destinationResolver.resolve(
+        sidebarSelection: sidebarSelection.selection)
+      isAddingTask = true
+    } catch {
+      errorPresenter.present(title: AppLabels.Error.addFailed, error: error)
+    }
   }
 
   /// The detail content plus search and change-tracking modifiers.
@@ -557,10 +557,11 @@ extension TaskDetailView {
     let registry = ProviderRegistry()
     let settings = AppSettings()
     let selectionStore = SelectionStore(registry: registry)
-    return TaskDetailView(
+    TaskDetailView(
       selectionStore: TaskSelectionStore(),
       registry: registry,
       queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
+      destinationResolver: TaskDestinationResolver(registry: registry, settings: settings),
       sidebarSelection: selectionStore,
       nav: MainNavigation(
         settings: settings, selectionStore: selectionStore, statsViewModel: .preview),

--- a/app/TaskmatoTests/ObsidianProviderWritableTests.swift
+++ b/app/TaskmatoTests/ObsidianProviderWritableTests.swift
@@ -106,6 +106,17 @@ struct ObsidianProviderWritableTests {
     #expect(item.list?.id == "tasks.md")
   }
 
+  @Test func addTaskFallsBackToFirstMatchingListWhenNoDefaultExists() async throws {
+    let vault = try makeVault()
+    defer { try? FileManager.default.removeItem(at: vault) }
+    try write("- [ ] Existing", at: "tasks.md", in: vault)
+    let provider = makeProvider(vaultURL: vault)
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    let item = try await provider.addTask(draft)
+    #expect(item.list?.id == "tasks.md")
+  }
+
   @Test func addTaskThrowsWhenNoListResolves() async throws {
     let vault = try makeVault()
     defer { try? FileManager.default.removeItem(at: vault) }

--- a/app/TaskmatoTests/RemindersProviderWritableTests.swift
+++ b/app/TaskmatoTests/RemindersProviderWritableTests.swift
@@ -96,6 +96,19 @@ struct RemindersProviderWritableTests {
     #expect(item.list?.id == work.calendarIdentifier)
   }
 
+  @Test func addTaskFallsBackToFirstVisibleListWhenSystemDefaultIsFiltered() async throws {
+    let (provider, store) = try await makeAuthorizedProvider()
+    let work = store.makeCalendar(title: "Work")
+    let personal = store.makeCalendar(title: "Personal")
+    store.stubbedCalendars = [work, personal]
+    store.stubbedDefaultCalendar = work
+    provider.setListPatterns(["Personal"])
+    var draft = TaskDraft()
+    draft.title = "Buy milk"
+    let item = try await provider.addTask(draft)
+    #expect(item.list?.id == personal.calendarIdentifier)
+  }
+
   @Test func addTaskThrowsWhenNoListResolves() async throws {
     let (provider, _) = try await makeAuthorizedProvider()
     var draft = TaskDraft()

--- a/app/TaskmatoTests/TaskDestinationResolverTests.swift
+++ b/app/TaskmatoTests/TaskDestinationResolverTests.swift
@@ -1,0 +1,187 @@
+//
+//  TaskDestinationResolverTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+private final class ResolverWritableProvider: WritableTaskProvider {
+  let id: ProviderID
+  let displayName: String
+  let icon = "square"
+  let entitlement: ProviderEntitlement = .free
+  let contentFormat: ContentFormat = .plainText
+  var defaultListID: String?
+  var availableLists: [TaskList]
+
+  init(
+    id: ProviderID, lists: [TaskList], defaultListID: String? = nil
+  ) {
+    self.id = id
+    self.displayName = id.rawValue
+    self.availableLists = lists
+    self.defaultListID = defaultListID
+  }
+
+  func authorize() async throws {}
+  func lists() async throws -> [TaskList] { availableLists }
+  func tasks(in _: TaskList?) async throws -> [TaskItem] { [] }
+  func observe() -> AsyncStream<[TaskItem]>? { nil }
+  func complete(_: TaskRef) async throws {}
+  func reopen(_: TaskRef) async throws {}
+
+  @discardableResult
+  func addTask(_ draft: TaskDraft) async throws -> TaskItem {
+    TaskItem(
+      id: TaskRef(providerID: id, nativeID: UUID().uuidString), title: draft.title,
+      notes: draft.notes, format: contentFormat, priority: draft.priority,
+      dueDate: draft.dueDate, dueDateIncludesTime: draft.dueDateIncludesTime,
+      scheduledDate: nil, startDate: nil,
+      list: availableLists.first { $0.id == draft.listID }, section: draft.section, sourceURL: nil)
+  }
+
+  func setDefaultList(_ listID: String) async throws { defaultListID = listID }
+  func updateTask(_: TaskRef, draft _: TaskDraft) async throws {}
+  func deleteTask(_: TaskRef) async throws {}
+}
+
+@MainActor
+struct TaskDestinationResolverTests {
+
+  private struct ResolverContext {
+    let registry: ProviderRegistry
+    let settings: AppSettings
+  }
+
+  private func makeContext() -> ResolverContext {
+    let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    let store = SettingsStore(defaults: defaults)
+    return ResolverContext(
+      registry: ProviderRegistry(store: store), settings: AppSettings(store: store))
+  }
+
+  private func makeList(_ id: String, providerID: ProviderID, name: String? = nil) -> TaskList {
+    TaskList(id: id, providerID: providerID, name: name ?? id)
+  }
+
+  @Test func explicitProviderAndListWin() async throws {
+    let context = makeContext()
+    let first = ResolverWritableProvider(
+      id: "first", lists: [makeList("first-list", providerID: "first")])
+    let second = ResolverWritableProvider(
+      id: "second", lists: [makeList("second-list", providerID: "second")])
+    context.registry.register(first)
+    context.registry.register(second)
+    context.registry.enable(first)
+    context.registry.enable(second)
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    let destination = try await resolver.resolve(
+      providerID: second.id, listID: "second-list",
+      sidebarSelection: .list(
+        SelectedList(providerID: first.id, listID: "first-list")))
+
+    #expect(destination.provider.id == second.id)
+    #expect(destination.listID == "second-list")
+  }
+
+  @Test func sidebarProviderAndListAreUsedBeforeSettings() async throws {
+    let context = makeContext()
+    let sidebarProvider = ResolverWritableProvider(
+      id: "sidebar", lists: [makeList("sidebar-list", providerID: "sidebar")])
+    let settingsProvider = ResolverWritableProvider(
+      id: "settings", lists: [makeList("settings-list", providerID: "settings")])
+    context.registry.register(sidebarProvider)
+    context.registry.register(settingsProvider)
+    context.registry.enable(sidebarProvider)
+    context.registry.enable(settingsProvider)
+    context.settings.defaultWritableProviderID = settingsProvider.id
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    let destination = try await resolver.resolve(
+      sidebarSelection: .list(
+        SelectedList(providerID: sidebarProvider.id, listID: "sidebar-list")))
+
+    #expect(destination.provider.id == sidebarProvider.id)
+    #expect(destination.listID == "sidebar-list")
+  }
+
+  @Test func settingsProviderWinsBeforeProviderOrder() async throws {
+    let context = makeContext()
+    let first = ResolverWritableProvider(
+      id: "first", lists: [makeList("first-list", providerID: "first")])
+    let preferred = ResolverWritableProvider(
+      id: "preferred", lists: [makeList("preferred-list", providerID: "preferred")])
+    context.registry.register(first)
+    context.registry.register(preferred)
+    context.registry.enable(first)
+    context.registry.enable(preferred)
+    context.settings.defaultWritableProviderID = preferred.id
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    let destination = try await resolver.resolve()
+
+    #expect(destination.provider.id == preferred.id)
+    #expect(destination.listID == "preferred-list")
+  }
+
+  @Test func invalidDefaultFallsBackToFirstAvailableList() async throws {
+    let context = makeContext()
+    let provider = ResolverWritableProvider(
+      id: "provider",
+      lists: [
+        makeList("first", providerID: "provider"), makeList("second", providerID: "provider"),
+      ],
+      defaultListID: "deleted")
+    context.registry.register(provider)
+    context.registry.enable(provider)
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    let destination = try await resolver.resolve()
+
+    #expect(destination.listID == "first")
+  }
+
+  @Test func listNameUsesCaseInsensitiveMatchAndUnmatchedNameFallsBack() async throws {
+    let context = makeContext()
+    let provider = ResolverWritableProvider(
+      id: "provider", lists: [makeList("work", providerID: "provider", name: "Work")],
+      defaultListID: "work")
+    context.registry.register(provider)
+    context.registry.enable(provider)
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    let matched = try await resolver.resolve(listName: "work")
+    let unmatched = try await resolver.resolve(listName: "Missing")
+
+    #expect(matched.listID == "work")
+    #expect(unmatched.listID == "work")
+  }
+
+  @Test func noWritableProviderThrowsTypedError() async {
+    let context = makeContext()
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    await #expect(throws: TaskDestinationResolutionError.noWritableProvider) {
+      try await resolver.resolve()
+    }
+  }
+
+  @Test func noAvailableListThrowsProviderScopedError() async {
+    let context = makeContext()
+    let provider = ResolverWritableProvider(id: "provider", lists: [])
+    context.registry.register(provider)
+    context.registry.enable(provider)
+    let resolver = TaskDestinationResolver(registry: context.registry, settings: context.settings)
+
+    await #expect(
+      throws: TaskDestinationResolutionError.noAvailableList(
+        providerID: provider.id, providerName: provider.displayName)
+    ) {
+      try await resolver.resolve()
+    }
+  }
+}

--- a/app/TaskmatoTests/URLSchemeHandlerTests.swift
+++ b/app/TaskmatoTests/URLSchemeHandlerTests.swift
@@ -45,7 +45,7 @@ private final class StubWritableProvider: WritableTaskProvider {
   let displayName: String
   let icon: String = "square"
   let entitlement: ProviderEntitlement = .free
-  let defaultListID: String? = nil
+  let defaultListID: String? = "default"
   let contentFormat: ContentFormat = .markdown
 
   init(id: ProviderID) {
@@ -54,7 +54,9 @@ private final class StubWritableProvider: WritableTaskProvider {
   }
 
   nonisolated func authorize() async throws {}
-  func lists() async throws -> [TaskList] { [] }
+  func lists() async throws -> [TaskList] {
+    [TaskList(id: "default", providerID: id, name: "Default")]
+  }
   func tasks(in _: TaskList?) async throws -> [TaskItem] { [] }
   func observe() -> AsyncStream<[TaskItem]>? { nil }
   func complete(_: TaskRef) async throws {}
@@ -128,6 +130,7 @@ struct URLSchemeHandlerTests {
     }
 
     let errorPresenter = ErrorPresenter()
+    let destinationResolver = TaskDestinationResolver(registry: registry, settings: settings)
     let handler = URLSchemeHandler(
       registry: registry,
       queryService: TaskQueryService(registry: registry, sorter: TaskSorter()),
@@ -138,7 +141,8 @@ struct URLSchemeHandlerTests {
         settings: settings,
         selectionStore: SelectionStore(registry: registry, store: settingsStore),
         statsViewModel: .preview),
-      errorPresenter: errorPresenter
+      errorPresenter: errorPresenter,
+      destinationResolver: destinationResolver
     )
     return HandlerContext(
       handler: handler,

--- a/docs/architecture/design/0012-task-destination-resolution-and-provider-settings.md
+++ b/docs/architecture/design/0012-task-destination-resolution-and-provider-settings.md
@@ -1,0 +1,326 @@
+# Task destination resolution and provider settings
+
+## Status
+
+Proposed — awaiting review. No implementation is authorized by this document alone.
+
+## Summary
+
+Introduce one app-level `TaskDestinationResolver` for selecting the writable provider and list used
+by newly created tasks. Standardize the behavior when `TaskDraft.listID` is `nil`, and move the
+provider-local default-list setting out of the per-list star affordance into provider configuration
+sheets.
+
+The proposed design has two separable implementation slices:
+
+1. Centralize destination resolution and make all Taskmato creation routes use it.
+2. Replace the sidebar's per-list star with a provider-scoped configuration control.
+
+The current star UI should remain unchanged until the resolver contract is approved and implemented.
+
+## Background
+
+Taskmato currently makes two independent decisions when creating a task:
+
+1. Which enabled writable provider receives it.
+2. Which list within that provider receives it.
+
+Those decisions are distributed across `TaskDetailView`, `AddTaskView`, clipboard paste handling,
+`URLSchemeHandler`, and each provider's implementation of `addTask`.
+
+This produces route-dependent behavior:
+
+- The Add Task sheet falls back to the first visible list when a provider has no default.
+- Clipboard paste passes `nil` and delegates to the provider.
+- LocalProvider falls back to its first list.
+- ObsidianProvider fails when no default file has been selected.
+- RemindersProvider uses EventKit's system default calendar.
+
+The sidebar star also represents a provider-local setting, but appears on every list row. With
+multiple writable providers enabled, several stars can be active simultaneously, which makes the
+control look like a global task destination or a favorite marker rather than a per-provider default.
+
+## Goals
+
+- Give every app-created task one predictable provider/list resolution policy.
+- Make `draft.listID == nil` behave consistently across writable providers.
+- Preserve explicit provider and list choices when a route supplies them.
+- Preserve provider-native defaults where they exist, while providing a deterministic first-list
+  fallback when no default is available.
+- Make the provider/list destination visible and understandable in the Add Task experience.
+- Move default-list configuration to a provider-scoped settings surface.
+- Keep URL and CLI creation deterministic and provide actionable errors when no destination exists.
+
+## Non-goals
+
+- Changing the task provider protocol hierarchy.
+- Adding a new persistence technology or dependency.
+- Changing the meaning of the Settings → Default writable provider preference.
+- Changing how existing tasks are searched, selected, or attributed to focus sessions.
+- Adding list lifecycle management to RemindersProvider or ObsidianProvider.
+- Redesigning the entire sidebar navigation structure.
+
+## Proposed decision
+
+### 1. Add an app-level destination resolver
+
+Add `TaskDestinationResolver` under `app/Taskmato/Tasks/Registry/`. It should be a main-actor
+service that depends on `ProviderRegistry` and `AppSettings`, but not on SwiftUI.
+
+The resolver returns a provider plus a resolved list target:
+
+```swift
+struct TaskDestination {
+  let provider: any WritableTaskProvider
+  let listID: String
+}
+```
+
+The normal successful result always contains a list ID. A missing list is represented by a typed
+resolution error, not by silently passing `nil` through an app creation route.
+
+Provider resolution order:
+
+1. An explicitly requested provider that is enabled and writable.
+2. The current writable sidebar provider, for interactive task creation.
+3. `AppSettings.defaultWritableProviderID` when enabled and writable.
+4. The first enabled writable provider in `ProviderRegistry.providers` order.
+5. A typed `noWritableProvider` error.
+
+An invalid or disabled explicit URL provider continues to fall through to the settings/default
+provider, preserving the current URL behavior.
+
+List resolution order within the selected provider:
+
+1. An explicit list ID supplied by a UI action or already resolved from a URL list name.
+2. The current sidebar list when it belongs to the selected provider.
+3. The provider's `defaultListID` when it identifies a currently available list.
+4. The first currently available list returned by `provider.lists()`.
+5. A typed `noAvailableList` error.
+
+The resolver must validate list IDs against the current list collection. This prevents stale
+provider defaults, filtered Reminders calendars, or deleted Obsidian files from being submitted as
+valid destinations.
+
+### 2. Standardize provider behavior for `draft.listID == nil`
+
+The provider protocol continues to allow `draft.listID` to be `nil`, but all writable providers
+should implement the same fallback contract:
+
+1. Use the provider's effective default list, including a native system default when applicable.
+2. If no effective default exists, use the first available provider list.
+3. If no list exists, throw a provider-specific error describing that no list is available.
+
+Normal Taskmato app routes should resolve a list before calling `addTask`. The provider-level
+fallback remains defensive for direct protocol callers, tests, and future integrations.
+
+Expected provider behavior:
+
+- `LocalProvider`: retain first-list fallback and await initial loading before mutating.
+- `RemindersProvider`: use the EventKit default when valid; otherwise use the first list visible
+  through the provider's current list policy.
+- `ObsidianProvider`: use the configured default file; otherwise use the first matching markdown
+  file instead of failing solely because no default file was selected.
+
+### 3. Use the resolver from every creation route
+
+#### Main window New Task, `⌘N`, and File → New Task
+
+- Use the current writable sidebar list when one is selected.
+- Otherwise resolve the provider from Settings and the provider order fallback.
+- Preselect the resolver's list in `AddTaskView`.
+- Keep the list picker so the user can override the resolved destination.
+
+#### Sidebar list context menu → Add Task…
+
+- Pass the clicked provider and list as explicit destination input.
+- The default-list setting is not consulted unless the clicked list becomes invalid before submit.
+
+#### Clipboard paste
+
+- Use the current writable sidebar list when available.
+- Otherwise use the same provider and list fallback as New Task.
+- Remove the current divergence where paste passes `nil` while Add Task preselects the first list.
+- Preserve the existing behavior that paste is disabled on a read-only list rather than silently
+  redirecting content to another provider.
+
+#### `taskmato://` and `scripts/taskmato.sh`
+
+- Resolve provider using `provider=`, Settings, and the enabled-provider fallback.
+- Resolve `list=<name>` against the selected provider's current lists.
+- When no list is supplied or the name cannot be resolved, use the provider default, then first
+  available list according to the shared policy.
+- Surface a provider-specific, actionable error when no list exists, including guidance to pass
+  `--list` for CLI callers.
+- Preserve the existing distinction between resolving an existing task and creating an ad-hoc task.
+
+#### URL disambiguation → Create new
+
+- Reuse the same `URLSchemeHandler.makeAdHocTask` resolver path without a second fallback policy.
+
+There is no task-creation route in the menu-bar popover today; it only routes users to the main
+window task surface. No new menu-bar creation affordance is proposed here.
+
+### 4. Move default-list configuration to provider settings
+
+Remove the trailing star button from each sidebar list row. The default list is a property of the
+provider, so expose it in a provider-scoped configuration sheet instead:
+
+```text
+Configure Local
+
+Task creation
+  Default list: Work
+```
+
+The same common task-creation section should appear in the existing Obsidian and Apple Reminders
+configuration sheets. The sheet's provider name supplies the missing scope that the current star
+cannot communicate.
+
+LocalProvider should conform to `ConfigurableTaskProvider` with `needsConfiguration == false`.
+This makes `Configure Local…` available from the provider header without automatically presenting a
+sheet when Local is enabled. The protocol documentation should describe both setup and settings,
+not only required first-run configuration.
+
+The list context menu may retain a secondary quick action, but its wording must include the provider:
+
+```text
+Set as Default List for Local
+```
+
+This preserves a fast path for users who are already acting on a specific list without restoring
+the ambiguous row-level star.
+
+If an icon is retained for the provider settings control, `arrow.down.to.line` may reinforce the
+idea of a destination, but the visible label and accessibility label must carry the provider scope.
+No icon should be treated as self-explanatory.
+
+## UX behavior after the change
+
+The Add Task sheet should expose both routing levels before submission:
+
+```text
+Adding to: Apple Reminders
+List: Personal
+```
+
+The provider shown is the resolved provider. The list picker starts at the resolved list but remains
+editable. This makes the Settings provider preference, sidebar selection, and provider-local
+default list understandable as separate layers.
+
+The global Settings description should be revised to explain that the preferred writable provider
+is used when the current sidebar context does not identify a writable provider, and by URL/CLI
+creation when no explicit provider is supplied.
+
+## Alternatives considered
+
+### Keep the star and only improve its wording
+
+Rejected as the primary design. Better labels would help, but multiple active stars still imply a
+global favorite/default model and keep provider configuration attached to individual list rows.
+
+### Put the default list in global Settings only
+
+Rejected. The setting is provider-local and its available choices depend on provider-specific list
+loading, authorization, filtering, or vault state. A provider sheet gives the setting the correct
+scope.
+
+### Remove configurable default lists entirely and always use the first list
+
+Rejected for now. Native Reminders defaults and user-selected preferred lists are useful behavior,
+especially for URL and CLI automation. The resolver should make the fallback deterministic without
+discarding the preference.
+
+### Let each provider retain independent nil-list behavior
+
+Rejected for app-created tasks. It is the direct cause of Local and Obsidian behaving differently
+for the same logical request. Provider-specific implementations may retain defensive fallbacks,
+but app routes must share one resolution policy.
+
+## Implementation plan
+
+### Slice A — Resolver contract and provider fallback
+
+Affected paths:
+
+- Add `app/Taskmato/Tasks/Registry/TaskDestinationResolver.swift`.
+- Add `app/TaskmatoTests/TaskDestinationResolverTests.swift`.
+- Update `app/Taskmato/Tasks/Local/LocalProvider.swift` to await readiness before direct mutation.
+- Update `app/Taskmato/Tasks/Obsidian/ObsidianProvider+Writable.swift` for first-list fallback.
+- Update `app/Taskmato/Tasks/Reminders/RemindersProvider.swift` for validated first-list fallback.
+
+Tests must cover explicit provider/list, current sidebar scope, Settings provider fallback, first
+enabled writable fallback, invalid defaults, no providers, no lists, and all three built-in
+providers when `draft.listID` is `nil`.
+
+### Slice B — Adopt resolver in creation routes
+
+Affected paths:
+
+- `app/Taskmato/Views/Tasks/TaskDetailView.swift`
+- `app/Taskmato/Views/Tasks/AddTaskView.swift`
+- `app/Taskmato/Views/Tasks/TaskDetailSelection.swift`
+- `app/Taskmato/Tasks/URLScheme/URLSchemeHandler.swift`
+- `app/TaskmatoTests/URLSchemeHandlerTests.swift`
+- `app/TaskmatoTests/TaskClipboardServiceTests.swift`
+
+Remove duplicated provider/list fallback logic from callers. Preserve explicit list selection from
+the sidebar context menu and preserve read-only paste behavior.
+
+### Slice C — Provider configuration surface
+
+Affected paths:
+
+- Add `app/Taskmato/Views/Settings/Local/LocalProvider+Configuration.swift`.
+- Add `app/Taskmato/Views/Settings/Local/LocalSettingsSheet.swift`.
+- Add a shared default-list settings component under
+  `app/Taskmato/Views/Settings/Components/`.
+- Update the existing Obsidian and Reminders configuration sheets to include the shared component.
+- Broaden `app/Taskmato/Tasks/ConfigurableTaskProvider.swift` documentation from setup-only to
+  setup/settings.
+
+The Local sheet must not auto-present on provider enable because Local has no required setup.
+
+### Slice D — Sidebar affordance change
+
+Affected paths:
+
+- `app/Taskmato/Views/App/AppSidebarView.swift`
+- `app/Taskmato/Views/Tasks/Components/TaskLabel.swift`
+- Sidebar/design documentation describing the star affordance.
+
+Remove the row-level star, add `Configure Local…` through the common configurable-provider path,
+and update the context-menu action to include the provider name if it remains.
+
+## Verification criteria
+
+- [ ] New Task, `⌘N`, File → New Task, sidebar Add Task, Paste, URL, CLI, and URL disambiguation
+      use the same provider/list resolution policy.
+- [ ] A writable provider with no configured default uses its first available list in app-created
+      tasks.
+- [ ] Local, Reminders, and Obsidian no longer diverge solely because `draft.listID` is `nil`.
+- [ ] A missing provider or missing list produces an actionable error naming the relevant scope.
+- [ ] Explicit provider and list selections always take precedence over defaults.
+- [ ] Add Task visibly identifies the resolved provider and preselects the resolved list.
+- [ ] The sidebar no longer presents multiple ambiguous global-looking stars.
+- [ ] Every provider configuration sheet exposes its provider-local default-list setting.
+- [ ] Enabling Local does not automatically open a configuration sheet.
+- [ ] `make sync-version` succeeds before builds.
+- [ ] `make lint`, `make format-check`, and `make test` pass.
+
+## Review decisions requested
+
+1. Approve the first-list fallback as the uniform behavior when a provider has no configured
+   default.
+2. Approve moving the default-list control from list rows into provider configuration sheets.
+3. Approve retaining a provider-qualified context-menu shortcut after removing the star.
+4. Confirm whether an unresolved URL `list=` name should continue falling back or become a strict
+   error in a later URL-specific follow-up.
+
+## Related architecture
+
+- [ADR-0001 — Pluggable task providers](../decisions/0001-pluggable-task-providers.md)
+- [ADR-0003 — NavigationSplitView sidebar](../decisions/0003-navigation-split-view-sidebar.md)
+- [ADR-0008 — Split TaskRegistry](../decisions/0008-split-task-registry.md)
+- [ADR-0011 — List management protocol split](../decisions/0011-list-management-protocol-split.md)
+- [Design 0002 — Provider sidebar revisited](0002-provider-sidebar-revisited.md)


### PR DESCRIPTION
## Summary
Centralize task destination selection so new tasks consistently resolve their writable provider and list, while replacing the ambiguous sidebar default-list star with provider-scoped configuration.

## Linked issue

Closes #559

## Approach

- Add a global `TaskDestinationResolver` used by in-app creation, paste, URL, and CLI-backed task creation.
- Resolve destinations by explicit provider/list, sidebar context, configured provider preference, provider default, and first available list.
- Align Local, Obsidian, and Reminders behavior when `draft.listID` is nil.
- Add Local provider configuration and shared default-list controls to provider sheets.
- Replace the sidebar star affordance with a provider-qualified context-menu action.
- Add resolver and provider fallback tests plus architecture documentation.

## Out of scope

Provider-specific URL formats, new permissions, and changes to the timer state machine are out of scope.

## Validation

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [ ] Manually verified the new behavior
- [x] Documentation updated where appropriate

## Release / deploy impact

- [ ] Preview deploy is useful for reviewing this change
- [ ] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

`make sync-version`, `make lint`, `make format-check`, and `make build` pass. The latest full test run compiled successfully and all unit tests passed; one UI smoke test failed because Xcode could not terminate a stale Taskmato process.