### PR TITLE
feat(stats): snapshot provider label and tint onto focus segments

### DIFF
--- a/app/Taskmato/AppComposition.swift
+++ b/app/Taskmato/AppComposition.swift
@@ -193,23 +193,30 @@ struct AppComposition {
 
   /// Builds the phase-end orchestrator (and its ``FocusAttribution`` collaborator) and
   /// launches the orchestrator, fire-and-forget, for the app's lifetime.
+  ///
+  /// `inputs.registry` resolves each focus slice's owning provider's label and tint, snapshotted
+  /// onto the slice at close (ADR-0010, D4).
   private static func makePhaseOrchestrator(
-    engine: SessionEngine, store: SessionStore, settings: AppSettings,
-    selectionStore: TaskSelectionStore, notifications: NotificationService
+    _ inputs: RuntimeInputs
   ) -> (orchestrator: PhaseOrchestrator, attribution: FocusAttribution) {
-    let attribution = FocusAttribution()
+    let registry = inputs.registry
+    let attribution = FocusAttribution(cosmetics: { [registry] providerID in
+      guard let provider = registry.providers.first(where: { $0.id == providerID }) else {
+        return nil
+      }
+      return (provider.displayName, provider.tint)
+    })
     let orchestrator = PhaseOrchestrator(
-      events: engine.phaseEvents, engine: engine, store: store, settings: settings,
-      selectionStore: selectionStore, notifications: notifications, attribution: attribution)
+      events: inputs.engine.phaseEvents, engine: inputs.engine, store: inputs.store,
+      settings: inputs.settings, selectionStore: inputs.selectionStore,
+      notifications: inputs.notifications, attribution: attribution)
     Task { await orchestrator.run() }
     return (orchestrator, attribution)
   }
 
   /// Builds the phase and active-task runtime services that share registry and navigation wiring.
   private static func makeRuntime(_ inputs: RuntimeInputs) -> RuntimeServices {
-    let (phaseOrchestrator, focusAttribution) = Self.makePhaseOrchestrator(
-      engine: inputs.engine, store: inputs.store, settings: inputs.settings,
-      selectionStore: inputs.selectionStore, notifications: inputs.notifications)
+    let (phaseOrchestrator, focusAttribution) = Self.makePhaseOrchestrator(inputs)
     Self.wireFocusHandoff(
       engine: inputs.engine, settings: inputs.settings, nav: inputs.nav,
       selectionStore: inputs.selectionStore,

--- a/app/Taskmato/Session/FocusAttribution.swift
+++ b/app/Taskmato/Session/FocusAttribution.swift
@@ -5,6 +5,10 @@
 
 import Foundation
 
+/// Resolves a provider's display cosmetics for the snapshot written onto each closed slice.
+/// Returns `nil` when the provider is not registered.
+typealias ProviderCosmeticsResolver = (ProviderID) -> (label: String, tint: ProviderTint)?
+
 /// Task-agnostic breakpoint log that partitions one focus phase's consumed time into per-task
 /// ``FocusSegment`` values (D4 of design doc 0010).
 ///
@@ -31,12 +35,20 @@ final class FocusAttribution {
 
   private var breakpoints: [Breakpoint] = []
 
+  private let cosmetics: ProviderCosmeticsResolver
+
   /// `true` while a focus phase is seeded and not yet finished.
   private(set) var isLive = false
 
   /// Invoked synchronously whenever a slice closes mid-phase (a task change while live), with
   /// the newly closed segment. ``PhaseOrchestrator`` uses this to upsert the durable draft.
   var onSliceClosed: ((FocusSegment) -> Void)?
+
+  /// - Parameter cosmetics: Resolves the provider label and tint snapshotted onto each closed
+  ///   slice (ADR-0010, D4). Defaults to no snapshot, leaving both fields `nil`.
+  init(cosmetics: @escaping ProviderCosmeticsResolver = { _ in nil }) {
+    self.cosmetics = cosmetics
+  }
 
   /// Seeds the log for a freshly begun focus phase with the task active at that moment.
   /// - Parameter task: The active task when the phase began, or `nil` for untracked focus.
@@ -60,9 +72,7 @@ final class FocusAttribution {
     breakpoints.append(Breakpoint(consumedSeconds: consumedSeconds, task: task))
     let seconds = consumedSeconds - last.consumedSeconds
     guard seconds > 0 else { return }
-    onSliceClosed?(
-      FocusSegment(
-        id: UUID(), taskRef: last.task?.id, taskTitle: last.task?.title, seconds: seconds))
+    onSliceClosed?(segment(for: last.task, seconds: seconds))
   }
 
   /// Resolves the full breakpoint log into segments and clears the log for the next phase.
@@ -80,11 +90,16 @@ final class FocusAttribution {
         index + 1 < breakpoints.count ? breakpoints[index + 1].consumedSeconds : consumedSeconds
       let seconds = end - breakpoint.consumedSeconds
       guard seconds > 0 else { continue }
-      segments.append(
-        FocusSegment(
-          id: UUID(), taskRef: breakpoint.task?.id, taskTitle: breakpoint.task?.title,
-          seconds: seconds))
+      segments.append(segment(for: breakpoint.task, seconds: seconds))
     }
     return segments
+  }
+
+  /// Builds a slice, snapshotting the owning provider's cosmetics when it resolves.
+  private func segment(for task: TaskItem?, seconds: TimeInterval) -> FocusSegment {
+    let snapshot = task.flatMap { cosmetics($0.id.providerID) }
+    return FocusSegment(
+      id: UUID(), taskRef: task?.id, taskTitle: task?.title, seconds: seconds,
+      providerLabel: snapshot?.label, providerTint: snapshot?.tint)
   }
 }

--- a/app/Taskmato/Session/Session.swift
+++ b/app/Taskmato/Session/Session.swift
@@ -22,6 +22,33 @@ nonisolated struct FocusSegment: Codable, Sendable, Identifiable, Equatable {
 
   /// Focus seconds attributed to this slice.
   let seconds: TimeInterval
+
+  /// Provider display name captured at slice close, so ported or synced stats render the real
+  /// name with the provider absent (ADR-0010, D4).
+  ///
+  /// `nil` for untracked focus, for a provider missing from the registry at capture time, and
+  /// for records written before D4.
+  let providerLabel: String?
+
+  /// Provider semantic tint captured at slice close; `nil` under the same conditions as
+  /// ``providerLabel``.
+  let providerTint: ProviderTint?
+
+  /// Creates a focus slice.
+  /// - Parameters:
+  ///   - providerLabel: Provider display-name snapshot; omit when the provider does not resolve.
+  ///   - providerTint: Provider tint snapshot; omit when the provider does not resolve.
+  init(
+    id: UUID, taskRef: TaskRef?, taskTitle: String?, seconds: TimeInterval,
+    providerLabel: String? = nil, providerTint: ProviderTint? = nil
+  ) {
+    self.id = id
+    self.taskRef = taskRef
+    self.taskTitle = taskTitle
+    self.seconds = seconds
+    self.providerLabel = providerLabel
+    self.providerTint = providerTint
+  }
 }
 
 /// An immutable record of a single Pomodoro phase.

--- a/app/Taskmato/Tasks/Models/ProviderTint.swift
+++ b/app/Taskmato/Tasks/Models/ProviderTint.swift
@@ -10,7 +10,10 @@ import Foundation
 /// A plain, Foundation-only token — the sibling of ``TaskProvider/icon`` — so the `Tasks`
 /// layer carries provider visual identity without importing SwiftUI. The Stats views map
 /// each case to a `Color`; focus time with no provider falls back to ``gray``.
-enum ProviderTint: Equatable, Sendable {
+///
+/// `String`-backed and `Codable` so the ``FocusSegment`` provider-cosmetics snapshot
+/// (ADR-0010, D4) has a stable on-disk representation independent of case ordering.
+nonisolated enum ProviderTint: String, Codable, Equatable, Sendable {
 
   /// Blue accent.
   case blue
@@ -26,4 +29,17 @@ enum ProviderTint: Equatable, Sendable {
 
   /// Neutral gray, used for untracked focus time and providers with no explicit tint.
   case gray
+}
+
+extension ProviderTint {
+
+  /// Decodes leniently, mapping an unrecognized raw value to ``gray``.
+  ///
+  /// A record written by a newer build may carry a tint case this build has never seen.
+  /// Segments decode as an array, so throwing here would discard a whole record's focus
+  /// attribution rather than a single swatch.
+  nonisolated init(from decoder: any Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ProviderTint(rawValue: raw) ?? .gray
+  }
 }

--- a/app/Taskmato/Views/Stats/StatsViewModel.swift
+++ b/app/Taskmato/Views/Stats/StatsViewModel.swift
@@ -98,13 +98,15 @@ final class StatsViewModel {
       }
     }
 
+    let snapshots = providerSnapshots
     return
       order
       .compactMap { key -> DayTotal? in
         guard let entry = accumulated[key] else { return nil }
         return DayTotal(
           day: entry.day, providerID: entry.providerID,
-          tint: displayTint(for: entry.providerID), minutes: Int(entry.seconds / 60))
+          tint: displayTint(for: entry.providerID, in: snapshots), minutes: Int(entry.seconds / 60)
+        )
       }
       .sorted { ($0.day, $0.providerID) < ($1.day, $1.providerID) }
   }
@@ -124,13 +126,14 @@ final class StatsViewModel {
       }
     }
 
+    let snapshots = providerSnapshots
     return
       order
       .map { providerID in
         ProviderSlice(
           providerID: providerID,
-          label: displayLabel(for: providerID),
-          tint: displayTint(for: providerID),
+          label: displayLabel(for: providerID, in: snapshots),
+          tint: displayTint(for: providerID, in: snapshots),
           minutes: Int((accumulated[providerID] ?? 0) / 60))
       }
       .sorted { $0.minutes > $1.minutes }
@@ -142,6 +145,7 @@ final class StatsViewModel {
   var allTaskRows: [AllTimeTaskRow] {
     var order: [String] = []
     var accumulated: [String: TaskBucket] = [:]
+    let snapshots = providerSnapshots
 
     for session in sessions where session.phase == .focus {
       for segment in session.segments {
@@ -166,7 +170,8 @@ final class StatsViewModel {
       order
       .compactMap { key -> AllTimeTaskRow? in
         guard let entry = accumulated[key] else { return nil }
-        let resolvedLabel = entry.taskRef.map { providerLabel($0.providerID.rawValue) } ?? "—"
+        let resolvedLabel =
+          entry.taskRef.map { displayLabel(for: $0.providerID.rawValue, in: snapshots) } ?? "—"
         return AllTimeTaskRow(
           taskRef: entry.taskRef, title: entry.title, providerLabel: resolvedLabel,
           totalMinutes: Int(entry.seconds / 60), lastSessionDate: entry.last)
@@ -228,6 +233,35 @@ final class StatsViewModel {
     var last: Date
   }
 
+  /// Latest provider cosmetics snapshot per provider id, harvested from segment snapshots.
+  ///
+  /// Sessions arrive oldest-first, so the last non-`nil` snapshot seen for a provider — the most
+  /// recent — wins if a provider's name or tint ever differs across records.
+  private struct ProviderSnapshots {
+    private var labels: [String: String] = [:]
+    private var tints: [String: ProviderTint] = [:]
+
+    init(sessions: [Session]) {
+      for session in sessions {
+        for segment in session.segments {
+          guard let providerID = segment.taskRef?.providerID.rawValue else { continue }
+          if let label = segment.providerLabel { labels[providerID] = label }
+          if let tint = segment.providerTint { tints[providerID] = tint }
+        }
+      }
+    }
+
+    /// The most recent snapshot label recorded for `providerID`, if any.
+    func label(for providerID: String) -> String? { labels[providerID] }
+
+    /// The most recent snapshot tint recorded for `providerID`, if any.
+    func tint(for providerID: String) -> ProviderTint? { tints[providerID] }
+  }
+
+  /// Snapshots harvested from the full log, so a provider absent from the current period still
+  /// resolves.
+  private var providerSnapshots: ProviderSnapshots { ProviderSnapshots(sessions: sessions) }
+
   /// Focus sessions that started today (calendar day, local time zone), regardless of
   /// completion — the population time metrics sum over.
   private var todaysFocus: [Session] {
@@ -251,14 +285,20 @@ final class StatsViewModel {
     }
   }
 
-  /// Display label for a provider grouping key, handling the untracked sentinel.
-  private func displayLabel(for providerID: String) -> String {
-    providerID == Self.untrackedKey ? "Untracked" : providerLabel(providerID)
+  /// Display label for a provider grouping key: the record's snapshot first, then the live
+  /// registry closure, so a ported record renders correctly with the provider absent (D4).
+  private func displayLabel(for providerID: String, in snapshots: ProviderSnapshots) -> String {
+    guard providerID != Self.untrackedKey else { return "Untracked" }
+    return snapshots.label(for: providerID) ?? providerLabel(providerID)
   }
 
-  /// Display color for a provider grouping key, gray for the untracked sentinel.
-  private func displayTint(for providerID: String) -> ProviderTint {
-    providerID == Self.untrackedKey ? .gray : providerTint(providerID)
+  /// Display color for a provider grouping key: snapshot first, then the live registry closure;
+  /// gray for the untracked sentinel.
+  private func displayTint(
+    for providerID: String, in snapshots: ProviderSnapshots
+  ) -> ProviderTint {
+    guard providerID != Self.untrackedKey else { return .gray }
+    return snapshots.tint(for: providerID) ?? providerTint(providerID)
   }
 
   /// The date range the scope-dependent outputs are computed over, honoring `offset`.

--- a/app/TaskmatoTests/FocusAttributionTests.swift
+++ b/app/TaskmatoTests/FocusAttributionTests.swift
@@ -192,4 +192,48 @@ struct FocusAttributionTests {
     #expect(segments.first?.taskRef == taskC.id)
     #expect(segments.first?.seconds == 100)
   }
+
+  // MARK: - Provider cosmetics snapshot (ADR-0010, D4)
+
+  @Test func finishSnapshotsCosmeticsWhenResolverMatches() {
+    let attribution = FocusAttribution(cosmetics: { _ in ("Local", .green) })
+    attribution.begin(task: taskA)
+    let segments = attribution.finish(consumedSeconds: 300)
+    #expect(segments.first?.providerLabel == "Local")
+    #expect(segments.first?.providerTint == .green)
+  }
+
+  @Test func taskChangedSnapshotsCosmeticsOnTheClosedSlice() {
+    let attribution = FocusAttribution(cosmetics: { _ in ("Local", .green) })
+    var closed: [FocusSegment] = []
+    attribution.onSliceClosed = { closed.append($0) }
+    attribution.begin(task: taskA)
+    attribution.taskChanged(to: taskB, consumedSeconds: 400)
+    #expect(closed.first?.providerLabel == "Local")
+    #expect(closed.first?.providerTint == .green)
+  }
+
+  @Test func untrackedFocusYieldsNilCosmetics() {
+    let attribution = FocusAttribution(cosmetics: { _ in ("Local", .green) })
+    attribution.begin(task: nil)
+    let segments = attribution.finish(consumedSeconds: 300)
+    #expect(segments.first?.providerLabel == nil)
+    #expect(segments.first?.providerTint == nil)
+  }
+
+  @Test func resolverReturningNilYieldsNilCosmetics() {
+    let attribution = FocusAttribution(cosmetics: { _ in nil })
+    attribution.begin(task: taskA)
+    let segments = attribution.finish(consumedSeconds: 300)
+    #expect(segments.first?.providerLabel == nil)
+    #expect(segments.first?.providerTint == nil)
+  }
+
+  @Test func defaultInitYieldsNilCosmetics() {
+    let attribution = FocusAttribution()
+    attribution.begin(task: taskA)
+    let segments = attribution.finish(consumedSeconds: 300)
+    #expect(segments.first?.providerLabel == nil)
+    #expect(segments.first?.providerTint == nil)
+  }
 }

--- a/app/TaskmatoTests/ProviderTintTests.swift
+++ b/app/TaskmatoTests/ProviderTintTests.swift
@@ -1,0 +1,41 @@
+//
+//  ProviderTintTests.swift
+//  TaskmatoTests
+//
+
+import Foundation
+import Testing
+
+@testable import Taskmato
+
+@Suite("ProviderTint")
+struct ProviderTintTests {
+
+  // MARK: - Raw value stability (rename guard — these values are now on disk)
+
+  @Test func rawValuesAreStable() {
+    #expect(ProviderTint.blue.rawValue == "blue")
+    #expect(ProviderTint.green.rawValue == "green")
+    #expect(ProviderTint.orange.rawValue == "orange")
+    #expect(ProviderTint.purple.rawValue == "purple")
+    #expect(ProviderTint.gray.rawValue == "gray")
+  }
+
+  // MARK: - Lenient decode
+
+  @Test func unknownRawValueDecodesToGray() throws {
+    let data = Data("\"chartreuse\"".utf8)
+    let decoded = try JSONDecoder().decode(ProviderTint.self, from: data)
+    #expect(decoded == .gray)
+  }
+
+  // MARK: - Encode/decode round-trip
+
+  @Test func everyCaseRoundTripsThroughEncodeDecode() throws {
+    for tint in [ProviderTint.blue, .green, .orange, .purple, .gray] {
+      let data = try JSONEncoder().encode(tint)
+      let decoded = try JSONDecoder().decode(ProviderTint.self, from: data)
+      #expect(decoded == tint)
+    }
+  }
+}

--- a/app/TaskmatoTests/SessionTests.swift
+++ b/app/TaskmatoTests/SessionTests.swift
@@ -45,4 +45,27 @@ struct SessionTests {
   @Test func durationIsComputedFromTimestamps() {
     #expect(makeSession().duration == 1500)
   }
+
+  // MARK: - Provider cosmetics snapshot (ADR-0010, D4)
+
+  @Test func focusSegmentRoundTripsProviderCosmetics() throws {
+    let ref = TaskRef(providerID: "obsidian", nativeID: "vault/tasks.md:10")
+    let segment = FocusSegment(
+      id: UUID(), taskRef: ref, taskTitle: "Write plan", seconds: 900,
+      providerLabel: "Obsidian", providerTint: .purple)
+    let data = try JSONEncoder().encode(segment)
+    let decoded = try JSONDecoder().decode(FocusSegment.self, from: data)
+    #expect(decoded.providerLabel == "Obsidian")
+    #expect(decoded.providerTint == .purple)
+  }
+
+  @Test func legacyFocusSegmentJSONWithoutCosmeticsDecodesWithNilFields() throws {
+    let json = """
+      {"id":"\(UUID().uuidString)","taskRef":null,"taskTitle":null,"seconds":900}
+      """
+    let data = Data(json.utf8)
+    let decoded = try JSONDecoder().decode(FocusSegment.self, from: data)
+    #expect(decoded.providerLabel == nil)
+    #expect(decoded.providerTint == nil)
+  }
 }

--- a/app/TaskmatoTests/StatsViewModelTests.swift
+++ b/app/TaskmatoTests/StatsViewModelTests.swift
@@ -28,11 +28,14 @@ struct StatsViewModelTests {
 
   private func focus(
     start: Date, minutes: Int = 25, completed: Bool = true,
-    provider: ProviderID? = nil, nativeID: String = "t1", title: String? = nil
+    provider: ProviderID? = nil, nativeID: String = "t1", title: String? = nil,
+    providerLabel: String? = nil, providerTint: ProviderTint? = nil
   ) -> Session {
     let ref = provider.map { TaskRef(providerID: $0, nativeID: nativeID) }
     let seconds = TimeInterval(minutes * 60)
-    let segment = FocusSegment(id: UUID(), taskRef: ref, taskTitle: title, seconds: seconds)
+    let segment = FocusSegment(
+      id: UUID(), taskRef: ref, taskTitle: title, seconds: seconds, providerLabel: providerLabel,
+      providerTint: providerTint)
     return Session(
       id: UUID(), phase: .focus, startedAt: start,
       endedAt: start.addingTimeInterval(seconds),
@@ -328,6 +331,76 @@ struct StatsViewModelTests {
     let totals = viewModel.dailyFocusTotals
     #expect(totals.first { $0.providerID == "local" }?.tint == .green)
     #expect(totals.first { $0.providerID == "__untracked__" }?.tint == .gray)
+  }
+
+  // MARK: - Provider cosmetics snapshot (ADR-0010, D4)
+
+  @Test func snapshotResolvesWhenProviderIsAbsentFromTheLiveRegistry() async {
+    let day = Self.fixedNoon(day: 500)
+    let viewModel = await makeViewModel([
+      focus(
+        start: day, minutes: 25, provider: "obsidian", nativeID: "a", title: "Task A",
+        providerLabel: "Obsidian", providerTint: .purple)
+    ])
+    viewModel.scope = .allTime
+
+    let breakdown = viewModel.providerBreakdown
+    #expect(breakdown.first?.label == "Obsidian")
+    #expect(breakdown.first?.tint == .purple)
+
+    let totals = viewModel.dailyFocusTotals
+    #expect(totals.first?.tint == .purple)
+
+    let rows = viewModel.allTaskRows
+    #expect(rows.first?.providerLabel == "Obsidian")
+  }
+
+  @Test func snapshotMatchesLiveRegistryWhenProviderIsPresent() async {
+    let day = Self.fixedNoon(day: 501)
+    let viewModel = await makeViewModel(
+      [
+        focus(
+          start: day, minutes: 25, provider: "obsidian", nativeID: "a", title: "Task A",
+          providerLabel: "Obsidian", providerTint: .purple)
+      ],
+      providerLabel: { ["obsidian": "Obsidian"][$0] ?? $0 },
+      providerTint: { ["obsidian": ProviderTint.purple][$0] ?? .gray })
+    viewModel.scope = .allTime
+
+    let breakdown = viewModel.providerBreakdown
+    #expect(breakdown.first?.label == "Obsidian")
+    #expect(breakdown.first?.tint == .purple)
+  }
+
+  @Test func legacySnapshotlessSegmentsStillResolveThroughTheLiveRegistry() async {
+    let day = Self.fixedNoon(day: 502)
+    let viewModel = await makeViewModel(
+      [focus(start: day, minutes: 25, provider: "reminders", nativeID: "a", title: "Task A")],
+      providerLabel: { ["reminders": "Reminders"][$0] ?? $0 },
+      providerTint: { ["reminders": ProviderTint.orange][$0] ?? .gray })
+    viewModel.scope = .allTime
+
+    let breakdown = viewModel.providerBreakdown
+    #expect(breakdown.first?.label == "Reminders")
+    #expect(breakdown.first?.tint == .orange)
+  }
+
+  @Test func latestSnapshotWinsAcrossSessions() async {
+    let earlier = Self.fixedNoon(day: 503)
+    let later = Self.fixedNoon(day: 504)
+    let viewModel = await makeViewModel([
+      focus(
+        start: earlier, minutes: 25, provider: "obsidian", nativeID: "a", title: "Task A",
+        providerLabel: "Old Name", providerTint: .green),
+      focus(
+        start: later, minutes: 25, provider: "obsidian", nativeID: "a", title: "Task A",
+        providerLabel: "New Name", providerTint: .purple),
+    ])
+    viewModel.scope = .allTime
+
+    let breakdown = viewModel.providerBreakdown
+    #expect(breakdown.first?.label == "New Name")
+    #expect(breakdown.first?.tint == .purple)
   }
 
   // MARK: - Live updates via the store

--- a/app/TaskmatoTests/SwiftDataSessionRepositoryTests.swift
+++ b/app/TaskmatoTests/SwiftDataSessionRepositoryTests.swift
@@ -81,6 +81,28 @@ struct SwiftDataSessionRepositoryTests {
     #expect(session?.segments.first?.taskTitle == nil)
   }
 
+  // MARK: - Provider cosmetics snapshot (ADR-0010, D4)
+
+  @Test func upsertPreservesProviderCosmeticsSnapshot() async throws {
+    let repository = try SwiftDataSessionRepository.makeInMemory()
+    let id = UUID()
+    let start = Date(timeIntervalSinceReferenceDate: 0)
+    let ref = TaskRef(providerID: "obsidian", nativeID: "a")
+    let session = Session(
+      id: id, phase: .focus, startedAt: start, endedAt: start.addingTimeInterval(900),
+      wasCompleted: true,
+      segments: [
+        FocusSegment(
+          id: UUID(), taskRef: ref, taskTitle: "Task A", seconds: 900,
+          providerLabel: "Obsidian", providerTint: .purple)
+      ])
+    try await repository.upsert(session)
+
+    let sessions = try await repository.sessions(over: Self.allTime)
+    #expect(sessions.first?.segments.first?.providerLabel == "Obsidian")
+    #expect(sessions.first?.segments.first?.providerTint == .purple)
+  }
+
   // MARK: - upsert (D7 of design doc 0010)
 
   @Test func upsertInsertsWhenIDIsNew() async throws {


### PR DESCRIPTION
## Summary

Stats resolved provider display names and colors live from the registry, so a ported or synced record rendered the raw provider id (`"obsidian"`) in gray on any machine where that provider was not installed. Historical titles, time, and counts already travelled via the `taskTitle` snapshot, so this cosmetic gap was the last thing that degraded — and portability (#540) is what makes it visible.

Each `FocusSegment` now snapshots the owning provider's display name and semantic tint at slice close, and `StatsViewModel` prefers that snapshot when projecting. Per [ADR-0010](https://github.com/richwklein/taskmato/blob/main/docs/architecture/decisions/0010-pro-portability-capability-gate.md) D4 and [design 0011](https://github.com/richwklein/taskmato/blob/main/docs/architecture/design/0011-taskmato-pro-portability.md) D4.

## Linked issue

Closes #541

## Approach

- **`FocusSegment` gains optional `providerLabel` / `providerTint`** plus an explicit init defaulting both to `nil`, which is what keeps the existing construction sites untouched.
- **Capture lives in `FocusAttribution`**, the only place segments are minted. A private `segment(for:seconds:)` helper now serves both the mid-phase `taskChanged` path and `finish`, so neither can drift from the other. The resolver is an injected `ProviderCosmeticsResolver` closure, keeping `ProviderRegistry` out of the `Session` layer — `PhaseOrchestrator` needed no change at all.
- **`StatsViewModel` prefers the snapshot, then the live registry closure**, then raw-id/gray. A private `ProviderSnapshots` index harvests the most recent snapshot per provider across the whole log, so a provider whose only snapshot falls outside the current period still resolves. Applied to `providerBreakdown`, `dailyFocusTotals`, and `allTaskRows`.
- **No `SessionEntity` change** — a deliberate deviation from the issue's third bullet. `segments` is already a native SwiftData attribute over `[FocusSegment]`, so the fields are persisted the moment they exist on the struct. Flat mirror columns would have no reader: the current build consults the legacy flat columns only when `segments` is empty, which by definition means no snapshot exists. This also means zero schema surface is touched.
- **`ProviderTint` becomes `String`-backed and `Codable`** (it had no raw value before), with a lenient `init(from:)` mapping an unrecognized raw value to `.gray`. Not in the issue text, but necessary: design 0011 plans six cloud providers against four non-gray tints, three already claimed, so new tint cases are near-certain — and because the tint decodes inside an array, a strict throw would fail the whole `segments` array rather than one swatch.

## Out of scope

- **No backfill of existing rows.** Only newly written segments carry a snapshot. Enriching history belongs in #540's export path, where the exporting machine still has the provider registered — [noted on that issue](https://github.com/richwklein/taskmato/issues/540#issuecomment-5267448676) with a suggested acceptance criterion.
- iCloud sync's equivalent gap (it pushes entities straight from the store, with no serialization step to hook) — also flagged on #540.
- The provider icon, which Stats never renders.

## Validation

_Put an `x` in the boxes that apply._

- [x] Lint passes locally
- [x] Unit tests pass locally
- [x] Added or updated tests covering the new behavior
- [ ] Manually verified the new behavior
- [ ] Documentation updated where appropriate

## Release / deploy impact

_Put an `x` in the boxes that apply._

- [ ] Preview deploy is useful for reviewing this change
- [x] Safe to label `no-deploy`
- [ ] Breaking change (also apply the `breaking-change` label)

## Reviewer notes

**Two unchecked boxes, explained.** Docs needed no update — ADR-0010 D4 and design 0011 already specify this change. On manual verification: the real store was verified, but the new behavior itself was not. A spike ran the modified build against the live 109-row session store and confirmed it opens with no migration and renders history correctly, which covers the legacy-decode risk. The provider-absent path (run a focus session with Obsidian, disable it, confirm Stats still shows "Obsidian" in purple) is covered by unit tests but has not been exercised by hand — worth doing before merge.

**Deviation worth a look:** `makePhaseOrchestrator` now takes `_ inputs: RuntimeInputs` instead of five named parameters. Adding `registry` as a sixth tripped SwiftLint's `function_parameter_count` (max 5, `--strict`). Bundling beat suppressing the rule, but the function now receives `nav`, `errorPresenter`, and `sidebarSelection` that it does not use, so the signature no longer documents its real dependencies. Easy to swap for a narrower struct if you would rather.

**Test-suite note, unrelated to this change:** a full `make test` run hit `Error 65` from the `TaskmatoUITests` runner failing to initialize — "Timed out while enabling automation mode." Re-running that target alone passed all 4 tests. Zero unit tests failed in either run. Flagging it because it can bite a fresh session or CI.
